### PR TITLE
feat: integrate community browse API into SelectAudienceModal

### DIFF
--- a/src/components/shared/Modal.tsx
+++ b/src/components/shared/Modal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { cn } from '@/lib/utils'
@@ -84,11 +85,11 @@ export function Modal({
 
   if (!isOpen) return null
 
-  return (
+  return createPortal(
     <div
       ref={overlayRef}
       onClick={handleOverlayClick}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      className="fixed inset-0 z-60 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
     >
       <div
         ref={contentRef}
@@ -120,6 +121,7 @@ export function Modal({
           {children}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/src/components/shared/SelectAudienceModal.tsx
+++ b/src/components/shared/SelectAudienceModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { Users, TrendingUp, Waypoints, Copy } from 'lucide-react'
+import { Users, TrendingUp, Globe, Loader2 } from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { cn } from '@/lib/utils'
 import { useReducedMotion } from '@/hooks'
@@ -7,27 +7,13 @@ import { Modal } from './Modal'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Avatar } from '@/components/ui/avatar'
-
-export interface Subreddit {
-  id: string
-  name: string
-  icon?: string
-}
-
-export interface Audience {
-  id: string
-  name: string
-  subredditCount: number
-  totalMembers: number
-  weeklyGrowth: number
-  subreddits: readonly Subreddit[]
-}
+import { useBrowseCommunities } from '@/modules/community/application/hooks'
+import type { Community } from '@/modules/community/domain/entities/Community.entity'
 
 export interface SelectAudienceModalProps {
   isOpen: boolean
   onClose: () => void
-  audiences: readonly Audience[]
-  onCreateAudience: (name: string, selectedAudiences: string[]) => void
+  onCreateAudience: (name: string, selectedCommunityNames: string[]) => void
   isLoading?: boolean
 }
 
@@ -41,24 +27,21 @@ function formatNumber(num: number): string {
   return num.toString()
 }
 
-interface AudienceSelectCardProps {
-  audience: Audience
+interface CommunitySelectCardProps {
+  community: Community
   isSelected: boolean
-  onToggle: (id: string) => void
+  onToggle: (name: string) => void
   index: number
 }
 
-function AudienceSelectCard({
-  audience,
+function CommunitySelectCard({
+  community,
   isSelected,
   onToggle,
   index,
-}: Readonly<AudienceSelectCardProps>) {
+}: Readonly<CommunitySelectCardProps>) {
   const cardRef = useRef<HTMLDivElement>(null)
   const prefersReducedMotion = useReducedMotion()
-
-  const displayedSubreddits = audience.subreddits.slice(0, 5)
-  const remainingCount = audience.subreddits.length - displayedSubreddits.length
 
   useEffect(() => {
     if (!cardRef.current || prefersReducedMotion) return
@@ -97,7 +80,7 @@ function AudienceSelectCard({
   return (
     <div
       ref={cardRef}
-      onClick={() => onToggle(audience.id)}
+      onClick={() => onToggle(community.getName())}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       className={cn(
@@ -108,55 +91,46 @@ function AudienceSelectCard({
           : 'border-transparent hover:border-gray-200 dark:hover:border-zinc-700'
       )}
     >
-      <div className="flex items-start justify-between mb-3">
-        <h4 className="font-bold text-gray-900 dark:text-white">
-          {audience.name}
-        </h4>
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-          }}
-          className="cursor-pointer w-7 h-7 rounded-md flex items-center justify-center text-gray-400 hover:text-lime hover:bg-lime/10 transition-colors duration-200"
-          title="Copy"
-        >
-          <Copy className="w-4 h-4" />
-        </button>
+      <div className="flex items-start gap-3 mb-3">
+        <Avatar
+          src={community.getIconUrl()}
+          alt={community.getTitle()}
+          fallback={community.getTitle().charAt(0)}
+          size="sm"
+          className="w-8 h-8"
+        />
+        <div className="flex-1 min-w-0">
+          <h4 className="font-bold text-gray-900 dark:text-white truncate">
+            {community.getTitle()}
+          </h4>
+          {community.getCategory() && (
+            <span className="text-xs text-gray-400 dark:text-zinc-500">
+              {community.getCategory()}
+            </span>
+          )}
+        </div>
       </div>
 
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-zinc-400 mb-3">
-        <div className="flex items-center gap-1">
-          <Waypoints className="w-3.5 h-3.5" />
-          <span>{audience.subredditCount} Subs</span>
-        </div>
+      <p className="text-xs text-gray-500 dark:text-zinc-400 mb-3 line-clamp-2">
+        {community.getDescription()}
+      </p>
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-zinc-400">
         <div className="flex items-center gap-1">
           <Users className="w-3.5 h-3.5" />
-          <span>{formatNumber(audience.totalMembers)} Users</span>
+          <span>{formatNumber(community.getSubscribers())} members</span>
         </div>
-        <div
-          className={cn(
-            'flex items-center gap-1',
-            audience.weeklyGrowth >= 0 ? 'text-success-light' : 'text-error-light'
-          )}
-        >
-          <TrendingUp className="w-3.5 h-3.5" />
-          <span>{audience.weeklyGrowth.toFixed(2)}%/mo</span>
-        </div>
-      </div>
-
-      <div className="flex items-center -space-x-1.5">
-        {displayedSubreddits.map((subreddit) => (
-          <Avatar
-            key={subreddit.id}
-            src={subreddit.icon}
-            alt={subreddit.name}
-            fallback={subreddit.name.charAt(0)}
-            size="sm"
-            className="border-2 border-gray-50 dark:border-zinc-800 w-7 h-7"
-          />
-        ))}
-        {remainingCount > 0 && (
-          <div className="w-7 h-7 rounded-full bg-gray-200 dark:bg-zinc-700 flex items-center justify-center text-[10px] font-medium text-gray-600 dark:text-zinc-400 border-2 border-gray-50 dark:border-zinc-800">
-            +{remainingCount}
+        {community.getGrowthWeek() !== null && (
+          <div
+            className={cn(
+              'flex items-center gap-1',
+              community.getGrowthWeek()! >= 0
+                ? 'text-success-light'
+                : 'text-error-light'
+            )}
+          >
+            <TrendingUp className="w-3.5 h-3.5" />
+            <span>{community.getGrowthWeek()!.toFixed(2)}%/wk</span>
           </div>
         )}
       </div>
@@ -167,44 +141,55 @@ function AudienceSelectCard({
 export function SelectAudienceModal({
   isOpen,
   onClose,
-  audiences,
   onCreateAudience,
   isLoading = false,
 }: Readonly<SelectAudienceModalProps>) {
   const [audienceName, setAudienceName] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
-  const [selectedAudiences, setSelectedAudiences] = useState<string[]>([])
+  const [selectedCommunities, setSelectedCommunities] = useState<string[]>([])
 
-  useEffect(() => {
-    if (!isOpen) {
-      setAudienceName('')
-      setSearchQuery('')
-      setSelectedAudiences([])
-    }
-  }, [isOpen])
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isLoadingCommunities,
+  } = useBrowseCommunities()
 
-  const filteredAudiences = audiences.filter((audience) =>
-    audience.name.toLowerCase().includes(searchQuery.toLowerCase())
+  const allCommunities = data?.pages.flatMap((page) => page.communities) ?? []
+
+  const filteredCommunities = allCommunities.filter(
+    (community) =>
+      community.getTitle().toLowerCase().includes(searchQuery.toLowerCase()) ||
+      community.getName().toLowerCase().includes(searchQuery.toLowerCase()) ||
+      community.getCategory().toLowerCase().includes(searchQuery.toLowerCase())
   )
 
-  const handleToggleAudience = (id: string) => {
-    setSelectedAudiences((prev) =>
-      prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id]
+  const handleClose = () => {
+    setAudienceName('')
+    setSearchQuery('')
+    setSelectedCommunities([])
+    onClose()
+  }
+
+  const handleToggleCommunity = (name: string) => {
+    setSelectedCommunities((prev) =>
+      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]
     )
   }
 
   const handleSubmit = () => {
     if (audienceName.trim()) {
-      onCreateAudience(audienceName.trim(), selectedAudiences)
+      onCreateAudience(audienceName.trim(), selectedCommunities)
     }
   }
 
   return (
     <Modal
       isOpen={isOpen}
-      onClose={onClose}
-      title="New Audience - Select Subreddits"
-      icon={<Users className="w-5 h-5" />}
+      onClose={handleClose}
+      title="New Audience - Select Communities"
+      icon={<Globe className="w-5 h-5" />}
       size="xl"
     >
       <div className="p-6">
@@ -221,11 +206,11 @@ export function SelectAudienceModal({
             />
             <Button
               onClick={handleSubmit}
-              disabled={isLoading}
+              disabled={isLoading || selectedCommunities.length === 0}
               variant="primary"
               size="md"
             >
-              {isLoading ? 'Creating...' : 'Find Communities'}
+              {isLoading ? 'Creating...' : 'Create Audience'}
             </Button>
           </div>
         </div>
@@ -233,46 +218,65 @@ export function SelectAudienceModal({
         <div className="mb-4">
           <div className="flex items-center justify-between mb-3">
             <p className="text-xs font-semibold text-gray-500 dark:text-zinc-400 uppercase tracking-wide">
-              No audience in mind? Explore a curated one, or browse{' '}
-              <button className="text-lime hover:underline cursor-pointer uppercase">
-                Trending Subreddits
-              </button>
-              .
+              Browse and select communities for your audience
             </p>
             <Input
               icon
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              placeholder="Search audiences..."
+              placeholder="Search communities..."
               className="w-64"
             />
           </div>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-h-[400px] overflow-y-auto pr-2">
-          {filteredAudiences.map((audience, index) => (
-            <AudienceSelectCard
-              key={audience.id}
-              audience={audience}
-              isSelected={selectedAudiences.includes(audience.id)}
-              onToggle={handleToggleAudience}
-              index={index}
-            />
-          ))}
-          {filteredAudiences.length === 0 && (
-            <div className="col-span-full text-center py-12 text-gray-500 dark:text-zinc-400">
-              No audiences found matching "{searchQuery}"
+          {isLoadingCommunities ? (
+            <div className="col-span-full flex justify-center py-12">
+              <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
             </div>
+          ) : (
+            <>
+              {filteredCommunities.map((community, index) => (
+                <CommunitySelectCard
+                  key={community.getName()}
+                  community={community}
+                  isSelected={selectedCommunities.includes(
+                    community.getName()
+                  )}
+                  onToggle={handleToggleCommunity}
+                  index={index}
+                />
+              ))}
+              {filteredCommunities.length === 0 && (
+                <div className="col-span-full text-center py-12 text-gray-500 dark:text-zinc-400">
+                  No communities found matching "{searchQuery}"
+                </div>
+              )}
+            </>
           )}
         </div>
 
-        {selectedAudiences.length > 0 && (
+        {hasNextPage && !searchQuery && (
+          <div className="mt-4 flex justify-center">
+            <Button
+              onClick={() => fetchNextPage()}
+              disabled={isFetchingNextPage}
+              variant="outline"
+              size="sm"
+            >
+              {isFetchingNextPage ? 'Loading...' : 'Load More Communities'}
+            </Button>
+          </div>
+        )}
+
+        {selectedCommunities.length > 0 && (
           <div className="mt-4 pt-4 border-t border-gray-200 dark:border-zinc-800">
             <p className="text-sm text-gray-600 dark:text-zinc-400">
               <span className="font-semibold text-lime">
-                {selectedAudiences.length}
+                {selectedCommunities.length}
               </span>{' '}
-              audience{selectedAudiences.length !== 1 ? 's' : ''} selected
+              communit{selectedCommunities.length !== 1 ? 'ies' : 'y'} selected
             </p>
           </div>
         )}

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -2,8 +2,4 @@ export { Modal } from './Modal'
 export type { ModalProps } from './Modal'
 
 export { SelectAudienceModal } from './SelectAudienceModal'
-export type {
-  SelectAudienceModalProps,
-  Audience,
-  Subreddit,
-} from './SelectAudienceModal'
+export type { SelectAudienceModalProps } from './SelectAudienceModal'

--- a/src/modules/audience/application/hooks/useFetchDefaultAudiences.ts
+++ b/src/modules/audience/application/hooks/useFetchDefaultAudiences.ts
@@ -1,13 +1,14 @@
 import { useQuery } from '@tanstack/react-query'
 import { container, TYPES } from '@/modules/shared'
 import type { IFetchDefaultAudiencesUseCase } from '@/modules/audience/domain/use-cases'
+import type { AudienceTemplate } from '../../domain/entities/AudienceTemplate.entity'
 
 const fetchDefaultAudiencesUseCase = container.get<IFetchDefaultAudiencesUseCase>(TYPES.FetchDefaultAudiencesUseCase)
 
 export const DEFAULT_AUDIENCES_QUERY_KEY = ['default-audiences'] as const
 
 export function useFetchDefaultAudiences() {
-  return useQuery({
+  return useQuery<AudienceTemplate[], Error>({
     queryKey: DEFAULT_AUDIENCES_QUERY_KEY,
     queryFn: () => fetchDefaultAudiencesUseCase.execute(),
   })

--- a/src/modules/audience/domain/entities/AudienceTemplate.entity.ts
+++ b/src/modules/audience/domain/entities/AudienceTemplate.entity.ts
@@ -17,6 +17,8 @@ interface AudienceTemplateProps {
   display_order: number
   communities: CommunityData[] | string[]
   communities_count: number
+  total_subscribers: number
+  subscribers_loaded: number
 }
 
 export class AudienceTemplate {
@@ -29,7 +31,8 @@ export class AudienceTemplate {
   private readonly displayOrder: number
   private readonly communities: CommunityData[]
   private readonly communitiesCount: number
-
+  private readonly total_subscribers: number
+  private readonly subscribers_loaded: number
   constructor({
     id,
     name,
@@ -40,6 +43,8 @@ export class AudienceTemplate {
     display_order,
     communities,
     communities_count,
+    total_subscribers,
+    subscribers_loaded,
   }: AudienceTemplateProps) {
     this.id = id
     this.name = name
@@ -50,6 +55,8 @@ export class AudienceTemplate {
     this.displayOrder = display_order
     this.communities = this.normalizeCommunities(communities)
     this.communitiesCount = communities_count
+    this.total_subscribers = total_subscribers
+    this.subscribers_loaded = subscribers_loaded
   }
 
   private normalizeCommunities(communities: CommunityData[] | string[]): CommunityData[] {
@@ -106,6 +113,14 @@ export class AudienceTemplate {
     return this.communitiesCount
   }
 
+  getTotalSubscribers(): number {
+    return this.total_subscribers
+  }
+
+  getSubscribersLoaded(): number {
+    return this.subscribers_loaded
+  }
+
   toJSON(): object {
     return {
       id: this.id,
@@ -117,6 +132,8 @@ export class AudienceTemplate {
       displayOrder: this.displayOrder,
       communities: this.communities,
       communitiesCount: this.communitiesCount,
+      total_subscribers: this.total_subscribers,
+      subscribers_loaded: this.subscribers_loaded,
     }
   }
 }

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -13,6 +13,8 @@ interface AudienceTemplateResponse {
   display_order: number
   communities: string[]
   communities_count: number
+  total_subscribers: number
+  subscribers_loaded: number
 }
 
 interface AudienceTemplatesApiResponse {

--- a/src/modules/community/application/hooks/index.ts
+++ b/src/modules/community/application/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useBrowseCommunities, BROWSE_COMMUNITIES_QUERY_KEY } from './useBrowseCommunities'

--- a/src/modules/community/application/hooks/useBrowseCommunities.ts
+++ b/src/modules/community/application/hooks/useBrowseCommunities.ts
@@ -1,0 +1,21 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IBrowseCommunitiesUseCase } from '@/modules/community/domain/use-cases'
+import type { BrowseCommunitiesResponse } from '../../domain/entities/BrowseCommunitiesResponse'
+
+const browseCommunitiesUseCase = container.get<IBrowseCommunitiesUseCase>(TYPES.BrowseCommunitiesUseCase)
+
+const PAGE_SIZE = 20
+
+export const BROWSE_COMMUNITIES_QUERY_KEY = ['browse-communities'] as const
+
+export function useBrowseCommunities() {
+  return useInfiniteQuery<BrowseCommunitiesResponse, Error>({
+    queryKey: BROWSE_COMMUNITIES_QUERY_KEY,
+    queryFn: ({ pageParam = 0 }) =>
+      browseCommunitiesUseCase.execute({ offset: pageParam as number, limit: PAGE_SIZE }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined,
+  })
+}

--- a/src/modules/community/application/use-cases/browse-communities-use-case/index.ts
+++ b/src/modules/community/application/use-cases/browse-communities-use-case/index.ts
@@ -1,0 +1,11 @@
+import type { BrowseCommunitiesResponse } from '@/modules/community/domain/entities/BrowseCommunitiesResponse'
+import type { ICommunityRepository } from '@/modules/community/domain/repositories'
+import type { IBrowseCommunitiesUseCase } from '@/modules/community/domain/use-cases'
+
+export class BrowseCommunitiesUseCase implements IBrowseCommunitiesUseCase {
+  constructor(private readonly communityRepository: ICommunityRepository) {}
+
+  async execute(params: { offset: number; limit: number }): Promise<BrowseCommunitiesResponse> {
+    return this.communityRepository.browseCommunities(params)
+  }
+}

--- a/src/modules/community/application/use-cases/index.ts
+++ b/src/modules/community/application/use-cases/index.ts
@@ -1,0 +1,1 @@
+export { BrowseCommunitiesUseCase } from './browse-communities-use-case'

--- a/src/modules/community/domain/entities/BrowseCommunitiesResponse.ts
+++ b/src/modules/community/domain/entities/BrowseCommunitiesResponse.ts
@@ -1,0 +1,9 @@
+import type { Community } from './Community.entity'
+
+export interface BrowseCommunitiesResponse {
+  communities: Community[]
+  total: number
+  limit: number
+  offset: number
+  hasMore: boolean
+}

--- a/src/modules/community/domain/entities/Community.entity.ts
+++ b/src/modules/community/domain/entities/Community.entity.ts
@@ -1,0 +1,77 @@
+interface CommunityProps {
+  name: string
+  title: string
+  description: string
+  subscribers: number
+  icon_url: string
+  growth_week: number | null
+  growth_month: number | null
+  category: string
+}
+
+export class Community {
+  private readonly name: string
+  private readonly title: string
+  private readonly description: string
+  private readonly subscribers: number
+  private readonly iconUrl: string
+  private readonly growthWeek: number | null
+  private readonly growthMonth: number | null
+  private readonly category: string
+
+  constructor(props: CommunityProps) {
+    this.name = props.name
+    this.title = props.title
+    this.description = props.description
+    this.subscribers = props.subscribers
+    this.iconUrl = props.icon_url
+    this.growthWeek = props.growth_week
+    this.growthMonth = props.growth_month
+    this.category = props.category
+  }
+
+  getName(): string {
+    return this.name
+  }
+
+  getTitle(): string {
+    return this.title
+  }
+
+  getDescription(): string {
+    return this.description
+  }
+
+  getSubscribers(): number {
+    return this.subscribers
+  }
+
+  getIconUrl(): string {
+    return this.iconUrl
+  }
+
+  getGrowthWeek(): number | null {
+    return this.growthWeek
+  }
+
+  getGrowthMonth(): number | null {
+    return this.growthMonth
+  }
+
+  getCategory(): string {
+    return this.category
+  }
+
+  toJSON(): object {
+    return {
+      name: this.name,
+      title: this.title,
+      description: this.description,
+      subscribers: this.subscribers,
+      iconUrl: this.iconUrl,
+      growthWeek: this.growthWeek,
+      growthMonth: this.growthMonth,
+      category: this.category,
+    }
+  }
+}

--- a/src/modules/community/domain/entities/index.ts
+++ b/src/modules/community/domain/entities/index.ts
@@ -1,0 +1,2 @@
+export { Community } from './Community.entity'
+export type { BrowseCommunitiesResponse } from './BrowseCommunitiesResponse'

--- a/src/modules/community/domain/repositories/community.repository.ts
+++ b/src/modules/community/domain/repositories/community.repository.ts
@@ -1,0 +1,5 @@
+import type { BrowseCommunitiesResponse } from '../entities/BrowseCommunitiesResponse'
+
+export interface ICommunityRepository {
+  browseCommunities(params: { offset: number; limit: number }): Promise<BrowseCommunitiesResponse>
+}

--- a/src/modules/community/domain/repositories/index.ts
+++ b/src/modules/community/domain/repositories/index.ts
@@ -1,0 +1,1 @@
+export type { ICommunityRepository } from './community.repository'

--- a/src/modules/community/domain/use-cases/browse-communities.use-case.ts
+++ b/src/modules/community/domain/use-cases/browse-communities.use-case.ts
@@ -1,0 +1,5 @@
+import type { BrowseCommunitiesResponse } from '../entities/BrowseCommunitiesResponse'
+
+export interface IBrowseCommunitiesUseCase {
+  execute(params: { offset: number; limit: number }): Promise<BrowseCommunitiesResponse>
+}

--- a/src/modules/community/domain/use-cases/index.ts
+++ b/src/modules/community/domain/use-cases/index.ts
@@ -1,0 +1,1 @@
+export type { IBrowseCommunitiesUseCase } from './browse-communities.use-case'

--- a/src/modules/community/infra/repositories/community.repository.ts
+++ b/src/modules/community/infra/repositories/community.repository.ts
@@ -1,0 +1,39 @@
+import type { HttpClient } from '@/modules/shared'
+import { Community } from '../../domain/entities/Community.entity'
+import type { BrowseCommunitiesResponse } from '../../domain/entities/BrowseCommunitiesResponse'
+import type { ICommunityRepository } from '../../domain/repositories/community.repository'
+
+interface BrowseCommunitiesApiResponse {
+  communities: Array<{
+    name: string
+    title: string
+    description: string
+    subscribers: number
+    icon_url: string
+    growth_week: number | null
+    growth_month: number | null
+    category: string
+  }>
+  total: number
+  limit: number
+  offset: number
+  has_more: boolean
+}
+
+export class CommunityRepository implements ICommunityRepository {
+  constructor(private readonly httpClient: HttpClient) {}
+
+  async browseCommunities(params: { offset: number; limit: number }): Promise<BrowseCommunitiesResponse> {
+    const response = await this.httpClient.get<BrowseCommunitiesApiResponse>(
+      'communities/browse',
+      { searchParams: { offset: params.offset, limit: params.limit } }
+    )
+    return {
+      communities: response.communities.map((data) => new Community(data)),
+      total: response.total,
+      limit: response.limit,
+      offset: response.offset,
+      hasMore: response.has_more,
+    }
+  }
+}

--- a/src/modules/community/infra/repositories/index.ts
+++ b/src/modules/community/infra/repositories/index.ts
@@ -1,0 +1,1 @@
+export { CommunityRepository } from './community.repository'

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -5,6 +5,10 @@ import { AudienceRepository } from '@/modules/audience/infra/repositories'
 import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
 import { ListGenericAudiencesUseCases, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase } from '@/modules/audience/application/use-cases'
 import type { IListGenericAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase } from '@/modules/audience/domain/use-cases'
+import { CommunityRepository } from '@/modules/community/infra/repositories'
+import type { ICommunityRepository } from '@/modules/community/domain/repositories'
+import { BrowseCommunitiesUseCase } from '@/modules/community/application/use-cases'
+import type { IBrowseCommunitiesUseCase } from '@/modules/community/domain/use-cases'
 
 const container = new Container()
 
@@ -28,6 +32,16 @@ container.bind<IFetchDefaultAudiencesUseCase>(TYPES.FetchDefaultAudiencesUseCase
 container.bind<IGetAudienceTemplateByIdUseCase>(TYPES.GetAudienceTemplateByIdUseCase).toDynamicValue(() => {
   const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
   return new GetAudienceTemplateByIdUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<ICommunityRepository>(TYPES.CommunityRepository).toDynamicValue(() => {
+  const httpClient = container.get<HttpClient>(TYPES.HttpClient)
+  return new CommunityRepository(httpClient)
+}).inSingletonScope()
+
+container.bind<IBrowseCommunitiesUseCase>(TYPES.BrowseCommunitiesUseCase).toDynamicValue(() => {
+  const communityRepository = container.get<ICommunityRepository>(TYPES.CommunityRepository)
+  return new BrowseCommunitiesUseCase(communityRepository)
 }).inSingletonScope()
 
 export { container }

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -4,4 +4,6 @@ export const TYPES = {
   ListGenericAudiencesUseCase: Symbol.for('ListGenericAudiencesUseCase'),
   FetchDefaultAudiencesUseCase: Symbol.for('FetchDefaultAudiencesUseCase'),
   GetAudienceTemplateByIdUseCase: Symbol.for('GetAudienceTemplateByIdUseCase'),
+  CommunityRepository: Symbol.for('CommunityRepository'),
+  BrowseCommunitiesUseCase: Symbol.for('BrowseCommunitiesUseCase'),
 } as const

--- a/src/pages/AudienceDetail.tsx
+++ b/src/pages/AudienceDetail.tsx
@@ -275,7 +275,7 @@ export function AudienceDetail() {
   const subredditsData = communities.map((community, index) => ({
     id: `${audienceTemplate.getId()}-${index}`,
     name: `r/${community.name}`,
-    members: community.subscribers,
+    members: community.subscribers ?? 0,
     monthlyGrowth: community.growth_month ?? 0,
   }))
 

--- a/src/pages/Audiences.tsx
+++ b/src/pages/Audiences.tsx
@@ -24,8 +24,9 @@ export function Audiences() {
     id: template.getId(),
     name: template.getName(),
     subredditCount: template.getCommunitiesCount(),
-    totalMembers: template.getCommunities().reduce((sum, c) => sum + c.subscribers, 0),
+    totalMembers: template.getTotalSubscribers() ?? 0,
     weeklyGrowth: 0,
+    total_subscribers: template.getTotalSubscribers(),
     subreddits: template.getCommunities().map((community, index) => ({
       id: `${template.getId()}-${index}`,
       name: `r/${community.name}`,
@@ -156,7 +157,7 @@ export function Audiences() {
             id={audience.id}
             name={audience.name}
             subredditCount={audience.subredditCount}
-            totalMembers={audience.totalMembers}
+            totalMembers={audience.total_subscribers}
             weeklyGrowth={audience.weeklyGrowth}
             subreddits={audience.subreddits}
             onSaveClick={handleSaveClick}
@@ -177,9 +178,8 @@ export function Audiences() {
       <SelectAudienceModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        audiences={audiences}
-        onCreateAudience={(name, selectedAudiences) => {
-          console.log('Creating audience:', name, selectedAudiences)
+        onCreateAudience={(name, selectedCommunityNames) => {
+          console.log('Creating audience:', name, 'with communities:', selectedCommunityNames)
           setIsModalOpen(false)
         }}
       />


### PR DESCRIPTION
## Summary
- Add new `community` module following Clean Architecture (entity, repository, use case, hook) to fetch communities from `/communities/browse` endpoint with pagination support
- Refactor `SelectAudienceModal` to display browsable communities with `useInfiniteQuery` and "Load More" button, replacing the previous audience template selection
- Enhance `AudienceTemplate` entity with `total_subscribers` and `subscribers_loaded` fields, render Modal via `createPortal`, and fix null safety in `AudienceDetail`

## Test plan
- [ ] Open the Audiences page and click "Add Audience" — modal should load communities from the API
- [ ] Verify search filters communities by name, title, and category
- [ ] Verify "Load More Communities" button loads the next page
- [ ] Select multiple communities and confirm the counter updates
- [ ] Enter a name and click "Create Audience" — verify callback receives selected community names
- [ ] Verify TypeScript compiles without errors (`npx tsc --noEmit`)