### PR TITLE
fix: add dark mode support to Card UI component

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
     <div
       ref={ref}
       className={cn(
-        'bg-white rounded-[1.875rem] p-6 border border-transparent transition-all duration-300 hover:border-gray-200',
+        'bg-white dark:bg-zinc-900 rounded-[1.875rem] p-6 border border-transparent transition-all duration-300 hover:border-gray-200 dark:hover:border-zinc-700',
         className
       )}
       {...props}
@@ -30,7 +30,7 @@ const CardTitle = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLHeadingEle
   ({ className, ...props }, ref) => (
     <h3
       ref={ref}
-      className={cn('text-2xl font-bold text-gray-900', className)}
+      className={cn('text-2xl font-bold text-gray-900 dark:text-white', className)}
       {...props}
     />
   )
@@ -41,7 +41,7 @@ const CardDescription = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLPara
   ({ className, ...props }, ref) => (
     <p
       ref={ref}
-      className={cn('text-sm text-gray-600', className)}
+      className={cn('text-sm text-gray-600 dark:text-zinc-400', className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- Added `dark:bg-zinc-900` and `dark:hover:border-zinc-700` to the `Card` component base styles
- Added `dark:text-white` to `CardTitle` and `dark:text-zinc-400` to `CardDescription`
- Fixes white-on-white text issue on Profile page (and all other pages using the Card component) in dark mode

## Test plan
- [ ] Open the Profile page in dark mode and verify cards have dark background
- [ ] Verify all text inside cards is visible (not white-on-white)
- [ ] Verify hover border works in both light and dark mode
- [ ] Check other pages using the Card component are not broken