### PR TITLE
feat: implement audience detail page with tabs

### DIFF
--- a/src/components/audiences/AudienceCard.tsx
+++ b/src/components/audiences/AudienceCard.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react'
-import { Users, TrendingUp, Waypoints, Tag, Link2, Unplug } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { Users, TrendingUp, Waypoints, Tag, Unplug } from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { cn } from '@/lib/utils'
 import { useReducedMotion } from '@/hooks'
@@ -17,7 +18,7 @@ export interface AudienceCardProps {
   subredditCount: number
   totalMembers: number
   weeklyGrowth: number
-  subreddits: Subreddit[]
+  subreddits: readonly Subreddit[]
   onSaveClick?: (id: string) => void
   onShareClick?: (id: string) => void
 }
@@ -36,11 +37,11 @@ export interface AddAudienceCardProps {
   onClick?: () => void
 }
 
-export function AddAudienceCard({ onClick }: AddAudienceCardProps) {
+export function AddAudienceCard({ onClick }: Readonly<AddAudienceCardProps>) {
   return (
     <button
       onClick={onClick}
-      className="cursor-pointer bg-transparent rounded-[1.875rem] p-6 border-2 border-dashed border-gray-300 dark:border-zinc-700 transition-all duration-300 hover:border-lime dark:hover:border-lime flex items-center justify-center min-h-[140px]"
+      className="cursor-pointer bg-transparent rounded-2xl p-6 border-2 border-dashed border-gray-300 dark:border-zinc-700 transition-all duration-300 hover:border-lime dark:hover:border-lime flex items-center justify-center min-h-[140px]"
     >
       <span className="text-lg font-bold text-gray-400 dark:text-zinc-500">Add new Audience</span>
     </button>
@@ -56,7 +57,8 @@ export function AudienceCard({
   subreddits,
   onSaveClick,
   onShareClick,
-}: AudienceCardProps) {
+}: Readonly<AudienceCardProps>) {
+  const navigate = useNavigate()
   const cardRef = useRef<HTMLDivElement>(null)
   const prefersReducedMotion = useReducedMotion()
 
@@ -96,10 +98,16 @@ export function AudienceCard({
   return (
     <div
       ref={cardRef}
-      className="bg-white dark:bg-zinc-900 rounded-[1.875rem] p-6 border border-transparent transition-all duration-300 hover:border-gray-200 dark:hover:border-zinc-700 flex flex-col"
+      className="bg-white dark:bg-zinc-900 rounded-2xl p-6 border border-transparent transition-all duration-300 hover:border-gray-200 dark:hover:border-zinc-700 flex flex-col"
     >
       <div className="flex items-start justify-between mb-4">
-        <h3 className="text-lg font-bold text-gray-900 dark:text-white">{name}</h3>
+        <button
+          type="button"
+          onClick={() => navigate(`/audiences/${id}`)}
+          className="text-lg font-bold text-gray-900 dark:text-white cursor-pointer hover:text-lime transition-colors text-left"
+        >
+          {name}
+        </button>
         <div className="flex items-center gap-2">
           <button
             onClick={() => onSaveClick?.(id)}

--- a/src/components/audiences/detail/AboutAudiencePanel.tsx
+++ b/src/components/audiences/detail/AboutAudiencePanel.tsx
@@ -1,0 +1,329 @@
+import { useRef, useEffect } from 'react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
+
+export interface AudienceStats {
+  type: 'Curated Audience' | 'Auto-generated'
+  totalMembers: number
+  monthlyGrowth: number
+}
+
+export interface RadarData {
+  age: number
+  reach: number
+  size: number
+  activity: number
+  growth: number
+}
+
+export interface AboutAudiencePanelProps {
+  stats: AudienceStats
+  radarData: RadarData
+  audienceName: string
+  comparisonName?: string
+}
+
+function formatNumber(num: number): string {
+  if (num >= 1_000_000) {
+    return `${(num / 1_000_000).toFixed(1)}M`
+  }
+  if (num >= 1_000) {
+    return `${(num / 1_000).toFixed(0)}K`
+  }
+  return num.toString()
+}
+
+function RadarChart({
+  data,
+  audienceName,
+  comparisonName,
+}: {
+  data: RadarData
+  audienceName: string
+  comparisonName?: string
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const centerX = canvas.width / 2
+    const centerY = canvas.height / 2
+    const radius = Math.min(centerX, centerY) - 40
+
+    // Clear canvas
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+    // Labels
+    const labels = ['Age', 'Reach', 'Size', 'Activity', 'Growth']
+    const values = [data.age, data.reach, data.size, data.activity, data.growth]
+    const numPoints = labels.length
+    const angleStep = (Math.PI * 2) / numPoints
+    const startAngle = -Math.PI / 2 // Start from top
+
+    // Draw grid lines
+    ctx.strokeStyle = 'rgba(113, 113, 122, 0.2)' // zinc-500 with opacity
+    ctx.lineWidth = 1
+
+    // Draw concentric pentagons (grid)
+    for (let level = 1; level <= 5; level++) {
+      const levelRadius = (radius * level) / 5
+      ctx.beginPath()
+      for (let i = 0; i <= numPoints; i++) {
+        const angle = startAngle + i * angleStep
+        const x = centerX + Math.cos(angle) * levelRadius
+        const y = centerY + Math.sin(angle) * levelRadius
+        if (i === 0) {
+          ctx.moveTo(x, y)
+        } else {
+          ctx.lineTo(x, y)
+        }
+      }
+      ctx.closePath()
+      ctx.stroke()
+    }
+
+    // Draw spokes
+    for (let i = 0; i < numPoints; i++) {
+      const angle = startAngle + i * angleStep
+      ctx.beginPath()
+      ctx.moveTo(centerX, centerY)
+      ctx.lineTo(centerX + Math.cos(angle) * radius, centerY + Math.sin(angle) * radius)
+      ctx.stroke()
+    }
+
+    // Draw labels
+    ctx.fillStyle = 'rgba(161, 161, 170, 0.9)' // zinc-400
+    ctx.font = '11px Inter, system-ui, sans-serif'
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+
+    for (let i = 0; i < numPoints; i++) {
+      const angle = startAngle + i * angleStep
+      const labelRadius = radius + 25
+      const x = centerX + Math.cos(angle) * labelRadius
+      const y = centerY + Math.sin(angle) * labelRadius
+      ctx.fillText(labels[i], x, y)
+    }
+
+    // Draw comparison area (Reddit Avg) - red/pink
+    const avgValues = [50, 60, 70, 50, 40] // Average values
+    ctx.beginPath()
+    for (let i = 0; i <= numPoints; i++) {
+      const idx = i % numPoints
+      const angle = startAngle + idx * angleStep
+      const valueRadius = (radius * avgValues[idx]) / 100
+      const x = centerX + Math.cos(angle) * valueRadius
+      const y = centerY + Math.sin(angle) * valueRadius
+      if (i === 0) {
+        ctx.moveTo(x, y)
+      } else {
+        ctx.lineTo(x, y)
+      }
+    }
+    ctx.closePath()
+    ctx.fillStyle = 'rgba(239, 68, 68, 0.1)' // red with low opacity
+    ctx.fill()
+    ctx.strokeStyle = 'rgba(239, 68, 68, 0.5)'
+    ctx.lineWidth = 2
+    ctx.stroke()
+
+    // Draw audience data area - lime/cyan
+    const drawAudienceData = (progress: number) => {
+      ctx.beginPath()
+      for (let i = 0; i <= numPoints; i++) {
+        const idx = i % numPoints
+        const angle = startAngle + idx * angleStep
+        const valueRadius = (radius * values[idx] * progress) / 100
+        const x = centerX + Math.cos(angle) * valueRadius
+        const y = centerY + Math.sin(angle) * valueRadius
+        if (i === 0) {
+          ctx.moveTo(x, y)
+        } else {
+          ctx.lineTo(x, y)
+        }
+      }
+      ctx.closePath()
+      ctx.fillStyle = 'rgba(165, 241, 81, 0.15)' // lime with opacity
+      ctx.fill()
+      ctx.strokeStyle = 'rgba(165, 241, 81, 0.8)'
+      ctx.lineWidth = 2
+      ctx.stroke()
+    }
+
+    if (prefersReducedMotion) {
+      drawAudienceData(1)
+    } else {
+      // Animate the audience data
+      let progress = 0
+      const animate = () => {
+        if (progress >= 1) return
+
+        progress += 0.05
+        if (progress > 1) progress = 1
+
+        // Clear and redraw
+        ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+        // Redraw grid
+        ctx.strokeStyle = 'rgba(113, 113, 122, 0.2)'
+        ctx.lineWidth = 1
+        for (let level = 1; level <= 5; level++) {
+          const levelRadius = (radius * level) / 5
+          ctx.beginPath()
+          for (let i = 0; i <= numPoints; i++) {
+            const angle = startAngle + i * angleStep
+            const x = centerX + Math.cos(angle) * levelRadius
+            const y = centerY + Math.sin(angle) * levelRadius
+            if (i === 0) {
+              ctx.moveTo(x, y)
+            } else {
+              ctx.lineTo(x, y)
+            }
+          }
+          ctx.closePath()
+          ctx.stroke()
+        }
+
+        // Redraw spokes
+        for (let i = 0; i < numPoints; i++) {
+          const angle = startAngle + i * angleStep
+          ctx.beginPath()
+          ctx.moveTo(centerX, centerY)
+          ctx.lineTo(centerX + Math.cos(angle) * radius, centerY + Math.sin(angle) * radius)
+          ctx.stroke()
+        }
+
+        // Redraw labels
+        ctx.fillStyle = 'rgba(161, 161, 170, 0.9)'
+        ctx.font = '11px Inter, system-ui, sans-serif'
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'middle'
+        for (let i = 0; i < numPoints; i++) {
+          const angle = startAngle + i * angleStep
+          const labelRadius = radius + 25
+          const x = centerX + Math.cos(angle) * labelRadius
+          const y = centerY + Math.sin(angle) * labelRadius
+          ctx.fillText(labels[i], x, y)
+        }
+
+        // Redraw avg area
+        ctx.beginPath()
+        for (let i = 0; i <= numPoints; i++) {
+          const idx = i % numPoints
+          const angle = startAngle + idx * angleStep
+          const valueRadius = (radius * avgValues[idx]) / 100
+          const x = centerX + Math.cos(angle) * valueRadius
+          const y = centerY + Math.sin(angle) * valueRadius
+          if (i === 0) {
+            ctx.moveTo(x, y)
+          } else {
+            ctx.lineTo(x, y)
+          }
+        }
+        ctx.closePath()
+        ctx.fillStyle = 'rgba(239, 68, 68, 0.1)'
+        ctx.fill()
+        ctx.strokeStyle = 'rgba(239, 68, 68, 0.5)'
+        ctx.lineWidth = 2
+        ctx.stroke()
+
+        drawAudienceData(progress)
+
+        requestAnimationFrame(animate)
+      }
+      animate()
+    }
+  }, [data, prefersReducedMotion])
+
+  return (
+    <div className="flex flex-col items-center">
+      <canvas
+        ref={canvasRef}
+        width={240}
+        height={240}
+        className="max-w-full"
+      />
+      <div className="flex items-center gap-4 mt-2 text-xs">
+        <div className="flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded-sm bg-red-500/50" />
+          <span className="text-gray-500 dark:text-zinc-400">Reddit Avg</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded-sm bg-lime/50" />
+          <span className="text-gray-500 dark:text-zinc-400">{audienceName}</span>
+        </div>
+        {comparisonName && (
+          <div className="flex items-center gap-1.5">
+            <span className="w-3 h-3 rounded-sm bg-cyan-500/50" />
+            <span className="text-gray-500 dark:text-zinc-400">{comparisonName}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function AboutAudiencePanel({
+  stats,
+  radarData,
+  audienceName,
+  comparisonName,
+}: Readonly<AboutAudiencePanelProps>) {
+  const panelRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    if (!panelRef.current || prefersReducedMotion) return
+
+    gsap.fromTo(
+      panelRef.current,
+      { opacity: 0, x: 20 },
+      { opacity: 1, x: 0, duration: 0.4, ease: 'power2.out' }
+    )
+  }, [prefersReducedMotion])
+
+  return (
+    <div
+      ref={panelRef}
+      className="bg-white dark:bg-zinc-900 rounded-2xl p-5"
+    >
+      <h3 className="font-semibold text-gray-900 dark:text-white mb-4">
+        About this audience
+      </h3>
+
+      <div className="space-y-3 mb-6">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-gray-500 dark:text-zinc-400">
+            {stats.type === 'Curated Audience' ? '📋' : '✨'}
+          </span>
+          <span className="text-gray-600 dark:text-zinc-300">{stats.type}</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-gray-500 dark:text-zinc-400">👥</span>
+          <span className="text-gray-600 dark:text-zinc-300">
+            {formatNumber(stats.totalMembers)} Members
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <span className="text-gray-500 dark:text-zinc-400">📈</span>
+          <span className="text-gray-600 dark:text-zinc-300">
+            {stats.monthlyGrowth >= 0 ? '+' : ''}
+            {stats.monthlyGrowth.toFixed(1)}% / month
+          </span>
+        </div>
+      </div>
+
+      <RadarChart
+        data={radarData}
+        audienceName={audienceName}
+        comparisonName={comparisonName}
+      />
+    </div>
+  )
+}

--- a/src/components/audiences/detail/SubredditCard.tsx
+++ b/src/components/audiences/detail/SubredditCard.tsx
@@ -1,0 +1,118 @@
+import { MoreVertical, TrendingUp, TrendingDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Avatar } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import type { SubredditDetail } from '@/data/audienceDetails'
+
+export interface SubredditCardProps {
+  subreddit: SubredditDetail & {
+    activityLevel?: 'Super Active' | 'High Activity' | 'Active' | 'Moderate'
+    sizeCategory?: 'Massive' | 'Huge' | 'Large' | 'Medium' | 'Small'
+    description?: string
+  }
+  onClick?: () => void
+}
+
+function formatNumber(num: number): string {
+  if (num >= 1_000_000) {
+    return `${(num / 1_000_000).toFixed(1)}M`
+  }
+  if (num >= 1_000) {
+    return `${Math.round(num / 1_000)}k`
+  }
+  return num.toString()
+}
+
+function getSizeCategory(members: number): string {
+  if (members >= 5_000_000) return 'Massive'
+  if (members >= 1_000_000) return 'Huge'
+  if (members >= 500_000) return 'Large'
+  if (members >= 100_000) return 'Medium'
+  return 'Small'
+}
+
+function getActivityLevel(growth: number): string {
+  if (growth >= 1.0) return 'Super Active'
+  if (growth >= 0.5) return 'High Activity'
+  if (growth >= 0.2) return 'Active'
+  return 'Moderate'
+}
+
+export function SubredditCard({ subreddit, onClick }: Readonly<SubredditCardProps>) {
+  const sizeCategory = subreddit.sizeCategory || getSizeCategory(subreddit.members)
+  const activityLevel = subreddit.activityLevel || getActivityLevel(subreddit.monthlyGrowth)
+  const isPositiveGrowth = subreddit.monthlyGrowth >= 0
+
+  return (
+    <div
+      onClick={onClick}
+      className="bg-white dark:bg-zinc-900 rounded-2xl p-4 border border-transparent hover:border-gray-200 dark:hover:border-zinc-700 transition-colors cursor-pointer"
+    >
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <Avatar
+            src={subreddit.icon}
+            alt={subreddit.name}
+            fallback={subreddit.name.charAt(2)}
+            size="md"
+          />
+          <div>
+            <h4 className="font-semibold text-gray-900 dark:text-white text-sm">
+              {subreddit.name}
+            </h4>
+            <p className="text-xs text-gray-500 dark:text-zinc-400">
+              {formatNumber(subreddit.members)} members
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <div
+            className={cn(
+              'flex items-center gap-1 text-xs',
+              isPositiveGrowth ? 'text-success-light' : 'text-error-light'
+            )}
+          >
+            {isPositiveGrowth ? (
+              <TrendingUp className="w-3 h-3" />
+            ) : (
+              <TrendingDown className="w-3 h-3" />
+            )}
+            <span>
+              {isPositiveGrowth ? '' : ''}
+              {Math.abs(subreddit.monthlyGrowth).toFixed(1)}% / month
+            </span>
+          </div>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+            }}
+            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-white transition-colors"
+          >
+            <MoreVertical className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 mb-3">
+        <Badge variant="neutral" size="sm">
+          {sizeCategory}
+        </Badge>
+        <Badge variant="neutral" size="sm">
+          {activityLevel}
+        </Badge>
+      </div>
+
+      {subreddit.description && (
+        <>
+          <p className="text-[10px] font-medium text-gray-500 dark:text-zinc-500 uppercase tracking-wide mb-1">
+            Description
+          </p>
+          <p className="text-xs text-gray-600 dark:text-zinc-400 line-clamp-3">
+            {subreddit.description}
+          </p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/audiences/detail/SubredditsGrid.tsx
+++ b/src/components/audiences/detail/SubredditsGrid.tsx
@@ -1,0 +1,136 @@
+import { useRef, useEffect, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
+import { SubredditCard } from './SubredditCard'
+import type { SubredditDetail } from '@/data/audienceDetails'
+
+export interface ExtendedSubreddit extends SubredditDetail {
+  activityLevel?: 'Super Active' | 'High Activity' | 'Active' | 'Moderate'
+  sizeCategory?: 'Massive' | 'Huge' | 'Large' | 'Medium' | 'Small'
+  description?: string
+}
+
+export interface SubredditsGridProps {
+  subreddits: readonly ExtendedSubreddit[]
+  totalCount: number
+  onSubredditClick?: (subreddit: ExtendedSubreddit) => void
+}
+
+type SortOption = 'largest' | 'smallest' | 'most_active' | 'newest'
+
+export function SubredditsGrid({
+  subreddits,
+  totalCount,
+  onSubredditClick,
+}: Readonly<SubredditsGridProps>) {
+  const gridRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+  const [sortBy, setSortBy] = useState<SortOption>('largest')
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+
+  const sortOptions: { value: SortOption; label: string }[] = [
+    { value: 'largest', label: 'Largest' },
+    { value: 'smallest', label: 'Smallest' },
+    { value: 'most_active', label: 'Most Active' },
+    { value: 'newest', label: 'Newest' },
+  ]
+
+  const sortedSubreddits = [...subreddits].sort((a, b) => {
+    switch (sortBy) {
+      case 'largest':
+        return b.members - a.members
+      case 'smallest':
+        return a.members - b.members
+      case 'most_active':
+        return b.monthlyGrowth - a.monthlyGrowth
+      case 'newest':
+        return b.monthlyGrowth - a.monthlyGrowth
+      default:
+        return 0
+    }
+  })
+
+  useEffect(() => {
+    if (!gridRef.current || prefersReducedMotion) return
+
+    const cards = Array.from(gridRef.current.children)
+    gsap.fromTo(
+      cards,
+      { opacity: 0, y: 20 },
+      {
+        opacity: 1,
+        y: 0,
+        duration: 0.4,
+        stagger: 0.05,
+        ease: 'power2.out',
+      }
+    )
+  }, [prefersReducedMotion, sortBy])
+
+  return (
+    <div className="flex-1">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="font-semibold text-gray-900 dark:text-white">
+          Subreddits
+        </h3>
+        <div className="relative">
+          <button
+            onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+            className="flex items-center gap-2 text-sm text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-white transition-colors"
+          >
+            Sort by: {sortOptions.find((o) => o.value === sortBy)?.label}
+            <ChevronDown className="w-4 h-4" />
+          </button>
+          {isDropdownOpen && (
+            <>
+              <div
+                className="fixed inset-0 z-10"
+                onClick={() => setIsDropdownOpen(false)}
+              />
+              <div className="absolute right-0 top-full mt-1 z-20 bg-white dark:bg-zinc-800 rounded-lg shadow-lg border border-gray-200 dark:border-zinc-700 py-1 min-w-[120px]">
+                {sortOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    onClick={() => {
+                      setSortBy(option.value)
+                      setIsDropdownOpen(false)
+                    }}
+                    className={`w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors ${
+                      sortBy === option.value
+                        ? 'text-lime font-medium'
+                        : 'text-gray-700 dark:text-zinc-300'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div
+        ref={gridRef}
+        className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"
+      >
+        {sortedSubreddits.map((subreddit) => (
+          <SubredditCard
+            key={subreddit.id}
+            subreddit={subreddit}
+            onClick={() => onSubredditClick?.(subreddit)}
+          />
+        ))}
+      </div>
+
+      {totalCount > sortedSubreddits.length && (
+        <div className="mt-4 text-center">
+          <button className="text-sm text-gray-500 dark:text-zinc-400 hover:text-lime transition-colors">
+            Load more ({totalCount - sortedSubreddits.length} remaining)
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/audiences/detail/SubredditsList.tsx
+++ b/src/components/audiences/detail/SubredditsList.tsx
@@ -1,0 +1,119 @@
+import { useRef, useEffect } from 'react'
+import { TrendingUp, Plus } from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { cn } from '@/lib/utils'
+import { useReducedMotion } from '@/hooks'
+import { Avatar } from '@/components/ui/avatar'
+import type { SubredditDetail } from '@/data/audienceDetails'
+
+export interface SubredditsListProps {
+  subreddits: readonly SubredditDetail[]
+  totalCount: number
+  onAddClick?: () => void
+  showHeader?: boolean
+}
+
+function formatNumber(num: number): string {
+  if (num >= 1_000_000) {
+    return `${(num / 1_000_000).toFixed(1)}M`
+  }
+  if (num >= 1_000) {
+    return `${(num / 1_000).toFixed(1)}K`
+  }
+  return num.toString()
+}
+
+export function SubredditsList({
+  subreddits,
+  totalCount,
+  onAddClick,
+  showHeader = true,
+}: Readonly<SubredditsListProps>) {
+  const listRef = useRef<HTMLUListElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  const displayedSubreddits = subreddits.slice(0, 6)
+  const remainingCount = totalCount - displayedSubreddits.length
+
+  useEffect(() => {
+    if (!listRef.current || prefersReducedMotion) return
+
+    const items = Array.from(listRef.current.children)
+    gsap.fromTo(
+      items,
+      { opacity: 0, x: -20 },
+      {
+        opacity: 1,
+        x: 0,
+        duration: 0.4,
+        stagger: 0.05,
+        ease: 'power2.out',
+      }
+    )
+  }, [prefersReducedMotion, subreddits])
+
+  return (
+    <div className="bg-white dark:bg-zinc-900 rounded-2xl p-5 cursor-pointer hover:border-gray-200 dark:hover:border-zinc-700 border border-transparent transition-colors h-full flex flex-col">
+      {showHeader && (
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold text-gray-900 dark:text-white">
+              Subreddits
+            </h3>
+            <span className="text-sm text-gray-500 dark:text-zinc-400">
+              {totalCount}
+            </span>
+          </div>
+          <button
+            onClick={onAddClick}
+            className="cursor-pointer flex items-center gap-1 text-sm text-gray-500 dark:text-zinc-400 hover:text-lime transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            Add
+          </button>
+        </div>
+      )}
+
+      <ul ref={listRef} className="space-y-1 flex-1">
+        {displayedSubreddits.map((subreddit) => (
+          <li
+            key={subreddit.id}
+            className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+          >
+            <Avatar
+              src={subreddit.icon}
+              alt={subreddit.name}
+              fallback={subreddit.name.charAt(2)}
+              size="sm"
+            />
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-gray-900 dark:text-white text-sm truncate">
+                {subreddit.name}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-zinc-400">
+                {formatNumber(subreddit.members)} members
+              </p>
+            </div>
+            <div
+              className={cn(
+                'flex items-center gap-1 text-xs',
+                subreddit.monthlyGrowth >= 0
+                  ? 'text-success-light'
+                  : 'text-error-light'
+              )}
+            >
+              <TrendingUp className="w-3 h-3" />
+              <span>{subreddit.monthlyGrowth.toFixed(1)}% / month</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {remainingCount > 0 && (
+        <button className="cursor-pointer w-full mt-3 py-2 text-sm text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-zinc-300 transition-colors">
+          + {remainingCount} more
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/audiences/detail/ThemeDetailPanel.tsx
+++ b/src/components/audiences/detail/ThemeDetailPanel.tsx
@@ -1,0 +1,221 @@
+import { useRef, useEffect, useLayoutEffect } from 'react'
+import { Search, Sparkles, Copy, MessageSquare } from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
+import { Button } from '@/components/ui/button'
+
+export interface ThemeSubcategory {
+  name: string
+  count: number
+}
+
+export interface ThemeTopic {
+  name: string
+  count: number
+}
+
+export interface ThemeSubreddit {
+  name: string
+  icon?: string
+  count: number
+}
+
+export interface ThemeDetail {
+  id: string
+  name: string
+  description: string
+  subcategories: ThemeSubcategory[]
+  topics: ThemeTopic[]
+  subreddits: ThemeSubreddit[]
+}
+
+export interface ThemeDetailPanelProps {
+  theme: ThemeDetail | null
+}
+
+export function ThemeDetailPanel({ theme }: Readonly<ThemeDetailPanelProps>) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  useLayoutEffect(() => {
+    if (!containerRef.current || !panelRef.current) return
+
+    if (!theme) {
+      gsap.set(panelRef.current, { opacity: 0, x: 50, display: 'none' })
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!containerRef.current || !panelRef.current) return
+
+    if (theme) {
+      gsap.set(panelRef.current, { display: 'block' })
+
+      if (prefersReducedMotion) {
+        gsap.set(panelRef.current, { opacity: 1, x: 0 })
+      } else {
+        gsap.fromTo(
+          panelRef.current,
+          { opacity: 0, x: 50, scale: 0.95 },
+          {
+            opacity: 1,
+            x: 0,
+            scale: 1,
+            duration: 0.4,
+            ease: 'power3.out',
+          }
+        )
+      }
+    } else {
+      if (prefersReducedMotion) {
+        gsap.set(panelRef.current, { opacity: 0, display: 'none' })
+      } else {
+        gsap.to(panelRef.current, {
+          opacity: 0,
+          x: 30,
+          scale: 0.98,
+          duration: 0.25,
+          ease: 'power2.in',
+          onComplete: () => {
+            gsap.set(panelRef.current, { display: 'none' })
+          },
+        })
+      }
+    }
+  }, [prefersReducedMotion, theme])
+
+  return (
+    <div ref={containerRef} className="h-full">
+      <div
+        ref={panelRef}
+        className="bg-white dark:bg-zinc-900 rounded-2xl p-6 hidden"
+      >
+        {theme && (
+          <>
+            <h3 className="font-semibold text-lg text-gray-900 dark:text-white mb-4">
+              {theme.name}
+            </h3>
+
+            <p className="text-sm text-gray-600 dark:text-zinc-300 mb-6 leading-relaxed">
+              {theme.description}
+            </p>
+
+            <div className="flex flex-wrap justify-end gap-2 mb-6">
+              <Button variant="primary" size="sm" className="gap-1.5">
+                <Search className="w-3.5 h-3.5" />
+                Browse all
+              </Button>
+              <Button variant="outline" size="sm" className="gap-1.5">
+                <Sparkles className="w-3.5 h-3.5" />
+                Patterns
+              </Button>
+              <Button variant="outline" size="sm" className="gap-1.5">
+                <Sparkles className="w-3.5 h-3.5" />
+                Ask
+              </Button>
+              <Button variant="outline" size="sm" className="gap-1.5">
+                <Copy className="w-3.5 h-3.5" />
+                Copy
+              </Button>
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              {/* Subcategories */}
+              <div>
+                <div className="flex items-center gap-2 mb-3">
+                  <h4 className="font-medium text-gray-900 dark:text-white text-sm">
+                    Subcategories
+                  </h4>
+                  <span className="text-xs text-gray-500 dark:text-zinc-400">
+                    {theme.subcategories.length}
+                  </span>
+                </div>
+                <ul className="space-y-1">
+                  {theme.subcategories.map((sub) => (
+                    <li
+                      key={sub.name}
+                      className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-zinc-500" />
+                        <span className="text-sm text-gray-700 dark:text-zinc-300">
+                          {sub.name}
+                        </span>
+                      </div>
+                      <span className="text-sm text-gray-500 dark:text-zinc-400">
+                        {sub.count}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Topics */}
+              <div>
+                <div className="flex items-center gap-2 mb-3">
+                  <h4 className="font-medium text-gray-900 dark:text-white text-sm">
+                    Topics
+                  </h4>
+                  <span className="text-xs text-gray-500 dark:text-zinc-400">
+                    {theme.topics.length}
+                  </span>
+                </div>
+                <ul className="space-y-1">
+                  {theme.topics.map((topic) => (
+                    <li
+                      key={topic.name}
+                      className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+                    >
+                      <div className="flex items-center gap-2">
+                        <MessageSquare className="w-3 h-3 text-gray-400 dark:text-zinc-500" />
+                        <span className="text-sm text-gray-700 dark:text-zinc-300">
+                          {topic.name}
+                        </span>
+                      </div>
+                      <span className="text-sm text-gray-500 dark:text-zinc-400">
+                        {topic.count}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* Subreddits */}
+              <div>
+                <div className="flex items-center gap-2 mb-3">
+                  <h4 className="font-medium text-gray-900 dark:text-white text-sm">
+                    Subreddits
+                  </h4>
+                  <span className="text-xs text-gray-500 dark:text-zinc-400">
+                    {theme.subreddits.length}
+                  </span>
+                </div>
+                <ul className="space-y-1 max-h-[400px] overflow-y-auto">
+                  {theme.subreddits.map((subreddit) => (
+                    <li
+                      key={subreddit.name}
+                      className="flex items-center justify-between py-1.5 px-2 rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+                    >
+                      <div className="flex items-center gap-2">
+                        <div className="w-5 h-5 rounded-full bg-gray-200 dark:bg-zinc-700 flex items-center justify-center text-[10px] font-medium text-gray-500 dark:text-zinc-400">
+                          {subreddit.name.charAt(2).toUpperCase()}
+                        </div>
+                        <span className="text-sm text-gray-700 dark:text-zinc-300">
+                          {subreddit.name}
+                        </span>
+                      </div>
+                      <span className="text-sm text-gray-500 dark:text-zinc-400">
+                        {subreddit.count}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/audiences/detail/ThemesGrid.tsx
+++ b/src/components/audiences/detail/ThemesGrid.tsx
@@ -1,0 +1,190 @@
+import { useRef, useEffect } from 'react'
+import {
+  Flame,
+  Trophy,
+  HelpCircle,
+  Frown,
+  Lightbulb,
+  Megaphone,
+  MessageSquare,
+  Newspaper,
+  Bookmark,
+} from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
+
+export interface ThemeGridItem {
+  id: string
+  name: string
+  description: string
+  count?: number
+  type: 'scoring' | 'ai-tagged'
+}
+
+export interface ThemesGridProps {
+  themes: readonly ThemeGridItem[]
+  selectedThemeId?: string | null
+  onThemeSelect?: (theme: ThemeGridItem) => void
+}
+
+const themeIcons: Record<string, typeof Flame> = {
+  'Hot Discussions': Flame,
+  'Top Content': Trophy,
+  'Advice Requests': HelpCircle,
+  'Pain & Anger': Frown,
+  'Solution Requests': Lightbulb,
+  'Self-Promotion': Megaphone,
+  Ideas: MessageSquare,
+  News: Newspaper,
+}
+
+export function ThemesGrid({
+  themes,
+  selectedThemeId,
+  onThemeSelect,
+}: Readonly<ThemesGridProps>) {
+  const scoringRef = useRef<HTMLDivElement>(null)
+  const aiTaggedRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  const scoringThemes = themes.filter((t) => t.type === 'scoring')
+  const aiTaggedThemes = themes.filter((t) => t.type === 'ai-tagged')
+  const displayedAiThemes = aiTaggedThemes.slice(0, 6)
+  const remainingCount = aiTaggedThemes.length - displayedAiThemes.length
+
+  useEffect(() => {
+    if (prefersReducedMotion) return
+
+    if (scoringRef.current) {
+      const items = Array.from(scoringRef.current.children)
+      gsap.fromTo(
+        items,
+        { opacity: 0, y: 20 },
+        {
+          opacity: 1,
+          y: 0,
+          duration: 0.4,
+          stagger: 0.05,
+          ease: 'power2.out',
+        }
+      )
+    }
+
+    if (aiTaggedRef.current) {
+      const items = Array.from(aiTaggedRef.current.children)
+      gsap.fromTo(
+        items,
+        { opacity: 0, y: 20 },
+        {
+          opacity: 1,
+          y: 0,
+          duration: 0.4,
+          stagger: 0.05,
+          ease: 'power2.out',
+          delay: 0.2,
+        }
+      )
+    }
+  }, [prefersReducedMotion, themes])
+
+  return (
+    <div className="space-y-6">
+      {/* Scoring themes */}
+      <div>
+        <h3 className="font-semibold text-gray-900 dark:text-white mb-4">
+          Scoring themes
+        </h3>
+        <div ref={scoringRef} className="grid grid-cols-2 gap-4">
+          {scoringThemes.map((theme) => {
+            const Icon = themeIcons[theme.name] ?? Flame
+            return (
+              <button
+                key={theme.id}
+                type="button"
+                onClick={() => onThemeSelect?.(theme)}
+                className={`text-left p-4 rounded-xl transition-colors cursor-pointer bg-white dark:bg-zinc-800 border ${
+                  selectedThemeId === theme.id
+                    ? 'border-lime'
+                    : 'border-transparent hover:border-gray-200 dark:hover:border-zinc-700'
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-gray-100 dark:bg-zinc-700 flex items-center justify-center shrink-0">
+                    <Icon className="w-5 h-5 text-gray-500 dark:text-zinc-400" />
+                  </div>
+                  <div>
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      {theme.name}
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-zinc-400">
+                      {theme.description}
+                    </p>
+                  </div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* AI-tagged themes */}
+      <div>
+        <h3 className="font-semibold text-gray-900 dark:text-white mb-4">
+          AI-tagged themes
+        </h3>
+        <div ref={aiTaggedRef} className="grid grid-cols-2 gap-4">
+          {displayedAiThemes.map((theme) => {
+            const Icon = themeIcons[theme.name] ?? MessageSquare
+            return (
+              <button
+                key={theme.id}
+                type="button"
+                onClick={() => onThemeSelect?.(theme)}
+                className={`text-left p-4 rounded-xl transition-colors cursor-pointer bg-white dark:bg-zinc-800 border ${
+                  selectedThemeId === theme.id
+                    ? 'border-lime'
+                    : 'border-transparent hover:border-gray-200 dark:hover:border-zinc-700'
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-gray-100 dark:bg-zinc-700 flex items-center justify-center shrink-0">
+                    <Icon className="w-5 h-5 text-gray-500 dark:text-zinc-400" />
+                  </div>
+                  <div>
+                    <p className="font-medium text-gray-900 dark:text-white">
+                      {theme.name}
+                    </p>
+                    <p className="text-sm text-gray-500 dark:text-zinc-400">
+                      {theme.count !== undefined && (
+                        <span className="font-semibold text-gray-700 dark:text-zinc-200">
+                          {theme.count}{' '}
+                        </span>
+                      )}
+                      {theme.description}
+                    </p>
+                  </div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+        {remainingCount > 0 && (
+          <button className="cursor-pointer w-full mt-4 py-2 text-sm text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-zinc-300 transition-colors">
+            + {remainingCount} more
+          </button>
+        )}
+      </div>
+
+      {/* Your Bookmarks */}
+      <div>
+        <h3 className="font-semibold text-gray-900 dark:text-white mb-4">
+          Your Bookmarks
+        </h3>
+        <div className="flex items-center gap-2 text-gray-500 dark:text-zinc-400">
+          <Bookmark className="w-4 h-4" />
+          <span className="text-sm">No posts bookmarked yet</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/audiences/detail/ThemesList.tsx
+++ b/src/components/audiences/detail/ThemesList.tsx
@@ -1,0 +1,95 @@
+import { useRef, useEffect } from 'react'
+import {
+  Flame,
+  Trophy,
+  HelpCircle,
+  Frown,
+  Lightbulb,
+  Megaphone,
+} from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
+import type { Theme } from '@/data/audienceDetails'
+
+export interface ThemesListProps {
+  themes: readonly Theme[]
+  totalCount: number
+  showHeader?: boolean
+}
+
+const themeIcons: Record<string, typeof Flame> = {
+  'Hot Discussions': Flame,
+  'Top Content': Trophy,
+  'Advice Requests': HelpCircle,
+  'Pain & Anger': Frown,
+  'Solution Requests': Lightbulb,
+  'Self-Promotion': Megaphone,
+}
+
+export function ThemesList({ themes, totalCount, showHeader = true }: Readonly<ThemesListProps>) {
+  const listRef = useRef<HTMLUListElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  const displayedThemes = themes.slice(0, 6)
+  const remainingCount = totalCount - displayedThemes.length
+
+  useEffect(() => {
+    if (!listRef.current || prefersReducedMotion) return
+
+    const items = Array.from(listRef.current.children)
+    gsap.fromTo(
+      items,
+      { opacity: 0, x: -20 },
+      {
+        opacity: 1,
+        x: 0,
+        duration: 0.4,
+        stagger: 0.05,
+        ease: 'power2.out',
+      }
+    )
+  }, [prefersReducedMotion, themes])
+
+  return (
+    <div className="bg-white dark:bg-zinc-900 rounded-2xl p-5 cursor-pointer hover:border-gray-200 dark:hover:border-zinc-700 border border-transparent transition-colors h-full flex flex-col">
+      {showHeader && (
+        <div className="flex items-center gap-2 mb-4">
+          <h3 className="font-semibold text-gray-900 dark:text-white">Themes</h3>
+          <span className="text-sm text-gray-500 dark:text-zinc-400">
+            {totalCount}
+          </span>
+        </div>
+      )}
+
+      <ul ref={listRef} className="space-y-1 flex-1">
+        {displayedThemes.map((theme) => {
+          const Icon = themeIcons[theme.name] ?? Flame
+          return (
+            <li
+              key={theme.id}
+              className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+            >
+              <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-zinc-800 flex items-center justify-center">
+                <Icon className="w-4 h-4 text-gray-500 dark:text-zinc-400" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-gray-900 dark:text-white text-sm">
+                  {theme.name}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-zinc-400 truncate">
+                  {theme.description}
+                </p>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+
+      {remainingCount > 0 && (
+        <button className="cursor-pointer w-full mt-3 py-2 text-sm text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-zinc-300 transition-colors">
+          + {remainingCount} more
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/audiences/detail/TopicDetailPanel.tsx
+++ b/src/components/audiences/detail/TopicDetailPanel.tsx
@@ -1,0 +1,179 @@
+import { useRef, useEffect, useLayoutEffect } from 'react'
+import { TrendingUp, Search, Sparkles, MessageSquare } from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
+import { Button } from '@/components/ui/button'
+
+export interface TopicSubreddit {
+  name: string
+  postCount: number
+}
+
+export interface TopicDetail {
+  id: string
+  name: string
+  frequency: number
+  frequencyUnit: 'day' | 'week' | 'mo'
+  growth: number
+  description: string
+  subreddits: TopicSubreddit[]
+}
+
+export interface TopicDetailPanelProps {
+  topic: TopicDetail | null
+}
+
+export function TopicDetailPanel({ topic }: Readonly<TopicDetailPanelProps>) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  useLayoutEffect(() => {
+    if (!containerRef.current || !panelRef.current) return
+
+    if (!topic) {
+      // Hide panel when no topic selected
+      gsap.set(panelRef.current, { opacity: 0, x: 50, display: 'none' })
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!containerRef.current || !panelRef.current) return
+
+    if (topic) {
+      // Show panel with animation
+      gsap.set(panelRef.current, { display: 'block' })
+
+      if (prefersReducedMotion) {
+        gsap.set(panelRef.current, { opacity: 1, x: 0 })
+      } else {
+        gsap.fromTo(
+          panelRef.current,
+          { opacity: 0, x: 50, scale: 0.95 },
+          {
+            opacity: 1,
+            x: 0,
+            scale: 1,
+            duration: 0.4,
+            ease: 'power3.out',
+          }
+        )
+      }
+    } else {
+      // Hide panel with animation
+      if (prefersReducedMotion) {
+        gsap.set(panelRef.current, { opacity: 0, display: 'none' })
+      } else {
+        gsap.to(panelRef.current, {
+          opacity: 0,
+          x: 30,
+          scale: 0.98,
+          duration: 0.25,
+          ease: 'power2.in',
+          onComplete: () => {
+            gsap.set(panelRef.current, { display: 'none' })
+          },
+        })
+      }
+    }
+  }, [prefersReducedMotion, topic])
+
+  return (
+    <div ref={containerRef} className="h-full">
+      <div
+        ref={panelRef}
+        className="bg-white dark:bg-zinc-900 rounded-2xl p-6 hidden"
+      >
+        {topic && (
+          <>
+            <div className="flex items-start justify-between mb-4">
+              <h3 className="font-semibold text-lg text-gray-900 dark:text-white">
+                {topic.name}
+              </h3>
+              <div className="flex items-center gap-2 text-sm">
+                <span className="text-gray-500 dark:text-zinc-400">
+                  {topic.frequency} / {topic.frequencyUnit}
+                </span>
+                <span className="flex items-center gap-1 text-green-500">
+                  <TrendingUp className="w-3 h-3" />
+                  {topic.growth}%
+                </span>
+              </div>
+            </div>
+
+            <p className="text-sm text-gray-600 dark:text-zinc-300 mb-6 leading-relaxed">
+              {topic.description}
+            </p>
+
+            <div className="flex flex-wrap justify-end gap-2 mb-6">
+              <Button
+                variant="primary"
+                size="sm"
+                className="gap-1.5"
+              >
+                <Search className="w-3.5 h-3.5" />
+                Browse all
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+              >
+                <Sparkles className="w-3.5 h-3.5" />
+                Patterns
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+              >
+                <Sparkles className="w-3.5 h-3.5" />
+                Sentiment
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5"
+              >
+                <Sparkles className="w-3.5 h-3.5" />
+                Ask
+              </Button>
+            </div>
+
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <h4 className="font-medium text-gray-900 dark:text-white text-sm">
+                  Subreddits
+                </h4>
+                <span className="text-xs text-gray-500 dark:text-zinc-400">
+                  {topic.subreddits.length}
+                </span>
+              </div>
+
+              <ul className="space-y-2">
+                {topic.subreddits.map((subreddit) => (
+                  <li
+                    key={subreddit.name}
+                    className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+                  >
+                    <div className="flex items-center gap-2">
+                      <div className="w-6 h-6 rounded-full bg-gray-200 dark:bg-zinc-700 flex items-center justify-center">
+                        <MessageSquare className="w-3 h-3 text-gray-500 dark:text-zinc-400" />
+                      </div>
+                      <span className="text-sm text-gray-900 dark:text-white">
+                        {subreddit.name}
+                      </span>
+                    </div>
+                    <span className="text-sm text-gray-500 dark:text-zinc-400">
+                      {subreddit.postCount}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/audiences/detail/TopicsList.tsx
+++ b/src/components/audiences/detail/TopicsList.tsx
@@ -1,0 +1,90 @@
+import { useRef, useEffect } from 'react'
+import { TrendingUp, MessageSquare } from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { cn } from '@/lib/utils'
+import { useReducedMotion } from '@/hooks'
+import { Badge } from '@/components/ui/badge'
+import type { Topic } from '@/data/audienceDetails'
+
+export interface TopicsListProps {
+  topics: readonly Topic[]
+  totalCount: number
+  showHeader?: boolean
+}
+
+export function TopicsList({ topics, totalCount, showHeader = true }: Readonly<TopicsListProps>) {
+  const listRef = useRef<HTMLUListElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  const displayedTopics = topics.slice(0, 6)
+  const remainingCount = totalCount - displayedTopics.length
+
+  useEffect(() => {
+    if (!listRef.current || prefersReducedMotion) return
+
+    const items = Array.from(listRef.current.children)
+    gsap.fromTo(
+      items,
+      { opacity: 0, x: -20 },
+      {
+        opacity: 1,
+        x: 0,
+        duration: 0.4,
+        stagger: 0.05,
+        ease: 'power2.out',
+      }
+    )
+  }, [prefersReducedMotion, topics])
+
+  return (
+    <div className="bg-white dark:bg-zinc-900 rounded-2xl p-5 cursor-pointer hover:border-gray-200 dark:hover:border-zinc-700 border border-transparent transition-colors h-full flex flex-col">
+      {showHeader && (
+        <div className="flex items-center gap-2 mb-4">
+          <h3 className="font-semibold text-gray-900 dark:text-white">Topics</h3>
+          <span className="text-sm text-gray-500 dark:text-zinc-400">
+            {totalCount}
+          </span>
+        </div>
+      )}
+
+      <ul ref={listRef} className="space-y-1 flex-1">
+        {displayedTopics.map((topic) => (
+          <li
+            key={topic.id}
+            className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+          >
+            <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-zinc-800 flex items-center justify-center">
+              <MessageSquare className="w-4 h-4 text-gray-500 dark:text-zinc-400" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-gray-900 dark:text-white text-sm">
+                {topic.name}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-zinc-400">
+                {topic.postsCount} posts about{' '}
+                <Badge variant="neutral" size="sm">
+                  {topic.relatedKeyword}
+                </Badge>
+              </p>
+            </div>
+            <div
+              className={cn(
+                'flex items-center gap-1 text-xs',
+                topic.growth >= 0 ? 'text-success-light' : 'text-error-light'
+              )}
+            >
+              <TrendingUp className="w-3 h-3" />
+              <span>{topic.growth}%</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {remainingCount > 0 && (
+        <button className="cursor-pointer w-full mt-3 py-2 text-sm text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-zinc-300 transition-colors">
+          + {remainingCount} more
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/audiences/detail/TopicsTable.tsx
+++ b/src/components/audiences/detail/TopicsTable.tsx
@@ -1,0 +1,239 @@
+import { useState, useRef, useEffect } from 'react'
+import { Search, ChevronDown, TrendingUp } from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
+
+export interface TopicTableItem {
+  id: string
+  name: string
+  growth: number
+  frequency: number
+  frequencyUnit: 'day' | 'week' | 'mo'
+  subreddits: string[]
+}
+
+export interface TopicsTableProps {
+  topics: readonly TopicTableItem[]
+  totalCount: number
+  selectedTopicId?: string | null
+  onTopicSelect?: (topic: TopicTableItem) => void
+}
+
+type SortOption = 'growth' | 'frequency' | 'name'
+
+function Sparkline({ growth }: { growth: number }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const width = canvas.width
+    const height = canvas.height
+
+    ctx.clearRect(0, 0, width, height)
+
+    // Generate sparkline data based on growth
+    const points = 20
+    const data: number[] = []
+    let value = 30 + Math.random() * 20
+
+    for (let i = 0; i < points; i++) {
+      const trend = growth > 200 ? 0.6 : growth > 100 ? 0.55 : 0.5
+      value = value + (Math.random() - (1 - trend)) * 10
+      value = Math.max(10, Math.min(90, value))
+      data.push(value)
+    }
+
+    // Draw line
+    ctx.beginPath()
+    ctx.strokeStyle = '#4ade80' // green-400
+    ctx.lineWidth = 2
+
+    data.forEach((val, i) => {
+      const x = (i / (points - 1)) * width
+      const y = height - (val / 100) * height
+      if (i === 0) {
+        ctx.moveTo(x, y)
+      } else {
+        ctx.lineTo(x, y)
+      }
+    })
+
+    ctx.stroke()
+  }, [growth])
+
+  return <canvas ref={canvasRef} width={70} height={28} />
+}
+
+export function TopicsTable({
+  topics,
+  totalCount,
+  selectedTopicId,
+  onTopicSelect,
+}: Readonly<TopicsTableProps>) {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [sortBy, setSortBy] = useState<SortOption>('growth')
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const listRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  const sortOptions: { value: SortOption; label: string }[] = [
+    { value: 'growth', label: 'Growth' },
+    { value: 'frequency', label: 'Frequency' },
+    { value: 'name', label: 'Name' },
+  ]
+
+  const filteredTopics = topics.filter((topic) =>
+    topic.name.toLowerCase().includes(searchQuery.toLowerCase())
+  )
+
+  const sortedTopics = [...filteredTopics].sort((a, b) => {
+    switch (sortBy) {
+      case 'growth':
+        return b.growth - a.growth
+      case 'frequency':
+        return b.frequency - a.frequency
+      case 'name':
+        return a.name.localeCompare(b.name)
+      default:
+        return 0
+    }
+  })
+
+  useEffect(() => {
+    if (!listRef.current || prefersReducedMotion) return
+
+    const items = Array.from(listRef.current.children)
+    gsap.fromTo(
+      items,
+      { opacity: 0, y: 10 },
+      {
+        opacity: 1,
+        y: 0,
+        duration: 0.3,
+        stagger: 0.03,
+        ease: 'power2.out',
+      }
+    )
+  }, [prefersReducedMotion, sortBy, searchQuery])
+
+  return (
+    <div className="flex-1">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="font-semibold text-gray-900 dark:text-white">
+            Popular Topics
+          </h3>
+          <span className="text-sm text-gray-500 dark:text-zinc-400">
+            {totalCount}
+          </span>
+        </div>
+        <div className="relative">
+          <button
+            onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+            className="cursor-pointer flex items-center gap-2 text-sm text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-white transition-colors"
+          >
+            Sort by: {sortOptions.find((o) => o.value === sortBy)?.label}
+            <ChevronDown className="w-4 h-4" />
+          </button>
+          {isDropdownOpen && (
+            <>
+              <div
+                className="fixed inset-0 z-10"
+                onClick={() => setIsDropdownOpen(false)}
+              />
+              <div className="absolute right-0 top-full mt-1 z-20 bg-white dark:bg-zinc-800 rounded-lg shadow-lg border border-gray-200 dark:border-zinc-700 py-1 min-w-[120px]">
+                {sortOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    onClick={() => {
+                      setSortBy(option.value)
+                      setIsDropdownOpen(false)
+                    }}
+                    className={`cursor-pointer w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-zinc-700 transition-colors ${
+                      sortBy === option.value
+                        ? 'text-lime font-medium'
+                        : 'text-gray-700 dark:text-zinc-300'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="mb-4">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-zinc-500" />
+          <input
+            type="text"
+            placeholder="Search topics"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-10 pr-4 py-2.5 bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-lg text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-lime/50 focus:border-lime transition-colors"
+          />
+        </div>
+      </div>
+
+      <div ref={listRef} className="space-y-2">
+        {sortedTopics.map((topic) => (
+          <button
+            type="button"
+            key={topic.id}
+            onClick={() => onTopicSelect?.(topic)}
+            className={`w-full text-left bg-white dark:bg-zinc-800 border rounded-xl p-4 transition-colors cursor-pointer ${
+              selectedTopicId === topic.id
+                ? 'border-lime'
+                : 'border-gray-200 dark:border-zinc-700 hover:border-lime dark:hover:border-lime'
+            }`}
+          >
+            <div className="flex items-center gap-4">
+              <div className="w-28 min-w-[112px]">
+                <p className="font-semibold text-gray-900 dark:text-white">
+                  {topic.name}
+                </p>
+              </div>
+
+              <div className="w-[70px] shrink-0">
+                <Sparkline growth={topic.growth} />
+              </div>
+
+              <div className="flex items-center gap-1 text-green-500 text-sm font-medium w-20 shrink-0">
+                <TrendingUp className="w-4 h-4" />
+                <span>{topic.growth}%</span>
+              </div>
+
+              <div className="flex-1 text-sm">
+                <span className="text-lime font-semibold">
+                  {topic.frequency} / {topic.frequencyUnit}
+                </span>
+                <span className="text-gray-500 dark:text-zinc-400"> in </span>
+                <span className="text-gray-700 dark:text-zinc-300">
+                  {topic.subreddits.slice(0, 2).join(', ')}
+                </span>
+                {topic.subreddits.length > 2 && (
+                  <span className="text-gray-400 dark:text-zinc-500">
+                    , and {topic.subreddits.length - 2} others
+                  </span>
+                )}
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {sortedTopics.length === 0 && (
+        <div className="py-8 text-center text-gray-500 dark:text-zinc-400 bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700">
+          No topics found
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/audiences/detail/index.ts
+++ b/src/components/audiences/detail/index.ts
@@ -1,0 +1,29 @@
+export { SubredditsList } from './SubredditsList'
+export type { SubredditsListProps } from './SubredditsList'
+
+export { ThemesList } from './ThemesList'
+export type { ThemesListProps } from './ThemesList'
+
+export { TopicsList } from './TopicsList'
+export type { TopicsListProps } from './TopicsList'
+
+export { AboutAudiencePanel } from './AboutAudiencePanel'
+export type { AboutAudiencePanelProps, AudienceStats, RadarData } from './AboutAudiencePanel'
+
+export { SubredditCard } from './SubredditCard'
+export type { SubredditCardProps } from './SubredditCard'
+
+export { SubredditsGrid } from './SubredditsGrid'
+export type { SubredditsGridProps, ExtendedSubreddit } from './SubredditsGrid'
+
+export { TopicsTable } from './TopicsTable'
+export type { TopicsTableProps, TopicTableItem } from './TopicsTable'
+
+export { TopicDetailPanel } from './TopicDetailPanel'
+export type { TopicDetailPanelProps, TopicDetail, TopicSubreddit } from './TopicDetailPanel'
+
+export { ThemeDetailPanel } from './ThemeDetailPanel'
+export type { ThemeDetailPanelProps, ThemeDetail, ThemeSubcategory, ThemeTopic, ThemeSubreddit } from './ThemeDetailPanel'
+
+export { ThemesGrid } from './ThemesGrid'
+export type { ThemesGridProps, ThemeGridItem } from './ThemesGrid'

--- a/src/components/shared/Modal.tsx
+++ b/src/components/shared/Modal.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+import { X } from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { cn } from '@/lib/utils'
+import { useReducedMotion } from '@/hooks'
+
+export interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  title?: string
+  icon?: ReactNode
+  children: ReactNode
+  className?: string
+  size?: 'sm' | 'md' | 'lg' | 'xl'
+}
+
+const sizeClasses = {
+  sm: 'max-w-md',
+  md: 'max-w-2xl',
+  lg: 'max-w-4xl',
+  xl: 'max-w-6xl',
+}
+
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  icon,
+  children,
+  className,
+  size = 'lg',
+}: Readonly<ModalProps>) {
+  const overlayRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    if (!overlayRef.current || !contentRef.current) return
+
+    if (isOpen) {
+      document.body.style.overflow = 'hidden'
+
+      if (!prefersReducedMotion) {
+        gsap.set(overlayRef.current, { opacity: 0 })
+        gsap.set(contentRef.current, { y: 20, scale: 0.95 })
+
+        gsap.to(overlayRef.current, {
+          opacity: 1,
+          duration: 0.2,
+          ease: 'power2.out',
+        })
+
+        gsap.to(contentRef.current, {
+          y: 0,
+          scale: 1,
+          duration: 0.3,
+          ease: 'power2.out',
+          delay: 0.1,
+        })
+      }
+    }
+
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [isOpen, prefersReducedMotion])
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [isOpen, onClose])
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) {
+      onClose()
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+    >
+      <div
+        ref={contentRef}
+        className={cn(
+          'w-full bg-white dark:bg-zinc-900 rounded-2xl shadow-xl overflow-hidden',
+          sizeClasses[size],
+          className
+        )}
+      >
+        {title && (
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-zinc-800">
+            <div className="flex items-center gap-3">
+              {icon && (
+                <div className="text-gray-600 dark:text-zinc-400">{icon}</div>
+              )}
+              <h2 className="text-lg font-bold text-gray-900 dark:text-white">
+                {title}
+              </h2>
+            </div>
+            <button
+              onClick={onClose}
+              className="cursor-pointer w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800 transition-colors duration-200"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        )}
+        <div className="max-h-[calc(100vh-12rem)] overflow-y-auto">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/shared/SelectAudienceModal.tsx
+++ b/src/components/shared/SelectAudienceModal.tsx
@@ -1,0 +1,282 @@
+import { useState, useEffect, useRef } from 'react'
+import { Users, TrendingUp, Waypoints, Copy } from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { cn } from '@/lib/utils'
+import { useReducedMotion } from '@/hooks'
+import { Modal } from './Modal'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Avatar } from '@/components/ui/avatar'
+
+export interface Subreddit {
+  id: string
+  name: string
+  icon?: string
+}
+
+export interface Audience {
+  id: string
+  name: string
+  subredditCount: number
+  totalMembers: number
+  weeklyGrowth: number
+  subreddits: readonly Subreddit[]
+}
+
+export interface SelectAudienceModalProps {
+  isOpen: boolean
+  onClose: () => void
+  audiences: readonly Audience[]
+  onCreateAudience: (name: string, selectedAudiences: string[]) => void
+  isLoading?: boolean
+}
+
+function formatNumber(num: number): string {
+  if (num >= 1_000_000) {
+    return `${(num / 1_000_000).toFixed(1)}M`
+  }
+  if (num >= 1_000) {
+    return `${(num / 1_000).toFixed(0)}K`
+  }
+  return num.toString()
+}
+
+interface AudienceSelectCardProps {
+  audience: Audience
+  isSelected: boolean
+  onToggle: (id: string) => void
+  index: number
+}
+
+function AudienceSelectCard({
+  audience,
+  isSelected,
+  onToggle,
+  index,
+}: Readonly<AudienceSelectCardProps>) {
+  const cardRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  const displayedSubreddits = audience.subreddits.slice(0, 5)
+  const remainingCount = audience.subreddits.length - displayedSubreddits.length
+
+  useEffect(() => {
+    if (!cardRef.current || prefersReducedMotion) return
+
+    gsap.fromTo(
+      cardRef.current,
+      { opacity: 0, y: 20 },
+      {
+        opacity: 1,
+        y: 0,
+        duration: 0.4,
+        delay: index * 0.05,
+        ease: 'power2.out',
+      }
+    )
+  }, [index, prefersReducedMotion])
+
+  const handleMouseEnter = () => {
+    if (!cardRef.current || prefersReducedMotion) return
+    gsap.to(cardRef.current, {
+      y: -2,
+      duration: 0.2,
+      ease: 'power2.out',
+    })
+  }
+
+  const handleMouseLeave = () => {
+    if (!cardRef.current || prefersReducedMotion) return
+    gsap.to(cardRef.current, {
+      y: 0,
+      duration: 0.2,
+      ease: 'power2.out',
+    })
+  }
+
+  return (
+    <div
+      ref={cardRef}
+      onClick={() => onToggle(audience.id)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      className={cn(
+        'cursor-pointer rounded-xl p-4 border-2 transition-colors duration-200',
+        'bg-gray-50 dark:bg-zinc-800/50',
+        isSelected
+          ? 'border-lime bg-lime/5 dark:bg-lime/10'
+          : 'border-transparent hover:border-gray-200 dark:hover:border-zinc-700'
+      )}
+    >
+      <div className="flex items-start justify-between mb-3">
+        <h4 className="font-bold text-gray-900 dark:text-white">
+          {audience.name}
+        </h4>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+          }}
+          className="cursor-pointer w-7 h-7 rounded-md flex items-center justify-center text-gray-400 hover:text-lime hover:bg-lime/10 transition-colors duration-200"
+          title="Copy"
+        >
+          <Copy className="w-4 h-4" />
+        </button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-zinc-400 mb-3">
+        <div className="flex items-center gap-1">
+          <Waypoints className="w-3.5 h-3.5" />
+          <span>{audience.subredditCount} Subs</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Users className="w-3.5 h-3.5" />
+          <span>{formatNumber(audience.totalMembers)} Users</span>
+        </div>
+        <div
+          className={cn(
+            'flex items-center gap-1',
+            audience.weeklyGrowth >= 0 ? 'text-success-light' : 'text-error-light'
+          )}
+        >
+          <TrendingUp className="w-3.5 h-3.5" />
+          <span>{audience.weeklyGrowth.toFixed(2)}%/mo</span>
+        </div>
+      </div>
+
+      <div className="flex items-center -space-x-1.5">
+        {displayedSubreddits.map((subreddit) => (
+          <Avatar
+            key={subreddit.id}
+            src={subreddit.icon}
+            alt={subreddit.name}
+            fallback={subreddit.name.charAt(0)}
+            size="sm"
+            className="border-2 border-gray-50 dark:border-zinc-800 w-7 h-7"
+          />
+        ))}
+        {remainingCount > 0 && (
+          <div className="w-7 h-7 rounded-full bg-gray-200 dark:bg-zinc-700 flex items-center justify-center text-[10px] font-medium text-gray-600 dark:text-zinc-400 border-2 border-gray-50 dark:border-zinc-800">
+            +{remainingCount}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function SelectAudienceModal({
+  isOpen,
+  onClose,
+  audiences,
+  onCreateAudience,
+  isLoading = false,
+}: Readonly<SelectAudienceModalProps>) {
+  const [audienceName, setAudienceName] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedAudiences, setSelectedAudiences] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setAudienceName('')
+      setSearchQuery('')
+      setSelectedAudiences([])
+    }
+  }, [isOpen])
+
+  const filteredAudiences = audiences.filter((audience) =>
+    audience.name.toLowerCase().includes(searchQuery.toLowerCase())
+  )
+
+  const handleToggleAudience = (id: string) => {
+    setSelectedAudiences((prev) =>
+      prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id]
+    )
+  }
+
+  const handleSubmit = () => {
+    if (audienceName.trim()) {
+      onCreateAudience(audienceName.trim(), selectedAudiences)
+    }
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="New Audience - Select Subreddits"
+      icon={<Users className="w-5 h-5" />}
+      size="xl"
+    >
+      <div className="p-6">
+        <div className="mb-6">
+          <label className="block text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide mb-2">
+            Name your custom audience
+          </label>
+          <div className="flex gap-3">
+            <Input
+              value={audienceName}
+              onChange={(e) => setAudienceName(e.target.value)}
+              placeholder='Pick a short name, like "Digital Marketers" or "Movie-Goers"'
+              className="flex-1"
+            />
+            <Button
+              onClick={handleSubmit}
+              disabled={isLoading}
+              variant="primary"
+              size="md"
+            >
+              {isLoading ? 'Creating...' : 'Find Communities'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide">
+              No audience in mind? Explore a curated one, or browse{' '}
+              <button className="text-lime hover:underline cursor-pointer uppercase">
+                Trending Subreddits
+              </button>
+              .
+            </p>
+            <Input
+              icon
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search audiences..."
+              className="w-64"
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-h-[400px] overflow-y-auto pr-2">
+          {filteredAudiences.map((audience, index) => (
+            <AudienceSelectCard
+              key={audience.id}
+              audience={audience}
+              isSelected={selectedAudiences.includes(audience.id)}
+              onToggle={handleToggleAudience}
+              index={index}
+            />
+          ))}
+          {filteredAudiences.length === 0 && (
+            <div className="col-span-full text-center py-12 text-gray-500 dark:text-zinc-400">
+              No audiences found matching "{searchQuery}"
+            </div>
+          )}
+        </div>
+
+        {selectedAudiences.length > 0 && (
+          <div className="mt-4 pt-4 border-t border-gray-200 dark:border-zinc-800">
+            <p className="text-sm text-gray-600 dark:text-zinc-400">
+              <span className="font-semibold text-lime">
+                {selectedAudiences.length}
+              </span>{' '}
+              audience{selectedAudiences.length !== 1 ? 's' : ''} selected
+            </p>
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,0 +1,9 @@
+export { Modal } from './Modal'
+export type { ModalProps } from './Modal'
+
+export { SelectAudienceModal } from './SelectAudienceModal'
+export type {
+  SelectAudienceModalProps,
+  Audience,
+  Subreddit,
+} from './SelectAudienceModal'

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,118 @@
+import { useState, createContext, useContext, type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+interface TabsContextValue {
+  activeTab: string
+  setActiveTab: (tab: string) => void
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null)
+
+function useTabs() {
+  const context = useContext(TabsContext)
+  if (!context) {
+    throw new Error('Tabs components must be used within a Tabs provider')
+  }
+  return context
+}
+
+export interface TabsProps {
+  defaultValue: string
+  children: ReactNode
+  className?: string
+}
+
+export function Tabs({ defaultValue, children, className }: Readonly<TabsProps>) {
+  const [activeTab, setActiveTab] = useState(defaultValue)
+
+  return (
+    <TabsContext.Provider value={{ activeTab, setActiveTab }}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  )
+}
+
+export interface TabsListProps {
+  children: ReactNode
+  className?: string
+}
+
+export function TabsList({ children, className }: Readonly<TabsListProps>) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-6 border-b border-gray-200 dark:border-zinc-800',
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+export interface TabsTriggerProps {
+  value: string
+  children: ReactNode
+  count?: number
+  className?: string
+}
+
+export function TabsTrigger({
+  value,
+  children,
+  count,
+  className,
+}: Readonly<TabsTriggerProps>) {
+  const { activeTab, setActiveTab } = useTabs()
+  const isActive = activeTab === value
+
+  return (
+    <button
+      onClick={() => setActiveTab(value)}
+      className={cn(
+        'cursor-pointer relative pb-3 text-sm font-medium transition-colors duration-200',
+        isActive
+          ? 'text-gray-900 dark:text-white'
+          : 'text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-zinc-300',
+        className
+      )}
+    >
+      <span className="flex items-center gap-2">
+        {children}
+        {count !== undefined && (
+          <span
+            className={cn(
+              'text-xs',
+              isActive
+                ? 'text-gray-600 dark:text-zinc-300'
+                : 'text-gray-400 dark:text-zinc-500'
+            )}
+          >
+            {count}
+          </span>
+        )}
+      </span>
+      {isActive && (
+        <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-lime" />
+      )}
+    </button>
+  )
+}
+
+export interface TabsContentProps {
+  value: string
+  children: ReactNode
+  className?: string
+}
+
+export function TabsContent({
+  value,
+  children,
+  className,
+}: Readonly<TabsContentProps>) {
+  const { activeTab } = useTabs()
+
+  if (activeTab !== value) return null
+
+  return <div className={className}>{children}</div>
+}

--- a/src/data/audienceDetails.ts
+++ b/src/data/audienceDetails.ts
@@ -1,0 +1,232 @@
+export interface SubredditDetail {
+  id: string
+  name: string
+  icon?: string
+  members: number
+  monthlyGrowth: number
+  description?: string
+  activityLevel?: 'Super Active' | 'High Activity' | 'Active' | 'Moderate'
+  sizeCategory?: 'Massive' | 'Huge' | 'Large' | 'Medium' | 'Small'
+}
+
+export interface Theme {
+  id: string
+  name: string
+  description: string
+  icon?: string
+}
+
+export interface Topic {
+  id: string
+  name: string
+  postsCount: number
+  relatedKeyword: string
+  growth: number
+}
+
+export interface AudienceDetailData {
+  id: string
+  name: string
+  subreddits: SubredditDetail[]
+  themes: Theme[]
+  topics: Topic[]
+}
+
+export const audienceDetailsMap: Record<string, AudienceDetailData> = {
+  '1': {
+    id: '1',
+    name: 'Influencers',
+    subreddits: [
+      { id: 's1', name: 'r/BGC', members: 2_100_000, monthlyGrowth: 1.5 },
+      { id: 's2', name: 'r/Instagram', members: 5_400_000, monthlyGrowth: 0.8 },
+      { id: 's3', name: 'r/TikTok', members: 3_200_000, monthlyGrowth: 2.1 },
+      { id: 's4', name: 'r/YouTube', members: 4_800_000, monthlyGrowth: 0.6 },
+      { id: 's5', name: 'r/Twitter', members: 1_900_000, monthlyGrowth: 0.3 },
+      { id: 's6', name: 'r/Twitch', members: 2_700_000, monthlyGrowth: 1.2 },
+      { id: 's7', name: 'r/LinkedIn', members: 890_000, monthlyGrowth: 0.9 },
+    ],
+    themes: [
+      { id: 't1', name: 'Hot Discussions', description: 'Popular discussions this week' },
+      { id: 't2', name: 'Top Content', description: 'Best-performing content of past month' },
+      { id: 't3', name: 'Advice Requests', description: 'People asking for advice & resources' },
+      { id: 't4', name: 'Pain & Anger', description: 'People expressing pain points & frustrations' },
+      { id: 't5', name: 'Solution Requests', description: 'People asking for tools & solutions' },
+      { id: 't6', name: 'Self-Promotion', description: 'People launching products & services' },
+    ],
+    topics: [
+      { id: 'tp1', name: 'Brand deals', postsCount: 45, relatedKeyword: 'Brand deals', growth: 280 },
+      { id: 'tp2', name: 'Engagement rate', postsCount: 38, relatedKeyword: 'Engagement rate', growth: 220 },
+      { id: 'tp3', name: 'Algorithm changes', postsCount: 52, relatedKeyword: 'Algorithm changes', growth: 180 },
+      { id: 'tp4', name: 'Monetization', postsCount: 67, relatedKeyword: 'Monetization', growth: 165 },
+      { id: 'tp5', name: 'Content calendar', postsCount: 29, relatedKeyword: 'Content calendar', growth: 145 },
+      { id: 'tp6', name: 'Sponsorships', postsCount: 41, relatedKeyword: 'Sponsorships', growth: 130 },
+    ],
+  },
+  '7': {
+    id: '7',
+    name: 'Parents',
+    subreddits: [
+      { id: 's43', name: 'r/Parenting', members: 2_100_000, monthlyGrowth: 0.8 },
+      { id: 's44', name: 'r/Mommit', members: 890_000, monthlyGrowth: 0.6 },
+      { id: 's45', name: 'r/Daddit', members: 720_000, monthlyGrowth: 0.7 },
+      { id: 's46', name: 'r/BabyBumps', members: 1_400_000, monthlyGrowth: 0.9 },
+      { id: 's47', name: 'r/Toddlers', members: 340_000, monthlyGrowth: 1.1 },
+      { id: 's48', name: 'r/NewParents', members: 180_000, monthlyGrowth: 1.3 },
+    ],
+    themes: [
+      { id: 't1', name: 'Hot Discussions', description: 'Popular discussions this week' },
+      { id: 't2', name: 'Top Content', description: 'Best-performing content of past month' },
+      { id: 't3', name: 'Advice Requests', description: 'People asking for advice & resources' },
+      { id: 't4', name: 'Pain & Anger', description: 'People expressing pain points & frustrations' },
+      { id: 't5', name: 'Solution Requests', description: 'People asking for tools & solutions' },
+      { id: 't6', name: 'Self-Promotion', description: 'People launching products & services' },
+    ],
+    topics: [
+      { id: 'tp1', name: 'Sleep training', postsCount: 89, relatedKeyword: 'Sleep training', growth: 320 },
+      { id: 'tp2', name: 'Screen time', postsCount: 67, relatedKeyword: 'Screen time', growth: 280 },
+      { id: 'tp3', name: 'Daycare costs', postsCount: 45, relatedKeyword: 'Daycare costs', growth: 240 },
+      { id: 'tp4', name: 'Work-life balance', postsCount: 78, relatedKeyword: 'Work-life balance', growth: 195 },
+      { id: 'tp5', name: 'Picky eaters', postsCount: 56, relatedKeyword: 'Picky eaters', growth: 160 },
+      { id: 'tp6', name: 'School choice', postsCount: 34, relatedKeyword: 'School choice', growth: 145 },
+    ],
+  },
+}
+
+// Generate default data for any audience not explicitly defined
+export function getAudienceDetails(audienceId: string, audienceName: string): AudienceDetailData {
+  if (audienceDetailsMap[audienceId]) {
+    return audienceDetailsMap[audienceId]
+  }
+
+  // Generate default mock data
+  return {
+    id: audienceId,
+    name: audienceName,
+    subreddits: [
+      {
+        id: 's1',
+        name: 'r/cats',
+        members: 8_600_000,
+        monthlyGrowth: 1.2,
+        description: 'Pictures, videos, questions, and articles featuring/about cats.',
+        sizeCategory: 'Massive',
+        activityLevel: 'Super Active',
+      },
+      {
+        id: 's2',
+        name: 'r/dogs',
+        members: 2_800_000,
+        monthlyGrowth: 0.3,
+        description: '/r/dogs is a place for dog owners of all levels of knowledge, skill, and experience to discuss various topics related to responsible dog ownership. This subreddit is a great starting...',
+        sizeCategory: 'Massive',
+        activityLevel: 'Super Active',
+      },
+      {
+        id: 's3',
+        name: 'r/Dogtraining',
+        members: 1_500_000,
+        monthlyGrowth: 0.1,
+        description: 'DogTraining: A forum on dog training and behavior. Here you will find content that will help you train your dogs. Dog training links, discussions and questions are encouraged and conten...',
+        sizeCategory: 'Massive',
+        activityLevel: 'High Activity',
+      },
+      {
+        id: 's4',
+        name: 'r/Aquariums',
+        members: 1_400_000,
+        monthlyGrowth: 0.4,
+        description: "The subreddit for anything related to aquariums! Come here to enjoy pictures, videos, articles and discussion. We're also here to help you if you need advice.",
+        sizeCategory: 'Massive',
+        activityLevel: 'Super Active',
+      },
+      {
+        id: 's5',
+        name: 'r/parrots',
+        members: 1_400_000,
+        monthlyGrowth: 0,
+        description: 'This is a community for the discussion of parrots. Feel free to talk about parrots in the wild, owning parrots, the pet trade, rescuing parrots, purchasing parrots, avian veterinarians, an...',
+        sizeCategory: 'Massive',
+        activityLevel: 'Super Active',
+      },
+      {
+        id: 's6',
+        name: 'r/dogpictures',
+        members: 1_000_000,
+        monthlyGrowth: 0.3,
+        description: 'Pictures of dogs!',
+        sizeCategory: 'Massive',
+        activityLevel: 'Super Active',
+      },
+      {
+        id: 's7',
+        name: 'r/dogswithjobs',
+        members: 912_000,
+        monthlyGrowth: 0,
+        description: 'This is a community for real working dogs. These are jobs or tasks a dog is specifically trained to perform such as Guide Dog, Service Dog, Herding Dog, Police Dog, Sled Dog, etc....',
+        sizeCategory: 'Huge',
+        activityLevel: 'Active',
+      },
+      {
+        id: 's8',
+        name: 'r/RATS',
+        members: 830_000,
+        monthlyGrowth: 0.9,
+        description: "🐀 This is a community for our little pocket puppies! We will occasionally accept wild rat posts, but this is mainly a place to celebrate our pets! We love art, stories, videos, and photos ...",
+        sizeCategory: 'Huge',
+        activityLevel: 'Super Active',
+      },
+      {
+        id: 's9',
+        name: 'r/BeardedDragons',
+        members: 719_000,
+        monthlyGrowth: 0.2,
+        description: 'A home to talk about all things Bearded Dragons!',
+        sizeCategory: 'Huge',
+        activityLevel: 'Super Active',
+      },
+      {
+        id: 's10',
+        name: 'r/birding',
+        members: 654_000,
+        monthlyGrowth: 1.0,
+        description: 'Birding, bird watching, twitching, listing. Whatever you want to call it, if you are looking at or listening to birds, this is where you should be.',
+        sizeCategory: 'Huge',
+        activityLevel: 'Super Active',
+      },
+      {
+        id: 's11',
+        name: 'r/DOG',
+        members: 455_000,
+        monthlyGrowth: 1.2,
+        description: 'A subreddit dedicated to the best animal ever, the dog!',
+        sizeCategory: 'Huge',
+        activityLevel: 'Super Active',
+      },
+      {
+        id: 's12',
+        name: 'r/CatAdvice',
+        members: 450_000,
+        monthlyGrowth: 2.8,
+        description: 'There are no dumb questions, except the ones asking for medical advice which is prohibited. Read the rules and the FAQ first.',
+        sizeCategory: 'Huge',
+        activityLevel: 'Super Active',
+      },
+    ],
+    themes: [
+      { id: 't1', name: 'Hot Discussions', description: 'Popular discussions this week' },
+      { id: 't2', name: 'Top Content', description: 'Best-performing content of past month' },
+      { id: 't3', name: 'Advice Requests', description: 'People asking for advice & resources' },
+      { id: 't4', name: 'Pain & Anger', description: 'People expressing pain points & frustrations' },
+      { id: 't5', name: 'Solution Requests', description: 'People asking for tools & solutions' },
+      { id: 't6', name: 'Self-Promotion', description: 'People launching products & services' },
+    ],
+    topics: [
+      { id: 'tp1', name: 'Health issues', postsCount: 21, relatedKeyword: 'Health issues', growth: 400 },
+      { id: 'tp2', name: 'Choice', postsCount: 27, relatedKeyword: 'Choice', growth: 300 },
+      { id: 'tp3', name: 'Dog health', postsCount: 27, relatedKeyword: 'Dog health', growth: 150 },
+      { id: 'tp4', name: 'Bird-species', postsCount: 21, relatedKeyword: 'Bird-species', growth: 133 },
+      { id: 'tp5', name: 'Mistake', postsCount: 81, relatedKeyword: 'Mistake', growth: 122 },
+      { id: 'tp6', name: 'Frog', postsCount: 34, relatedKeyword: 'Frog', growth: 120 },
+    ],
+  }
+}

--- a/src/pages/AudienceDetail.tsx
+++ b/src/pages/AudienceDetail.tsx
@@ -1,0 +1,676 @@
+import { useRef, useEffect, useState } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import {
+  ChevronLeft,
+  Search,
+  Info,
+  Pencil,
+  Share2,
+  Plus,
+  Sparkles,
+  TrendingUp,
+} from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import {
+  SubredditsList,
+  SubredditsGrid,
+  ThemesList,
+  TopicsList,
+  TopicsTable,
+  AboutAudiencePanel,
+  TopicDetailPanel,
+  ThemesGrid,
+  ThemeDetailPanel,
+} from '@/components/audiences/detail'
+import type { TopicTableItem, TopicDetail, ThemeGridItem, ThemeDetail } from '@/components/audiences/detail'
+import { audiences } from '@/data/audiences'
+import { getAudienceDetails } from '@/data/audienceDetails'
+
+// Theme data for the themes tab
+const themesGridData: ThemeGridItem[] = [
+  { id: 'th1', name: 'Hot Discussions', description: 'Popular discussions this week', type: 'scoring' },
+  { id: 'th2', name: 'Top Content', description: 'Best-performing content of past month', type: 'scoring' },
+  { id: 'th3', name: 'Advice Requests', description: 'People asking for advice & resources', count: 1000, type: 'ai-tagged' },
+  { id: 'th4', name: 'Pain & Anger', description: 'People expressing pain points & frustrations', count: 287, type: 'ai-tagged' },
+  { id: 'th5', name: 'Solution Requests', description: 'People asking for tools & solutions', count: 243, type: 'ai-tagged' },
+  { id: 'th6', name: 'Self-Promotion', description: 'People launching products & services', count: 26, type: 'ai-tagged' },
+  { id: 'th7', name: 'Ideas', description: 'People suggesting ideas', count: 25, type: 'ai-tagged' },
+  { id: 'th8', name: 'News', description: 'Conversations about current news & events', count: 12, type: 'ai-tagged' },
+]
+
+const themesDetailData: Record<string, Omit<ThemeDetail, 'id' | 'name'>> = {
+  th1: {
+    description: 'This week in the Pet Lovers communities on Reddit, members shared heartwarming stories and adorable photos of their pets. From fulfilling dreams of seeing puffins to celebrating the retirement of a beloved therapy dog, the discussions were filled with love and positivity. Members also shared cute moments of their pets, like snuggling buddies and newly adopted pups, creating a sense of joy and camaraderie among pet lovers.',
+    subcategories: [
+      { name: 'Frustration', count: 1 },
+      { name: 'Questions', count: 1 },
+    ],
+    topics: [
+      { name: 'Dog', count: 3 },
+      { name: 'Rat', count: 1 },
+      { name: 'Friendship', count: 1 },
+      { name: 'Breed', count: 1 },
+      { name: 'Rescue', count: 1 },
+      { name: 'Lab mix', count: 1 },
+      { name: 'Pup', count: 1 },
+    ],
+    subreddits: [
+      { name: 'r/dogbreed', count: 8 },
+      { name: 'r/cockatiel', count: 7 },
+      { name: 'r/DOG', count: 7 },
+      { name: 'r/turtle', count: 7 },
+      { name: 'r/RATS', count: 6 },
+      { name: 'r/germanshepherds', count: 6 },
+      { name: 'r/leopardgeckos', count: 5 },
+      { name: 'r/reptiles', count: 5 },
+      { name: 'r/BeardedDragons', count: 4 },
+      { name: 'r/puppy101', count: 4 },
+      { name: 'r/cats', count: 4 },
+      { name: 'r/goldenretrievers', count: 3 },
+      { name: 'r/DogAdvice', count: 3 },
+      { name: 'r/ballpython', count: 3 },
+      { name: 'r/dogs', count: 3 },
+      { name: 'r/herpetology', count: 3 },
+      { name: 'r/dogpictures', count: 2 },
+      { name: 'r/Pets', count: 2 },
+      { name: 'r/Aquariums', count: 2 },
+    ],
+  },
+  th2: {
+    description: 'The best-performing content from the past month in pet communities, featuring viral posts, highly upvoted discussions, and content that resonated most with community members.',
+    subcategories: [
+      { name: 'Photos', count: 5 },
+      { name: 'Stories', count: 3 },
+    ],
+    topics: [
+      { name: 'Cute moments', count: 4 },
+      { name: 'Advice', count: 2 },
+    ],
+    subreddits: [
+      { name: 'r/cats', count: 10 },
+      { name: 'r/dogs', count: 8 },
+      { name: 'r/aww', count: 6 },
+    ],
+  },
+  th3: {
+    description: 'Posts where community members are seeking advice about pet care, training, health concerns, and general guidance from experienced pet owners.',
+    subcategories: [
+      { name: 'Health', count: 8 },
+      { name: 'Training', count: 5 },
+      { name: 'Nutrition', count: 3 },
+    ],
+    topics: [
+      { name: 'Vet visits', count: 6 },
+      { name: 'Behavior', count: 4 },
+      { name: 'Diet', count: 3 },
+    ],
+    subreddits: [
+      { name: 'r/DogAdvice', count: 12 },
+      { name: 'r/CatAdvice', count: 10 },
+      { name: 'r/AskVet', count: 8 },
+    ],
+  },
+  th4: {
+    description: 'Posts where community members express frustration, anger, or pain points related to pet ownership, including vet costs, behavioral issues, and difficult situations.',
+    subcategories: [
+      { name: 'Vet costs', count: 5 },
+      { name: 'Behavioral issues', count: 4 },
+      { name: 'Loss & grief', count: 3 },
+    ],
+    topics: [
+      { name: 'Expensive care', count: 4 },
+      { name: 'Problem behavior', count: 3 },
+      { name: 'Frustration', count: 2 },
+    ],
+    subreddits: [
+      { name: 'r/dogs', count: 8 },
+      { name: 'r/cats', count: 6 },
+      { name: 'r/Pets', count: 4 },
+    ],
+  },
+  th5: {
+    description: 'Posts where community members are looking for specific tools, products, or solutions to address pet-related challenges and improve their pets\' lives.',
+    subcategories: [
+      { name: 'Products', count: 6 },
+      { name: 'Tools', count: 4 },
+      { name: 'Services', count: 2 },
+    ],
+    topics: [
+      { name: 'Pet tech', count: 3 },
+      { name: 'Food brands', count: 3 },
+      { name: 'Toys', count: 2 },
+    ],
+    subreddits: [
+      { name: 'r/DogAdvice', count: 7 },
+      { name: 'r/CatAdvice', count: 5 },
+      { name: 'r/Aquariums', count: 4 },
+    ],
+  },
+  th6: {
+    description: 'Posts where community members share their own products, services, or content related to pets, including small businesses and content creators.',
+    subcategories: [
+      { name: 'Products', count: 3 },
+      { name: 'Services', count: 2 },
+    ],
+    topics: [
+      { name: 'Pet products', count: 2 },
+      { name: 'Art & crafts', count: 1 },
+    ],
+    subreddits: [
+      { name: 'r/Pets', count: 4 },
+      { name: 'r/dogs', count: 3 },
+    ],
+  },
+  th7: {
+    description: 'Posts where community members share creative ideas, suggestions for improvement, or innovative approaches to pet care and community engagement.',
+    subcategories: [
+      { name: 'Suggestions', count: 3 },
+      { name: 'Innovations', count: 2 },
+    ],
+    topics: [
+      { name: 'DIY projects', count: 2 },
+      { name: 'Community ideas', count: 1 },
+    ],
+    subreddits: [
+      { name: 'r/Aquariums', count: 3 },
+      { name: 'r/reptiles', count: 2 },
+    ],
+  },
+  th8: {
+    description: 'Conversations about current news, events, and trending topics in the pet world, including legislation, viral stories, and industry updates.',
+    subcategories: [
+      { name: 'Legislation', count: 2 },
+      { name: 'Viral stories', count: 1 },
+    ],
+    topics: [
+      { name: 'Pet laws', count: 2 },
+      { name: 'Viral pets', count: 1 },
+    ],
+    subreddits: [
+      { name: 'r/dogs', count: 3 },
+      { name: 'r/cats', count: 2 },
+    ],
+  },
+}
+
+// Topic data with descriptions for the detail panel
+const topicsData: (TopicTableItem & { description: string; subredditCounts: { name: string; postCount: number }[] })[] = [
+  { id: 'tp1', name: 'Health issues', growth: 400, frequency: 3.0, frequencyUnit: 'mo', subreddits: ['r/CatAdvice', 'r/DogAdvice'], description: 'Health issues in the context of Pet Lovers refer to any physical or mental conditions that may affect the well-being of their beloved animals, requiring attention and care to ensure their health and happiness.', subredditCounts: [{ name: 'r/DogAdvice', postCount: 15 }, { name: 'r/CatAdvice', postCount: 6 }] },
+  { id: 'tp2', name: 'Choice', growth: 300, frequency: 2.4, frequencyUnit: 'mo', subreddits: ['r/CatAdvice'], description: 'Discussions about making choices regarding pet ownership, including breed selection, adoption vs buying, and lifestyle considerations.', subredditCounts: [{ name: 'r/CatAdvice', postCount: 12 }] },
+  { id: 'tp3', name: 'Dog health', growth: 150, frequency: 1.5, frequencyUnit: 'mo', subreddits: ['r/dogs', 'r/DogAdvice'], description: 'Specific health concerns, preventive care, and medical advice related to dogs of all breeds and ages.', subredditCounts: [{ name: 'r/dogs', postCount: 18 }, { name: 'r/DogAdvice', postCount: 9 }] },
+  { id: 'tp4', name: 'Bird-species', growth: 133, frequency: 2.1, frequencyUnit: 'mo', subreddits: ['r/birding'], description: 'Identification and discussion of various bird species, their characteristics, habitats, and behaviors.', subredditCounts: [{ name: 'r/birding', postCount: 21 }] },
+  { id: 'tp5', name: 'Mistake', growth: 122, frequency: 1.4, frequencyUnit: 'week', subreddits: ['r/CatAdvice', 'r/puppy101'], description: 'Common mistakes made by pet owners and lessons learned from pet care experiences.', subredditCounts: [{ name: 'r/CatAdvice', postCount: 8 }, { name: 'r/puppy101', postCount: 11 }] },
+  { id: 'tp6', name: 'Frog', growth: 120, frequency: 1.3, frequencyUnit: 'day', subreddits: ['r/reptiles', 'r/herpetology'], description: 'Care guides, habitat setup, and discussions about keeping frogs as pets.', subredditCounts: [{ name: 'r/reptiles', postCount: 7 }, { name: 'r/herpetology', postCount: 5 }] },
+  { id: 'tp7', name: 'Bird species', growth: 120, frequency: 3.3, frequencyUnit: 'mo', subreddits: ['r/birding', 'r/Ornithology'], description: 'In-depth discussions about specific bird species, their behaviors, and care requirements.', subredditCounts: [{ name: 'r/birding', postCount: 14 }, { name: 'r/Ornithology', postCount: 8 }] },
+  { id: 'tp8', name: 'Annoying', growth: 107, frequency: 2.2, frequencyUnit: 'week', subreddits: ['r/cats', 'r/CatAdvice'], description: 'Discussions about dealing with annoying pet behaviors and how to address them effectively.', subredditCounts: [{ name: 'r/cats', postCount: 16 }, { name: 'r/CatAdvice', postCount: 9 }] },
+  { id: 'tp9', name: 'Bird behavior', growth: 100, frequency: 1.5, frequencyUnit: 'mo', subreddits: ['r/cockatiel', 'r/birding', 'r/parrots', 'r/budgies'], description: 'Understanding and interpreting bird behaviors, communication patterns, and social interactions.', subredditCounts: [{ name: 'r/cockatiel', postCount: 6 }, { name: 'r/birding', postCount: 4 }, { name: 'r/parrots', postCount: 8 }, { name: 'r/budgies', postCount: 5 }] },
+  { id: 'tp10', name: 'Mix', growth: 79, frequency: 3.5, frequencyUnit: 'day', subreddits: ['r/DOG', 'r/germanshepherds', 'r/labrador'], description: 'Discussions about mixed breed dogs, their characteristics, and care requirements.', subredditCounts: [{ name: 'r/DOG', postCount: 12 }, { name: 'r/germanshepherds', postCount: 7 }, { name: 'r/labrador', postCount: 9 }] },
+  { id: 'tp11', name: 'Rehoming', growth: 77, frequency: 1.4, frequencyUnit: 'day', subreddits: ['r/RATS', 'r/dogs', 'r/cats', 'r/parrots', 'r/rabbits', 'r/hamsters', 'r/guineapigs', 'r/ferrets'], description: 'Resources and advice for responsibly rehoming pets when necessary.', subredditCounts: [{ name: 'r/RATS', postCount: 3 }, { name: 'r/dogs', postCount: 5 }, { name: 'r/cats', postCount: 4 }, { name: 'r/parrots', postCount: 2 }, { name: 'r/rabbits', postCount: 2 }, { name: 'r/hamsters', postCount: 1 }] },
+  { id: 'tp12', name: 'Tank setup', growth: 75, frequency: 6.4, frequencyUnit: 'week', subreddits: ['r/leopardgeckos', 'r/Aquariums', 'r/bettafish'], description: 'Guides and discussions about setting up proper tanks and enclosures for aquatic pets and reptiles.', subredditCounts: [{ name: 'r/leopardgeckos', postCount: 11 }, { name: 'r/Aquariums', postCount: 18 }, { name: 'r/bettafish', postCount: 14 }] },
+]
+
+export function AudienceDetail() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const headerRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+  const [selectedTopic, setSelectedTopic] = useState<TopicDetail | null>(null)
+  const [selectedTheme, setSelectedTheme] = useState<ThemeDetail | null>(null)
+
+  const audience = audiences.find((a) => a.id === id)
+  const audienceDetails = audience
+    ? getAudienceDetails(audience.id, audience.name)
+    : null
+
+  useEffect(() => {
+    if (!headerRef.current || !contentRef.current || prefersReducedMotion) return
+
+    gsap.fromTo(
+      headerRef.current,
+      { opacity: 0, y: -20 },
+      { opacity: 1, y: 0, duration: 0.4, ease: 'power2.out' }
+    )
+
+    gsap.fromTo(
+      contentRef.current.children,
+      { opacity: 0, y: 20 },
+      {
+        opacity: 1,
+        y: 0,
+        duration: 0.4,
+        stagger: 0.1,
+        ease: 'power2.out',
+        delay: 0.2,
+      }
+    )
+  }, [prefersReducedMotion, id])
+
+  if (!audience || !audienceDetails) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <p className="text-gray-500 dark:text-zinc-400">Audience not found</p>
+        <Button onClick={() => navigate('/audiences')} variant="outline">
+          Back to Audiences
+        </Button>
+      </div>
+    )
+  }
+
+  const suggestedTags = ['Search Tips', 'health issues', 'choice', 'I hate', 'Looking for']
+
+  return (
+    <div className="space-y-6">
+      <div ref={headerRef}>
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => navigate('/audiences')}
+              className="cursor-pointer w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800 transition-colors"
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              {audience.name}
+            </h1>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm">
+              <Info className="w-4 h-4" />
+              Info
+            </Button>
+            <Button variant="outline" size="sm">
+              <Pencil className="w-4 h-4" />
+              Edit
+            </Button>
+            <Button variant="outline" size="sm">
+              <Share2 className="w-4 h-4" />
+              Share
+            </Button>
+            <Button variant="primary" size="sm">
+              <Plus className="w-4 h-4" />
+              Add
+            </Button>
+          </div>
+        </div>
+
+        <Tabs defaultValue="search" className="w-full">
+          <TabsList>
+            <TabsTrigger value="search">
+              <Search className="w-4 h-4" />
+              Search
+            </TabsTrigger>
+            <TabsTrigger value="subreddits" count={audienceDetails.subreddits.length}>
+              Subreddits
+            </TabsTrigger>
+            <TabsTrigger value="topics" count={200}>
+              Topics
+            </TabsTrigger>
+            <TabsTrigger value="themes">
+              <Sparkles className="w-4 h-4" />
+              Themes
+            </TabsTrigger>
+            <TabsTrigger value="ask">
+              <Sparkles className="w-4 h-4" />
+              Ask
+            </TabsTrigger>
+            <TabsTrigger value="products">
+              <Sparkles className="w-4 h-4" />
+              Products
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="search" className="mt-6">
+            <div className="space-y-6">
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-900 dark:text-white mb-2">
+                    Keyword Search
+                  </label>
+                  <Input
+                    icon
+                    placeholder="Keyword search in audience"
+                    className="max-w-2xl"
+                  />
+                </div>
+
+                <div className="flex items-center gap-2 flex-wrap">
+                  {suggestedTags.map((tag) => (
+                    <Badge
+                      key={tag}
+                      variant="neutral"
+                      size="md"
+                      className="cursor-pointer hover:bg-gray-200 dark:hover:bg-zinc-700"
+                    >
+                      {tag === 'Search Tips' ? (
+                        <Info className="w-3 h-3" />
+                      ) : (
+                        <span className="w-2 h-2 rounded-full bg-lime" />
+                      )}
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+
+              <div
+                ref={contentRef}
+                className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+              >
+                <div className="flex flex-col">
+                  <div className="flex items-center justify-between mb-3">
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-semibold text-gray-900 dark:text-white">
+                        Subreddits
+                      </h3>
+                      <span className="text-sm text-gray-500 dark:text-zinc-400">
+                        {audience.subredditCount}
+                      </span>
+                    </div>
+                    <button className="cursor-pointer flex items-center gap-1 text-sm text-gray-500 dark:text-zinc-400 hover:text-lime transition-colors">
+                      <Plus className="w-4 h-4" />
+                      Add
+                    </button>
+                  </div>
+                  <SubredditsList
+                    subreddits={audienceDetails.subreddits}
+                    totalCount={audience.subredditCount}
+                    showHeader={false}
+                  />
+                </div>
+                <div className="flex flex-col">
+                  <div className="flex items-center gap-2 mb-3">
+                    <h3 className="font-semibold text-gray-900 dark:text-white">
+                      Themes
+                    </h3>
+                    <span className="text-sm text-gray-500 dark:text-zinc-400">
+                      {audienceDetails.themes.length}
+                    </span>
+                  </div>
+                  <ThemesList
+                    themes={audienceDetails.themes}
+                    totalCount={audienceDetails.themes.length}
+                    showHeader={false}
+                  />
+                </div>
+                <div className="flex flex-col">
+                  <div className="flex items-center gap-2 mb-3">
+                    <h3 className="font-semibold text-gray-900 dark:text-white">
+                      Topics
+                    </h3>
+                    <span className="text-sm text-gray-500 dark:text-zinc-400">
+                      200
+                    </span>
+                  </div>
+                  <TopicsList
+                    topics={audienceDetails.topics}
+                    totalCount={200}
+                    showHeader={false}
+                  />
+                </div>
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="subreddits" className="mt-6">
+            <div className="space-y-8">
+              <div className="flex gap-6">
+                <SubredditsGrid
+                  subreddits={audienceDetails.subreddits}
+                  totalCount={audience.subredditCount}
+                />
+                <div className="w-[280px] shrink-0">
+                  <AboutAudiencePanel
+                    stats={{
+                      type: 'Curated Audience',
+                      totalMembers: 24_200_000,
+                      monthlyGrowth: 0.8,
+                    }}
+                    radarData={{
+                      age: 65,
+                      reach: 80,
+                      size: 90,
+                      activity: 75,
+                      growth: 60,
+                    }}
+                    audienceName={audience.name}
+                    comparisonName="r/parrots"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <h3 className="font-semibold text-gray-900 dark:text-white mb-4">
+                  Expand your audience with similar communities
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                  {[
+                    {
+                      id: 'sim1',
+                      name: 'r/Austin',
+                      members: 547_000,
+                      weeklyGrowth: 0.35,
+                      sizeCategory: 'Huge',
+                      activityLevel: 'Super Active',
+                      description: 'The place for all things Austin, TX.',
+                    },
+                    {
+                      id: 'sim2',
+                      name: 'r/AnimalLovers',
+                      members: 890_000,
+                      weeklyGrowth: 0.28,
+                      sizeCategory: 'Huge',
+                      activityLevel: 'Super Active',
+                      description: 'Share your love for all animals, from pets to wildlife.',
+                    },
+                    {
+                      id: 'sim3',
+                      name: 'r/PetPhotography',
+                      members: 245_000,
+                      weeklyGrowth: 0.42,
+                      sizeCategory: 'Large',
+                      activityLevel: 'Active',
+                      description: 'Showcase your best pet photography and get tips from others.',
+                    },
+                    {
+                      id: 'sim4',
+                      name: 'r/Pets',
+                      members: 1_200_000,
+                      weeklyGrowth: 0.18,
+                      sizeCategory: 'Massive',
+                      activityLevel: 'Super Active',
+                      description: 'A community for pet lovers to share stories, photos, and advice about their furry friends.',
+                    },
+                    {
+                      id: 'sim5',
+                      name: 'r/AnimalRescue',
+                      members: 320_000,
+                      weeklyGrowth: 0.55,
+                      sizeCategory: 'Large',
+                      activityLevel: 'High Activity',
+                      description: 'Dedicated to animal rescue stories, adoption resources, and volunteer opportunities.',
+                    },
+                    {
+                      id: 'sim6',
+                      name: 'r/VetTech',
+                      members: 178_000,
+                      weeklyGrowth: 0.31,
+                      sizeCategory: 'Medium',
+                      activityLevel: 'Active',
+                      description: 'A community for veterinary technicians to share experiences and knowledge.',
+                    },
+                    {
+                      id: 'sim7',
+                      name: 'r/WildlifePhotography',
+                      members: 560_000,
+                      weeklyGrowth: 0.22,
+                      sizeCategory: 'Huge',
+                      activityLevel: 'Super Active',
+                      description: 'Share and discuss wildlife photography from around the world.',
+                    },
+                    {
+                      id: 'sim8',
+                      name: 'r/PetBehavior',
+                      members: 89_000,
+                      weeklyGrowth: 0.67,
+                      sizeCategory: 'Medium',
+                      activityLevel: 'Active',
+                      description: 'Understanding and improving pet behavior through positive reinforcement.',
+                    },
+                    {
+                      id: 'sim9',
+                      name: 'r/ExoticPets',
+                      members: 412_000,
+                      weeklyGrowth: 0.38,
+                      sizeCategory: 'Large',
+                      activityLevel: 'High Activity',
+                      description: 'For owners and enthusiasts of exotic and unusual pets.',
+                    },
+                  ].map((subreddit) => (
+                    <div
+                      key={subreddit.id}
+                      className="bg-white dark:bg-zinc-900 rounded-2xl p-5"
+                    >
+                      <div className="flex items-start gap-4 mb-3">
+                        <div className="w-14 h-14 rounded-full bg-gray-200 dark:bg-zinc-700 flex items-center justify-center text-lg font-medium text-gray-600 dark:text-zinc-300 shrink-0">
+                          {subreddit.name.charAt(2).toUpperCase()}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <h4 className="font-bold text-gray-900 dark:text-white text-base">
+                            {subreddit.name}
+                          </h4>
+                          <div className="flex items-center gap-2 text-sm">
+                            <span className="text-gray-500 dark:text-zinc-400">
+                              {subreddit.members >= 1_000_000
+                                ? `${(subreddit.members / 1_000_000).toFixed(1)}M`
+                                : `${Math.round(subreddit.members / 1_000)}k`}{' '}
+                              members
+                            </span>
+                            <span className="flex items-center gap-1 text-success-light">
+                              <TrendingUp className="w-3 h-3" />
+                              {subreddit.weeklyGrowth}% / week
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-3 mb-4">
+                        <span className="text-sm text-gray-600 dark:text-zinc-300 border-b border-dashed border-gray-400 dark:border-zinc-500">
+                          {subreddit.sizeCategory}
+                        </span>
+                        <span className="text-sm text-gray-600 dark:text-zinc-300 border-b border-dashed border-gray-400 dark:border-zinc-500">
+                          {subreddit.activityLevel}
+                        </span>
+                      </div>
+
+                      <div className="mb-4">
+                        <p className="text-[10px] font-medium text-gray-500 dark:text-zinc-500 uppercase tracking-wide mb-1">
+                          Description
+                        </p>
+                        <p className="text-sm text-gray-700 dark:text-zinc-300">
+                          {subreddit.description}
+                        </p>
+                      </div>
+
+                      <div className="flex gap-3">
+                        <button className="cursor-pointer flex-1 py-2.5 text-sm font-medium text-zinc-900 bg-cyan-400 hover:bg-cyan-500 rounded-lg transition-colors">
+                          Add to Audience
+                        </button>
+                        <button className="cursor-pointer flex-1 py-2.5 text-sm font-medium text-gray-300 dark:text-zinc-400 bg-gray-700 dark:bg-zinc-700 hover:bg-gray-600 dark:hover:bg-zinc-600 rounded-lg transition-colors">
+                          Not Relevant
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="topics" className="mt-6">
+            <div className="flex gap-6">
+              <TopicsTable
+                topics={topicsData}
+                totalCount={200}
+                selectedTopicId={selectedTopic?.id}
+                onTopicSelect={(topic) => {
+                  const fullTopic = topicsData.find((t) => t.id === topic.id)
+                  if (fullTopic) {
+                    setSelectedTopic({
+                      id: fullTopic.id,
+                      name: fullTopic.name,
+                      frequency: fullTopic.frequency,
+                      frequencyUnit: fullTopic.frequencyUnit,
+                      growth: fullTopic.growth,
+                      description: fullTopic.description,
+                      subreddits: fullTopic.subredditCounts,
+                    })
+                  }
+                }}
+              />
+              <div className="w-1/3 shrink-0">
+                <TopicDetailPanel topic={selectedTopic} />
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="themes" className="mt-6">
+            <div className="flex gap-6">
+              <div className="flex-1">
+                <ThemesGrid
+                  themes={themesGridData}
+                  selectedThemeId={selectedTheme?.id}
+                  onThemeSelect={(theme) => {
+                    const detailData = themesDetailData[theme.id]
+                    if (detailData) {
+                      setSelectedTheme({
+                        id: theme.id,
+                        name: theme.name,
+                        ...detailData,
+                      })
+                    }
+                  }}
+                />
+              </div>
+              <div className="w-1/2 shrink-0">
+                <ThemeDetailPanel theme={selectedTheme} />
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="ask" className="mt-6">
+            <div className="bg-white dark:bg-zinc-900 rounded-2xl p-6 text-center">
+              <Sparkles className="w-8 h-8 text-lime mx-auto mb-3" />
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-2">
+                Ask AI
+              </h3>
+              <p className="text-sm text-gray-500 dark:text-zinc-400">
+                Coming soon - Ask questions about this audience
+              </p>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="products" className="mt-6">
+            <div className="bg-white dark:bg-zinc-900 rounded-2xl p-6 text-center">
+              <Sparkles className="w-8 h-8 text-lime mx-auto mb-3" />
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-2">
+                Products
+              </h3>
+              <p className="text-sm text-gray-500 dark:text-zinc-400">
+                Coming soon - Discover products relevant to this audience
+              </p>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  )
+}
+
+export default AudienceDetail

--- a/src/pages/Audiences.tsx
+++ b/src/pages/Audiences.tsx
@@ -3,6 +3,7 @@ import { Search, LayoutGrid, List } from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { useReducedMotion } from '@/hooks'
 import { AudienceCard, AddAudienceCard } from '@/components/audiences'
+import { SelectAudienceModal } from '@/components/shared'
 import { audiences } from '@/data/audiences'
 
 type SortOption = 'growth' | 'members' | 'subreddits' | 'name'
@@ -14,6 +15,7 @@ export function Audiences() {
   const [searchQuery, setSearchQuery] = useState('')
   const [sortBy, setSortBy] = useState<SortOption>('growth')
   const [viewMode, setViewMode] = useState<ViewMode>('grid')
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   const filteredAudiences = audiences
     .filter((audience) =>
@@ -152,7 +154,7 @@ export function Audiences() {
             onShareClick={handleShareClick}
           />
         ))}
-        <AddAudienceCard onClick={() => console.log('Add new audience clicked')} />
+        <AddAudienceCard onClick={() => setIsModalOpen(true)} />
       </div>
 
       {filteredAudiences.length === 0 && (
@@ -162,6 +164,16 @@ export function Audiences() {
           </p>
         </div>
       )}
+
+      <SelectAudienceModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        audiences={audiences}
+        onCreateAudience={(name, selectedAudiences) => {
+          console.log('Creating audience:', name, selectedAudiences)
+          setIsModalOpen(false)
+        }}
+      />
     </div>
   )
 }

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,6 +4,7 @@ import { MainLayout } from '@/components/layout'
 
 const Dashboard = lazy(() => import('@/pages/Dashboard'))
 const Audiences = lazy(() => import('@/pages/Audiences'))
+const AudienceDetail = lazy(() => import('@/pages/AudienceDetail'))
 const Placeholder = lazy(() => import('@/pages/Placeholder'))
 const NotFound = lazy(() => import('@/pages/NotFound'))
 
@@ -41,6 +42,14 @@ const router = createBrowserRouter([
         element: (
           <Suspense fallback={<PageLoader />}>
             <Audiences />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'audiences/:id',
+        element: (
+          <Suspense fallback={<PageLoader />}>
+            <AudienceDetail />
           </Suspense>
         ),
       },


### PR DESCRIPTION
- Add AudienceDetail page with Overview, Topics, Themes tabs
- Create detail components: SubredditsGrid, TopicsTable, ThemesGrid
- Add detail panels for topics and themes with GSAP animations
- Include AboutAudiencePanel with stats and radar chart
- Create tabs UI component with animated selection indicator
- Update AudienceCard to navigate to detail page
- Add routing for /audiences/:id