### PR TITLE
feat: integrate audience templates with API

### DIFF
--- a/src/modules/audience/application/hooks/index.ts
+++ b/src/modules/audience/application/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useListGenericAudiences, AUDIENCES_QUERY_KEY } from './useListGenericAudiences'
 export { useFetchDefaultAudiences, DEFAULT_AUDIENCES_QUERY_KEY } from './useFetchDefaultAudiences'
+export { useGetAudienceTemplateById, AUDIENCE_TEMPLATE_QUERY_KEY } from './useGetAudienceTemplateById'

--- a/src/modules/audience/application/hooks/useGetAudienceTemplateById.ts
+++ b/src/modules/audience/application/hooks/useGetAudienceTemplateById.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IGetAudienceTemplateByIdUseCase } from '@/modules/audience/domain/use-cases'
+
+const getAudienceTemplateByIdUseCase = container.get<IGetAudienceTemplateByIdUseCase>(
+  TYPES.GetAudienceTemplateByIdUseCase
+)
+
+export const AUDIENCE_TEMPLATE_QUERY_KEY = (id: string) => ['audience-template', id] as const
+
+export function useGetAudienceTemplateById(id: string) {
+  return useQuery({
+    queryKey: AUDIENCE_TEMPLATE_QUERY_KEY(id),
+    queryFn: () => getAudienceTemplateByIdUseCase.execute(id),
+    enabled: !!id,
+  })
+}

--- a/src/modules/audience/application/use-cases/get-audience-template-by-id-use-case/index.ts
+++ b/src/modules/audience/application/use-cases/get-audience-template-by-id-use-case/index.ts
@@ -1,0 +1,11 @@
+import type { AudienceTemplate } from '@/modules/audience/domain/entities/AudienceTemplate.entity'
+import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
+import type { IGetAudienceTemplateByIdUseCase } from '@/modules/audience/domain/use-cases'
+
+export class GetAudienceTemplateByIdUseCase implements IGetAudienceTemplateByIdUseCase {
+  constructor(private readonly audienceRepository: IAudienceRepository) {}
+
+  async execute(id: string): Promise<AudienceTemplate | null> {
+    return this.audienceRepository.getAudienceTemplateById(id)
+  }
+}

--- a/src/modules/audience/application/use-cases/index.ts
+++ b/src/modules/audience/application/use-cases/index.ts
@@ -1,2 +1,3 @@
 export { ListGenericAudiencesUseCases } from './list-generic-audiences-use-cases'
 export { FetchDefaultAudiencesUseCase } from './fetch-default-audiences-use-case'
+export { GetAudienceTemplateByIdUseCase } from './get-audience-template-by-id-use-case'

