### PR TITLE
feat: add authentication module (JWT login + token refresh)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,16 @@
+import { useEffect } from 'react'
 import { QueryProvider } from '@/modules/shared'
 import { AppRouter } from '@/router'
+import { useAuthStore } from '@/modules/auth'
 import '@/styles/globals.css'
 
 function App() {
+  const hydrate = useAuthStore((state) => state.hydrate)
+
+  useEffect(() => {
+    hydrate()
+  }, [hydrate])
+
   return (
     <QueryProvider>
       <AppRouter />

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,11 +1,18 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Icon } from '@iconify/react'
 import { useGsapEntrance } from '@/hooks'
+import { useLogin } from '@/modules/auth'
 
 const FONT_DISPLAY = { fontFamily: "'Space Grotesk', sans-serif" }
 
 export function LoginForm() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
+  const navigate = useNavigate()
+
+  const { mutate: login, isPending, error } = useLogin()
 
   const ref = useGsapEntrance<HTMLDivElement>({
     y: 30,
@@ -14,6 +21,20 @@ export function LoginForm() {
     delay: 0.3,
     ease: 'power3.out',
   })
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    login(
+      { email, password },
+      { onSuccess: () => navigate('/dashboard', { replace: true }) }
+    )
+  }
+
+  const errorMessage = error
+    ? (error as { response?: { status?: number } }).response?.status === 401
+      ? 'Email ou senha inválidos'
+      : 'Erro ao fazer login. Tente novamente.'
+    : null
 
   return (
     <div
@@ -49,10 +70,18 @@ export function LoginForm() {
         </p>
       </div>
 
+      {/* Error */}
+      {errorMessage && (
+        <div className="flex items-center gap-2 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3">
+          <Icon icon="solar:danger-triangle-linear" className="text-lg text-red-400" />
+          <span className="text-sm text-red-300">{errorMessage}</span>
+        </div>
+      )}
+
       {/* Form */}
       <form
         className="flex flex-col gap-5"
-        onSubmit={(e) => e.preventDefault()}
+        onSubmit={handleSubmit}
       >
         {/* Email */}
         <div className="flex flex-col gap-1.5">
@@ -60,7 +89,11 @@ export function LoginForm() {
           <input
             type="email"
             placeholder="your@email.com"
-            className="h-11 w-full rounded-xl border border-white/10 bg-white/5 px-4 text-sm text-white placeholder:text-white/30 transition-colors duration-300 focus:border-purple-500 focus:outline-none"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            disabled={isPending}
+            className="h-11 w-full rounded-xl border border-white/10 bg-white/5 px-4 text-sm text-white placeholder:text-white/30 transition-colors duration-300 focus:border-purple-500 focus:outline-none disabled:opacity-50"
           />
         </div>
 
@@ -71,7 +104,11 @@ export function LoginForm() {
             <input
               type={showPassword ? 'text' : 'password'}
               placeholder="Enter your password"
-              className="h-11 w-full rounded-xl border border-white/10 bg-white/5 px-4 pr-11 text-sm text-white placeholder:text-white/30 transition-colors duration-300 focus:border-purple-500 focus:outline-none"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              disabled={isPending}
+              className="h-11 w-full rounded-xl border border-white/10 bg-white/5 px-4 pr-11 text-sm text-white placeholder:text-white/30 transition-colors duration-300 focus:border-purple-500 focus:outline-none disabled:opacity-50"
             />
             <button
               type="button"
@@ -110,15 +147,22 @@ export function LoginForm() {
         {/* Sign in button */}
         <button
           type="submit"
-          className="group relative flex h-12 w-full cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-full bg-white text-black transition-transform hover:scale-[1.02] active:scale-[0.98]"
+          disabled={isPending}
+          className="group relative flex h-12 w-full cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-full bg-white text-black transition-transform hover:scale-[1.02] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-70 disabled:hover:scale-100"
         >
-          <span className="relative z-10 text-sm font-semibold tracking-tight">
-            Sign in
-          </span>
-          <Icon
-            icon="solar:arrow-right-up-linear"
-            className="relative z-10 text-lg transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
-          />
+          {isPending ? (
+            <div className="relative z-10 h-5 w-5 animate-spin rounded-full border-2 border-black/20 border-t-black" />
+          ) : (
+            <>
+              <span className="relative z-10 text-sm font-semibold tracking-tight">
+                Sign in
+              </span>
+              <Icon
+                icon="solar:arrow-right-up-linear"
+                className="relative z-10 text-lg transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+              />
+            </>
+          )}
           <div className="absolute inset-0 bg-linear-to-r from-purple-200 to-purple-400 opacity-0 transition-opacity group-hover:opacity-100" />
         </button>
       </form>

--- a/src/modules/audience/domain/entities/Audience.entity.ts
+++ b/src/modules/audience/domain/entities/Audience.entity.ts
@@ -25,7 +25,7 @@ interface CommunityCardDisplay {
 }
 
 
-interface RelatedCommunity {
+export interface RelatedCommunity {
   name: string;
   title: string;
   description: string;

--- a/src/modules/audience/domain/entities/subreddit.entity.ts
+++ b/src/modules/audience/domain/entities/subreddit.entity.ts
@@ -1,3 +1,4 @@
+import type { RelatedCommunity } from './Audience.entity'
 
 interface SubredditProps {
   display_name: string;

--- a/src/modules/auth/application/hooks/index.ts
+++ b/src/modules/auth/application/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useLogin } from './useLogin'
+export { useGetMe, AUTH_ME_QUERY_KEY } from './useGetMe'

--- a/src/modules/auth/application/hooks/useGetMe.ts
+++ b/src/modules/auth/application/hooks/useGetMe.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IGetMeUseCase } from '@/modules/auth/domain/use-cases'
+
+const getMeUseCase = container.get<IGetMeUseCase>(TYPES.GetMeUseCase)
+
+export const AUTH_ME_QUERY_KEY = ['auth', 'me'] as const
+
+export function useGetMe(enabled = true) {
+  return useQuery({
+    queryKey: AUTH_ME_QUERY_KEY,
+    queryFn: () => getMeUseCase.execute(),
+    enabled: enabled && Boolean(localStorage.getItem('access_token')),
+  })
+}

--- a/src/modules/auth/application/hooks/useLogin.ts
+++ b/src/modules/auth/application/hooks/useLogin.ts
@@ -1,0 +1,33 @@
+import { useMutation } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { ILoginUseCase } from '@/modules/auth/domain/use-cases'
+import type { IGetMeUseCase } from '@/modules/auth/domain/use-cases'
+import { useAuthStore } from '../store'
+
+const loginUseCase = container.get<ILoginUseCase>(TYPES.LoginUseCase)
+const getMeUseCase = container.get<IGetMeUseCase>(TYPES.GetMeUseCase)
+
+interface LoginParams {
+  email: string
+  password: string
+}
+
+export function useLogin() {
+  const setAuth = useAuthStore((state) => state.setAuth)
+
+  return useMutation({
+    mutationFn: async ({ email, password }: LoginParams) => {
+      const tokens = await loginUseCase.execute(email, password)
+
+      localStorage.setItem('access_token', tokens.getAccessToken())
+      localStorage.setItem('refresh_token', tokens.getRefreshToken())
+
+      const user = await getMeUseCase.execute()
+
+      return { tokens, user }
+    },
+    onSuccess: ({ tokens, user }) => {
+      setAuth(user, tokens)
+    },
+  })
+}

--- a/src/modules/auth/application/index.ts
+++ b/src/modules/auth/application/index.ts
@@ -1,0 +1,3 @@
+export { LoginUseCase, RegisterUseCase, RefreshTokenUseCase, GetMeUseCase } from './use-cases'
+export { useLogin, useGetMe, AUTH_ME_QUERY_KEY } from './hooks'
+export { useAuthStore } from './store'

--- a/src/modules/auth/application/store/auth.store.ts
+++ b/src/modules/auth/application/store/auth.store.ts
@@ -1,0 +1,57 @@
+import { create } from 'zustand'
+import type { AuthUser } from '../../domain/entities/auth-user.entity'
+import type { AuthTokens } from '../../domain/entities/auth-tokens.entity'
+import { container, TYPES } from '@/modules/shared'
+import type { IGetMeUseCase } from '../../domain/use-cases'
+
+interface AuthState {
+  user: AuthUser | null
+  isAuthenticated: boolean
+  isHydrated: boolean
+
+  setAuth: (user: AuthUser, tokens: AuthTokens) => void
+  setUser: (user: AuthUser) => void
+  logout: () => void
+  hydrate: () => Promise<void>
+}
+
+export const useAuthStore = create<AuthState>()((set) => ({
+  user: null,
+  isAuthenticated: false,
+  isHydrated: false,
+
+  setAuth: (user: AuthUser, tokens: AuthTokens) => {
+    localStorage.setItem('access_token', tokens.getAccessToken())
+    localStorage.setItem('refresh_token', tokens.getRefreshToken())
+    set({ user, isAuthenticated: true })
+  },
+
+  setUser: (user: AuthUser) => {
+    set({ user, isAuthenticated: true })
+  },
+
+  logout: () => {
+    localStorage.removeItem('access_token')
+    localStorage.removeItem('refresh_token')
+    set({ user: null, isAuthenticated: false })
+  },
+
+  hydrate: async () => {
+    const token = localStorage.getItem('access_token')
+
+    if (!token) {
+      set({ isHydrated: true, isAuthenticated: false, user: null })
+      return
+    }
+
+    try {
+      const getMeUseCase = container.get<IGetMeUseCase>(TYPES.GetMeUseCase)
+      const user = await getMeUseCase.execute()
+      set({ user, isAuthenticated: true, isHydrated: true })
+    } catch {
+      localStorage.removeItem('access_token')
+      localStorage.removeItem('refresh_token')
+      set({ user: null, isAuthenticated: false, isHydrated: true })
+    }
+  },
+}))

--- a/src/modules/auth/application/store/index.ts
+++ b/src/modules/auth/application/store/index.ts
@@ -1,0 +1,1 @@
+export { useAuthStore } from './auth.store'

--- a/src/modules/auth/application/use-cases/get-me-use-case/index.ts
+++ b/src/modules/auth/application/use-cases/get-me-use-case/index.ts
@@ -1,0 +1,11 @@
+import type { AuthUser } from '@/modules/auth/domain/entities/auth-user.entity'
+import type { IAuthRepository } from '@/modules/auth/domain/repositories'
+import type { IGetMeUseCase } from '@/modules/auth/domain/use-cases'
+
+export class GetMeUseCase implements IGetMeUseCase {
+  constructor(private readonly authRepository: IAuthRepository) {}
+
+  async execute(): Promise<AuthUser> {
+    return this.authRepository.getMe()
+  }
+}

--- a/src/modules/auth/application/use-cases/index.ts
+++ b/src/modules/auth/application/use-cases/index.ts
@@ -1,0 +1,4 @@
+export { LoginUseCase } from './login-use-case'
+export { RegisterUseCase } from './register-use-case'
+export { RefreshTokenUseCase } from './refresh-token-use-case'
+export { GetMeUseCase } from './get-me-use-case'

--- a/src/modules/auth/application/use-cases/login-use-case/index.ts
+++ b/src/modules/auth/application/use-cases/login-use-case/index.ts
@@ -1,0 +1,11 @@
+import type { AuthTokens } from '@/modules/auth/domain/entities/auth-tokens.entity'
+import type { IAuthRepository } from '@/modules/auth/domain/repositories'
+import type { ILoginUseCase } from '@/modules/auth/domain/use-cases'
+
+export class LoginUseCase implements ILoginUseCase {
+  constructor(private readonly authRepository: IAuthRepository) {}
+
+  async execute(email: string, password: string): Promise<AuthTokens> {
+    return this.authRepository.login(email, password)
+  }
+}

--- a/src/modules/auth/application/use-cases/refresh-token-use-case/index.ts
+++ b/src/modules/auth/application/use-cases/refresh-token-use-case/index.ts
@@ -1,0 +1,11 @@
+import type { AuthTokens } from '@/modules/auth/domain/entities/auth-tokens.entity'
+import type { IAuthRepository } from '@/modules/auth/domain/repositories'
+import type { IRefreshTokenUseCase } from '@/modules/auth/domain/use-cases'
+
+export class RefreshTokenUseCase implements IRefreshTokenUseCase {
+  constructor(private readonly authRepository: IAuthRepository) {}
+
+  async execute(refreshToken: string): Promise<AuthTokens> {
+    return this.authRepository.refreshToken(refreshToken)
+  }
+}

--- a/src/modules/auth/application/use-cases/register-use-case/index.ts
+++ b/src/modules/auth/application/use-cases/register-use-case/index.ts
@@ -1,0 +1,11 @@
+import type { AuthUser } from '@/modules/auth/domain/entities/auth-user.entity'
+import type { IAuthRepository } from '@/modules/auth/domain/repositories'
+import type { IRegisterUseCase } from '@/modules/auth/domain/use-cases'
+
+export class RegisterUseCase implements IRegisterUseCase {
+  constructor(private readonly authRepository: IAuthRepository) {}
+
+  async execute(email: string, password: string, fullName: string): Promise<AuthUser> {
+    return this.authRepository.register(email, password, fullName)
+  }
+}

--- a/src/modules/auth/domain/entities/auth-tokens.entity.ts
+++ b/src/modules/auth/domain/entities/auth-tokens.entity.ts
@@ -1,0 +1,29 @@
+interface AuthTokensProps {
+  access_token: string
+  refresh_token: string
+  token_type: string
+}
+
+export class AuthTokens {
+  private readonly accessToken: string
+  private readonly refreshToken: string
+  private readonly tokenType: string
+
+  constructor({ access_token, refresh_token, token_type }: AuthTokensProps) {
+    this.accessToken = access_token
+    this.refreshToken = refresh_token
+    this.tokenType = token_type
+  }
+
+  getAccessToken(): string {
+    return this.accessToken
+  }
+
+  getRefreshToken(): string {
+    return this.refreshToken
+  }
+
+  getTokenType(): string {
+    return this.tokenType
+  }
+}

--- a/src/modules/auth/domain/entities/auth-user.entity.ts
+++ b/src/modules/auth/domain/entities/auth-user.entity.ts
@@ -1,0 +1,53 @@
+interface AuthUserProps {
+  id: string
+  email: string
+  full_name: string
+  is_active: boolean
+  is_superuser: boolean
+}
+
+export class AuthUser {
+  private readonly id: string
+  private readonly email: string
+  private readonly fullName: string
+  private readonly isActive: boolean
+  private readonly isSuperuser: boolean
+
+  constructor({ id, email, full_name, is_active, is_superuser }: AuthUserProps) {
+    this.id = id
+    this.email = email
+    this.fullName = full_name
+    this.isActive = is_active
+    this.isSuperuser = is_superuser
+  }
+
+  getId(): string {
+    return this.id
+  }
+
+  getEmail(): string {
+    return this.email
+  }
+
+  getFullName(): string {
+    return this.fullName
+  }
+
+  getIsActive(): boolean {
+    return this.isActive
+  }
+
+  getIsSuperuser(): boolean {
+    return this.isSuperuser
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      email: this.email,
+      full_name: this.fullName,
+      is_active: this.isActive,
+      is_superuser: this.isSuperuser,
+    }
+  }
+}

--- a/src/modules/auth/domain/entities/index.ts
+++ b/src/modules/auth/domain/entities/index.ts
@@ -1,0 +1,2 @@
+export { AuthTokens } from './auth-tokens.entity'
+export { AuthUser } from './auth-user.entity'

--- a/src/modules/auth/domain/index.ts
+++ b/src/modules/auth/domain/index.ts
@@ -1,0 +1,3 @@
+export { AuthTokens, AuthUser } from './entities'
+export type { IAuthRepository } from './repositories'
+export type { ILoginUseCase, IRegisterUseCase, IRefreshTokenUseCase, IGetMeUseCase } from './use-cases'

--- a/src/modules/auth/domain/repositories/auth.repository.ts
+++ b/src/modules/auth/domain/repositories/auth.repository.ts
@@ -1,0 +1,9 @@
+import type { AuthTokens } from '../entities/auth-tokens.entity'
+import type { AuthUser } from '../entities/auth-user.entity'
+
+export interface IAuthRepository {
+  login(email: string, password: string): Promise<AuthTokens>
+  register(email: string, password: string, fullName: string): Promise<AuthUser>
+  refreshToken(refreshToken: string): Promise<AuthTokens>
+  getMe(): Promise<AuthUser>
+}

--- a/src/modules/auth/domain/repositories/index.ts
+++ b/src/modules/auth/domain/repositories/index.ts
@@ -1,0 +1,1 @@
+export type { IAuthRepository } from './auth.repository'

--- a/src/modules/auth/domain/use-cases/get-me.use-case.ts
+++ b/src/modules/auth/domain/use-cases/get-me.use-case.ts
@@ -1,0 +1,5 @@
+import type { AuthUser } from '../entities/auth-user.entity'
+
+export interface IGetMeUseCase {
+  execute(): Promise<AuthUser>
+}

--- a/src/modules/auth/domain/use-cases/index.ts
+++ b/src/modules/auth/domain/use-cases/index.ts
@@ -1,0 +1,4 @@
+export type { ILoginUseCase } from './login.use-case'
+export type { IRegisterUseCase } from './register.use-case'
+export type { IRefreshTokenUseCase } from './refresh-token.use-case'
+export type { IGetMeUseCase } from './get-me.use-case'

--- a/src/modules/auth/domain/use-cases/login.use-case.ts
+++ b/src/modules/auth/domain/use-cases/login.use-case.ts
@@ -1,0 +1,5 @@
+import type { AuthTokens } from '../entities/auth-tokens.entity'
+
+export interface ILoginUseCase {
+  execute(email: string, password: string): Promise<AuthTokens>
+}

--- a/src/modules/auth/domain/use-cases/refresh-token.use-case.ts
+++ b/src/modules/auth/domain/use-cases/refresh-token.use-case.ts
@@ -1,0 +1,5 @@
+import type { AuthTokens } from '../entities/auth-tokens.entity'
+
+export interface IRefreshTokenUseCase {
+  execute(refreshToken: string): Promise<AuthTokens>
+}

--- a/src/modules/auth/domain/use-cases/register.use-case.ts
+++ b/src/modules/auth/domain/use-cases/register.use-case.ts
@@ -1,0 +1,5 @@
+import type { AuthUser } from '../entities/auth-user.entity'
+
+export interface IRegisterUseCase {
+  execute(email: string, password: string, fullName: string): Promise<AuthUser>
+}

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,0 +1,5 @@
+export { AuthTokens, AuthUser } from './domain'
+export type { IAuthRepository, ILoginUseCase, IRegisterUseCase, IRefreshTokenUseCase, IGetMeUseCase } from './domain'
+export { LoginUseCase, RegisterUseCase, RefreshTokenUseCase, GetMeUseCase } from './application'
+export { useLogin, useGetMe, AUTH_ME_QUERY_KEY, useAuthStore } from './application'
+export { AuthRepository } from './infra'

--- a/src/modules/auth/infra/index.ts
+++ b/src/modules/auth/infra/index.ts
@@ -1,0 +1,1 @@
+export { AuthRepository } from './repositories'

--- a/src/modules/auth/infra/repositories/auth.repository.ts
+++ b/src/modules/auth/infra/repositories/auth.repository.ts
@@ -1,0 +1,51 @@
+import type { HttpClient } from '@/modules/shared'
+import { AuthTokens } from '../../domain/entities/auth-tokens.entity'
+import { AuthUser } from '../../domain/entities/auth-user.entity'
+import type { IAuthRepository } from '../../domain/repositories/auth.repository'
+
+interface AuthTokensResponse {
+  access_token: string
+  refresh_token: string
+  token_type: string
+}
+
+interface AuthUserResponse {
+  id: string
+  email: string
+  full_name: string
+  is_active: boolean
+  is_superuser: boolean
+}
+
+export class AuthRepository implements IAuthRepository {
+  constructor(private readonly httpClient: HttpClient) {}
+
+  async login(email: string, password: string): Promise<AuthTokens> {
+    const response = await this.httpClient.post<AuthTokensResponse>('auth/login', {
+      email,
+      password,
+    })
+    return new AuthTokens(response)
+  }
+
+  async register(email: string, password: string, fullName: string): Promise<AuthUser> {
+    const response = await this.httpClient.post<AuthUserResponse>('auth/register', {
+      email,
+      password,
+      full_name: fullName,
+    })
+    return new AuthUser(response)
+  }
+
+  async refreshToken(refreshToken: string): Promise<AuthTokens> {
+    const response = await this.httpClient.post<AuthTokensResponse>('auth/refresh', {
+      refresh_token: refreshToken,
+    })
+    return new AuthTokens(response)
+  }
+
+  async getMe(): Promise<AuthUser> {
+    const response = await this.httpClient.get<AuthUserResponse>('auth/me')
+    return new AuthUser(response)
+  }
+}

--- a/src/modules/auth/infra/repositories/index.ts
+++ b/src/modules/auth/infra/repositories/index.ts
@@ -1,0 +1,1 @@
+export { AuthRepository } from './auth.repository'

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -9,6 +9,10 @@ import { CommunityRepository } from '@/modules/community/infra/repositories'
 import type { ICommunityRepository } from '@/modules/community/domain/repositories'
 import { BrowseCommunitiesUseCase } from '@/modules/community/application/use-cases'
 import type { IBrowseCommunitiesUseCase } from '@/modules/community/domain/use-cases'
+import { AuthRepository } from '@/modules/auth/infra/repositories'
+import type { IAuthRepository } from '@/modules/auth/domain/repositories'
+import { LoginUseCase, RegisterUseCase, RefreshTokenUseCase, GetMeUseCase } from '@/modules/auth/application/use-cases'
+import type { ILoginUseCase, IRegisterUseCase, IRefreshTokenUseCase, IGetMeUseCase } from '@/modules/auth/domain/use-cases'
 
 const container = new Container()
 
@@ -42,6 +46,31 @@ container.bind<ICommunityRepository>(TYPES.CommunityRepository).toDynamicValue((
 container.bind<IBrowseCommunitiesUseCase>(TYPES.BrowseCommunitiesUseCase).toDynamicValue(() => {
   const communityRepository = container.get<ICommunityRepository>(TYPES.CommunityRepository)
   return new BrowseCommunitiesUseCase(communityRepository)
+}).inSingletonScope()
+
+container.bind<IAuthRepository>(TYPES.AuthRepository).toDynamicValue(() => {
+  const httpClient = container.get<HttpClient>(TYPES.HttpClient)
+  return new AuthRepository(httpClient)
+}).inSingletonScope()
+
+container.bind<ILoginUseCase>(TYPES.LoginUseCase).toDynamicValue(() => {
+  const authRepository = container.get<IAuthRepository>(TYPES.AuthRepository)
+  return new LoginUseCase(authRepository)
+}).inSingletonScope()
+
+container.bind<IRegisterUseCase>(TYPES.RegisterUseCase).toDynamicValue(() => {
+  const authRepository = container.get<IAuthRepository>(TYPES.AuthRepository)
+  return new RegisterUseCase(authRepository)
+}).inSingletonScope()
+
+container.bind<IRefreshTokenUseCase>(TYPES.RefreshTokenUseCase).toDynamicValue(() => {
+  const authRepository = container.get<IAuthRepository>(TYPES.AuthRepository)
+  return new RefreshTokenUseCase(authRepository)
+}).inSingletonScope()
+
+container.bind<IGetMeUseCase>(TYPES.GetMeUseCase).toDynamicValue(() => {
+  const authRepository = container.get<IAuthRepository>(TYPES.AuthRepository)
+  return new GetMeUseCase(authRepository)
 }).inSingletonScope()
 
 export { container }

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -6,4 +6,9 @@ export const TYPES = {
   GetAudienceTemplateByIdUseCase: Symbol.for('GetAudienceTemplateByIdUseCase'),
   CommunityRepository: Symbol.for('CommunityRepository'),
   BrowseCommunitiesUseCase: Symbol.for('BrowseCommunitiesUseCase'),
+  AuthRepository: Symbol.for('AuthRepository'),
+  LoginUseCase: Symbol.for('LoginUseCase'),
+  RegisterUseCase: Symbol.for('RegisterUseCase'),
+  RefreshTokenUseCase: Symbol.for('RefreshTokenUseCase'),
+  GetMeUseCase: Symbol.for('GetMeUseCase'),
 } as const

--- a/src/modules/shared/infra/http/http-client.ts
+++ b/src/modules/shared/infra/http/http-client.ts
@@ -8,12 +8,51 @@ export interface HttpClient {
   delete<T>(url: string, options?: Options): Promise<T>
 }
 
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+let isRefreshing = false
+let pendingRequests: Array<{
+  resolve: (token: string) => void
+  reject: (error: unknown) => void
+}> = []
+
+function processPendingRequests(token: string | null, error: unknown = null) {
+  pendingRequests.forEach(({ resolve, reject }) => {
+    if (token) {
+      resolve(token)
+    } else {
+      reject(error)
+    }
+  })
+  pendingRequests = []
+}
+
+async function refreshAccessToken(): Promise<string | null> {
+  const refreshToken = localStorage.getItem('refresh_token')
+  if (!refreshToken) return null
+
+  try {
+    const response = await ky.post('auth/refresh', {
+      prefixUrl: API_BASE_URL,
+      json: { refresh_token: refreshToken },
+    }).json<{ access_token: string; refresh_token: string; token_type: string }>()
+
+    localStorage.setItem('access_token', response.access_token)
+    localStorage.setItem('refresh_token', response.refresh_token)
+    return response.access_token
+  } catch {
+    localStorage.removeItem('access_token')
+    localStorage.removeItem('refresh_token')
+    return null
+  }
+}
+
 export class KyHttpClient implements HttpClient {
   private readonly client: KyInstance
 
   constructor() {
     this.client = ky.create({
-      prefixUrl: import.meta.env.VITE_API_URL || 'http://localhost:8000',
+      prefixUrl: API_BASE_URL,
       timeout: 30000,
       retry: {
         limit: 2,
@@ -30,11 +69,39 @@ export class KyHttpClient implements HttpClient {
           },
         ],
         afterResponse: [
-          async (_request, _options, response) => {
-            if (response.status === 401) {
-              localStorage.removeItem('access_token')
-              window.location.href = '/'
+          async (request, options, response) => {
+            if (response.status !== 401) return response
+
+            const url = new URL(request.url)
+            if (url.pathname.includes('/auth/')) return response
+
+            if (isRefreshing) {
+              return new Promise<Response>((resolve, reject) => {
+                pendingRequests.push({
+                  resolve: (token: string) => {
+                    request.headers.set('Authorization', `Bearer ${token}`)
+                    resolve(ky(request, options))
+                  },
+                  reject,
+                })
+              })
             }
+
+            isRefreshing = true
+
+            const newToken = await refreshAccessToken()
+
+            if (newToken) {
+              processPendingRequests(newToken)
+              isRefreshing = false
+
+              request.headers.set('Authorization', `Bearer ${newToken}`)
+              return ky(request, options)
+            }
+
+            processPendingRequests(null, new Error('Refresh token expired'))
+            isRefreshing = false
+            window.location.href = '/login'
             return response
           },
         ],

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from 'react'
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import { MainLayout } from '@/components/layout'
+import { useAuthStore } from '@/modules/auth'
 
 const LandingPage = lazy(() => import('@/pages/LandingPage'))
 const LoginPage = lazy(() => import('@/pages/LoginPage'))
@@ -19,7 +20,11 @@ function PageLoader() {
 }
 
 function AuthRedirect() {
-  const isAuthenticated = Boolean(localStorage.getItem('access_token'))
+  const { isAuthenticated, isHydrated } = useAuthStore()
+
+  if (!isHydrated) {
+    return <PageLoader />
+  }
 
   if (isAuthenticated) {
     return <Navigate to="/dashboard" replace />
@@ -33,10 +38,14 @@ function AuthRedirect() {
 }
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
-  const isAuthenticated = Boolean(localStorage.getItem('access_token'))
+  const { isAuthenticated, isHydrated } = useAuthStore()
+
+  if (!isHydrated) {
+    return <PageLoader />
+  }
 
   if (!isAuthenticated) {
-    return <Navigate to="/" replace />
+    return <Navigate to="/login" replace />
   }
 
   return <>{children}</>


### PR DESCRIPTION
## Summary

- Implementa módulo completo de autenticação no frontend seguindo DDD/Clean Architecture
- Integra com o backend Identity (Issue #15) — endpoints `/auth/login`, `/auth/register`, `/auth/refresh`, `/auth/me`
- LoginForm conectado à API real com loading e tratamento de erros
- Auto-refresh de token (401 interceptor) com queue de requests concorrentes
- Auth store (Zustand) como fonte de verdade para estado de autenticação
- Hydration no init do app para validar token existente

## Estrutura do Módulo

```
src/modules/auth/
├── domain/          # Entities (AuthTokens, AuthUser), interfaces (IAuthRepository, use cases)
├── application/     # Use cases impl, React Query hooks (useLogin, useGetMe), Zustand auth store
└── infra/           # AuthRepository (HTTP implementation via ky)
```

## Arquivos Modificados

| Arquivo | Mudança |
|---------|---------|
| `src/modules/shared/infra/container/` | Auth bindings no IoC Container (Inversify) |
| `src/modules/shared/infra/http/http-client.ts` | Auto-refresh 401 interceptor com request queue |
| `src/components/auth/LoginForm.tsx` | Conectado à API com loading/error states |
| `src/router/index.tsx` | Auth guards usando Zustand store + hydration loading |
| `src/App.tsx` | Auth hydration no mount |
| `src/modules/audience/domain/entities/` | Fix build error pré-existente (RelatedCommunity import) |

## Test plan

- [ ] Login com email/senha válidos → redirect para `/dashboard`
- [ ] Login com credenciais inválidas → mensagem de erro inline
- [ ] Acesso a rota protegida sem token → redirect para `/login`
- [ ] Refresh automático quando access_token expira (401)
- [ ] Reload da página com token válido → mantém sessão (hydration)
- [ ] `npm run build` → sem erros

Closes #13