--- a/src/modules/audience/domain/entities/AudienceTemplate.entity.ts
+++ b/src/modules/audience/domain/entities/AudienceTemplate.entity.ts
@@ -1,3 +1,12 @@
+export interface CommunityData {
+  name: string
+  title: string
+  subscribers: number
+  icon_url: string
+  growth_week: number | null
+  growth_month: number | null
+}
+
 interface AudienceTemplateProps {
   id: string
   name: string
@@ -6,7 +15,7 @@ interface AudienceTemplateProps {
   icon: string
   category: string
   display_order: number
-  communities: string[]
+  communities: CommunityData[] | string[]
   communities_count: number
 }
 
@@ -18,7 +27,7 @@ export class AudienceTemplate {
   private readonly icon: string
   private readonly category: string
   private readonly displayOrder: number
-  private readonly communities: string[]
+  private readonly communities: CommunityData[]
   private readonly communitiesCount: number
 
   constructor({
@@ -39,8 +48,26 @@ export class AudienceTemplate {
     this.icon = icon
     this.category = category
     this.displayOrder = display_order
-    this.communities = communities
+    this.communities = this.normalizeCommunities(communities)
     this.communitiesCount = communities_count
+  }
+
+  private normalizeCommunities(communities: CommunityData[] | string[]): CommunityData[] {
+    if (communities.length === 0) return []
+
+    // Check if first element is a string (old format) or object (new format)
+    if (typeof communities[0] === 'string') {
+      return (communities as string[]).map((name) => ({
+        name,
+        title: name,
+        subscribers: 0,
+        icon_url: '',
+        growth_week: null,
+        growth_month: null,
+      }))
+    }
+
+    return communities as CommunityData[]
   }
 
   getId(): string {
@@ -71,7 +98,7 @@ export class AudienceTemplate {
     return this.displayOrder
   }
 
-  getCommunities(): string[] {
+  getCommunities(): CommunityData[] {
     return this.communities
   }
 

--- a/src/modules/audience/domain/repositories/audience.repository.ts
+++ b/src/modules/audience/domain/repositories/audience.repository.ts
@@ -5,4 +5,5 @@ export interface IAudienceRepository {
   listGenericAudiences(): Promise<Audience[]>
   getAudienceById(id: string): Promise<Audience | null>
   fetchDefaultAudiences(): Promise<AudienceTemplate[]>
+  getAudienceTemplateById(id: string): Promise<AudienceTemplate | null>
 }

--- a/src/modules/audience/domain/use-cases/get-audience-template-by-id.use-case.ts
+++ b/src/modules/audience/domain/use-cases/get-audience-template-by-id.use-case.ts
@@ -1,0 +1,5 @@
+import type { AudienceTemplate } from '../entities/AudienceTemplate.entity'
+
+export interface IGetAudienceTemplateByIdUseCase {
+  execute(id: string): Promise<AudienceTemplate | null>
+}

--- a/src/modules/audience/domain/use-cases/index.ts
+++ b/src/modules/audience/domain/use-cases/index.ts
@@ -1,2 +1,3 @@
 export type { IListGenericAudiencesUseCase } from './list-generic-audiences.use-case'
 export type { IFetchDefaultAudiencesUseCase } from './fetch-default-audiences.use-case'
+export type { IGetAudienceTemplateByIdUseCase } from './get-audience-template-by-id.use-case'

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -74,4 +74,13 @@ export class AudienceRepository implements IAudienceRepository {
       return null
     }
   }
+
+  async getAudienceTemplateById(id: string): Promise<AudienceTemplate | null> {
+    try {
+      const response = await this.httpClient.get<AudienceTemplateResponse>(`audience-templates/${id}`)
+      return new AudienceTemplate(response)
+    } catch {
+      return null
+    }
+  }
 }

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -3,8 +3,8 @@ import { TYPES } from './types'
 import { KyHttpClient, type HttpClient } from '../http'
 import { AudienceRepository } from '@/modules/audience/infra/repositories'
 import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
-import { ListGenericAudiencesUseCases, FetchDefaultAudiencesUseCase } from '@/modules/audience/application/use-cases'
-import type { IListGenericAudiencesUseCase, IFetchDefaultAudiencesUseCase } from '@/modules/audience/domain/use-cases'
+import { ListGenericAudiencesUseCases, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase } from '@/modules/audience/application/use-cases'
+import type { IListGenericAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase } from '@/modules/audience/domain/use-cases'
 
 const container = new Container()
 
@@ -23,6 +23,11 @@ container.bind<IListGenericAudiencesUseCase>(TYPES.ListGenericAudiencesUseCase).
 container.bind<IFetchDefaultAudiencesUseCase>(TYPES.FetchDefaultAudiencesUseCase).toDynamicValue(() => {
   const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
   return new FetchDefaultAudiencesUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<IGetAudienceTemplateByIdUseCase>(TYPES.GetAudienceTemplateByIdUseCase).toDynamicValue(() => {
+  const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
+  return new GetAudienceTemplateByIdUseCase(audienceRepository)
 }).inSingletonScope()
 
 export { container }

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -3,4 +3,5 @@ export const TYPES = {
   AudienceRepository: Symbol.for('AudienceRepository'),
   ListGenericAudiencesUseCase: Symbol.for('ListGenericAudiencesUseCase'),
   FetchDefaultAudiencesUseCase: Symbol.for('FetchDefaultAudiencesUseCase'),
+  GetAudienceTemplateByIdUseCase: Symbol.for('GetAudienceTemplateByIdUseCase'),
 } as const

--- a/src/pages/AudienceDetail.tsx
+++ b/src/pages/AudienceDetail.tsx
@@ -27,9 +27,13 @@ import {
   ThemesGrid,
   ThemeDetailPanel,
 } from '@/components/audiences/detail'
-import type { TopicTableItem, TopicDetail, ThemeGridItem, ThemeDetail } from '@/components/audiences/detail'
-import { audiences } from '@/data/audiences'
-import { getAudienceDetails } from '@/data/audienceDetails'
+import type {
+  TopicTableItem,
+  TopicDetail,
+  ThemeGridItem,
+  ThemeDetail,
+} from '@/components/audiences/detail'
+import { useGetAudienceTemplateById } from '@/modules/audience/application/hooks'
 
 // Theme data for the themes tab
 const themesGridData: ThemeGridItem[] = [
@@ -223,10 +227,7 @@ export function AudienceDetail() {
   const [selectedTopic, setSelectedTopic] = useState<TopicDetail | null>(null)
   const [selectedTheme, setSelectedTheme] = useState<ThemeDetail | null>(null)
 
-  const audience = audiences.find((a) => a.id === id)
-  const audienceDetails = audience
-    ? getAudienceDetails(audience.id, audience.name)
-    : null
+  const { data: audienceTemplate, isLoading, error } = useGetAudienceTemplateById(id ?? '')
 
   useEffect(() => {
     if (!headerRef.current || !contentRef.current || prefersReducedMotion) return
@@ -251,7 +252,15 @@ export function AudienceDetail() {
     )
   }, [prefersReducedMotion, id])
 
-  if (!audience || !audienceDetails) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="w-8 h-8 border-4 border-lime border-t-transparent rounded-full animate-spin" />
+      </div>
+    )
+  }
+
+  if (error || !audienceTemplate) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
         <p className="text-gray-500 dark:text-zinc-400">Audience not found</p>
@@ -261,6 +270,14 @@ export function AudienceDetail() {
       </div>
     )
   }
+
+  const communities = audienceTemplate.getCommunities()
+  const subredditsData = communities.map((community, index) => ({
+    id: `${audienceTemplate.getId()}-${index}`,
+    name: `r/${community.name}`,
+    members: community.subscribers,
+    monthlyGrowth: community.growth_month ?? 0,
+  }))
 
   const suggestedTags = ['Search Tips', 'health issues', 'choice', 'I hate', 'Looking for']
 
@@ -276,7 +293,7 @@ export function AudienceDetail() {
               <ChevronLeft className="w-5 h-5" />
             </button>
             <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
-              {audience.name}
+              {audienceTemplate.getName()}
             </h1>
           </div>
 
@@ -306,7 +323,7 @@ export function AudienceDetail() {
               <Search className="w-4 h-4" />
               Search
             </TabsTrigger>
-            <TabsTrigger value="subreddits" count={audienceDetails.subreddits.length}>
+            <TabsTrigger value="subreddits" count={audienceTemplate.getCommunitiesCount()}>
               Subreddits
             </TabsTrigger>
             <TabsTrigger value="topics" count={200}>
@@ -370,7 +387,7 @@ export function AudienceDetail() {
                         Subreddits
                       </h3>
                       <span className="text-sm text-gray-500 dark:text-zinc-400">
-                        {audience.subredditCount}
+                        {audienceTemplate.getCommunitiesCount()}
                       </span>
                     </div>
                     <button className="cursor-pointer flex items-center gap-1 text-sm text-gray-500 dark:text-zinc-400 hover:text-lime transition-colors">
@@ -379,8 +396,8 @@ export function AudienceDetail() {
                     </button>
                   </div>
                   <SubredditsList
-                    subreddits={audienceDetails.subreddits}
-                    totalCount={audience.subredditCount}
+                    subreddits={subredditsData}
+                    totalCount={audienceTemplate.getCommunitiesCount()}
                     showHeader={false}
                   />
                 </div>
@@ -390,12 +407,12 @@ export function AudienceDetail() {
                       Themes
                     </h3>
                     <span className="text-sm text-gray-500 dark:text-zinc-400">
-                      {audienceDetails.themes.length}
+                      0
                     </span>
                   </div>
                   <ThemesList
-                    themes={audienceDetails.themes}
-                    totalCount={audienceDetails.themes.length}
+                    themes={[]}
+                    totalCount={0}
                     showHeader={false}
                   />
                 </div>
@@ -409,8 +426,8 @@ export function AudienceDetail() {
                     </span>
                   </div>
                   <TopicsList
-                    topics={audienceDetails.topics}
-                    totalCount={200}
+                    topics={[]}
+                    totalCount={0}
                     showHeader={false}
                   />
                 </div>
@@ -422,8 +439,8 @@ export function AudienceDetail() {
             <div className="space-y-8">
               <div className="flex gap-6">
                 <SubredditsGrid
-                  subreddits={audienceDetails.subreddits}
-                  totalCount={audience.subredditCount}
+                  subreddits={subredditsData}
+                  totalCount={audienceTemplate.getCommunitiesCount()}
                 />
                 <div className="w-[280px] shrink-0">
                   <AboutAudiencePanel
@@ -439,7 +456,7 @@ export function AudienceDetail() {
                       activity: 75,
                       growth: 60,
                     }}
-                    audienceName={audience.name}
+                    audienceName={audienceTemplate.getName()}
                     comparisonName="r/parrots"
                   />
                 </div>

--- a/src/pages/Audiences.tsx
+++ b/src/pages/Audiences.tsx
@@ -4,9 +4,8 @@ import { gsap } from '@/lib/gsap'
 import { useReducedMotion } from '@/hooks'
 import { AudienceCard, AddAudienceCard } from '@/components/audiences'
 import { SelectAudienceModal } from '@/components/shared'
-import { audiences } from '@/data/audiences'
 
-type SortOption = 'growth' | 'members' | 'subreddits' | 'name'
+type SortOption = 'subreddits' | 'name'
 type ViewMode = 'grid' | 'list'
 
 import { useFetchDefaultAudiences } from '@/modules/audience/application/hooks'
@@ -15,23 +14,23 @@ export function Audiences() {
   const gridRef = useRef<HTMLDivElement>(null)
   const prefersReducedMotion = useReducedMotion()
   const [searchQuery, setSearchQuery] = useState('')
-  const [sortBy, setSortBy] = useState<SortOption>('growth')
+  const [sortBy, setSortBy] = useState<SortOption>('name')
   const [viewMode, setViewMode] = useState<ViewMode>('grid')
   const [isModalOpen, setIsModalOpen] = useState(false)
 
-  const { data: templates, isLoading, error } = useFetchDefaultAudiences()
+  const { data: templates } = useFetchDefaultAudiences()
   
-  useEffect(() => {
-    if (templates) {
-      console.log(templates)
-    }
-    if (error) {
-      console.error(error)
-    }
-    if (isLoading) {
-      console.log('Loading...')
-    }
-  }, [templates, error, isLoading])
+  const audiences = (templates ?? []).map((template) => ({
+    id: template.getId(),
+    name: template.getName(),
+    subredditCount: template.getCommunitiesCount(),
+    totalMembers: template.getCommunities().reduce((sum, c) => sum + c.subscribers, 0),
+    weeklyGrowth: 0,
+    subreddits: template.getCommunities().map((community, index) => ({
+      id: `${template.getId()}-${index}`,
+      name: `r/${community.name}`,
+    })),
+  }))
 
   const filteredAudiences = audiences
     .filter((audience) =>
@@ -39,10 +38,6 @@ export function Audiences() {
     )
     .sort((a, b) => {
       switch (sortBy) {
-        case 'growth':
-          return b.weeklyGrowth - a.weeklyGrowth
-        case 'members':
-          return b.totalMembers - a.totalMembers
         case 'subreddits':
           return b.subredditCount - a.subredditCount
         case 'name':
@@ -85,7 +80,7 @@ export function Audiences() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div className="flex items-center gap-2">
           <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-            Your Saved Audiences
+            Find Audiences
           </h2>
           <span className="text-lg text-gray-500 dark:text-zinc-400">
             {filteredAudiences.length}
@@ -100,10 +95,8 @@ export function Audiences() {
               onChange={(e) => setSortBy(e.target.value as SortOption)}
               className="bg-transparent border-none text-gray-900 dark:text-white font-medium cursor-pointer focus:ring-0 focus:outline-none"
             >
-              <option value="growth">Growth</option>
-              <option value="members">Members</option>
-              <option value="subreddits">Subreddits</option>
               <option value="name">Name</option>
+              <option value="subreddits">Subreddits</option>
             </select>
           </div>
 


### PR DESCRIPTION
- Add GetAudienceTemplateById use case for fetching single template
- Update AudienceTemplate entity to support new community data structure
- Add useGetAudienceTemplateById hook with React Query
- Update Audiences page to use API data instead of mocked data
- Update AudienceDetail page to fetch template by ID from API
- Add loading and error states to AudienceDetail
- Register new use case in dependency injection container