### PR TITLE
feat: add create audience use case (POST /audiences)

### DIFF
--- a/docs/issue-20-create-audience-use-case.md
+++ b/docs/issue-20-create-audience-use-case.md
@@ -1,0 +1,131 @@
+# Issue #20 — Use Case de Criação de Audiência (POST /audiences)
+
+**Issue:** https://github.com/robsonmvieira/oraculo-frontend/issues/20
+**PR:** https://github.com/robsonmvieira/oraculo-frontend/pull/21
+**Branch:** `feat/create-audience-use-case`
+**Status:** Implementada
+
+---
+
+## 1. Motivação
+
+O modal de criação de audiência (`SelectAudienceModal`) já existia com toda a UI funcional — campo de nome, busca de comunidades com infinite scroll, e seleção de comunidades. Porém, o callback `onCreateAudience` apenas fazia `console.log`, sem integração com a API.
+
+Com o endpoint `POST /audiences` disponível no backend, era necessário conectar o frontend para que audiências fossem efetivamente criadas e persistidas.
+
+---
+
+## 2. Decisões de Design
+
+### 2.1 Seguir o padrão DDD/Clean Arch existente
+
+A implementação segue exatamente o mesmo padrão das demais features (`auth`, `community`, `audience-templates`):
+
+```
+domain/    → Interface ICreateAudienceUseCase + tipos (params/result) + extensão da IAudienceRepository
+application/ → Implementação CreateAudienceUseCase + hook useCreateAudience (useMutation)
+infra/     → Implementação createAudience no AudienceRepository via HttpClient
+```
+
+### 2.2 useMutation (React Query) para a operação de escrita
+
+Diferente das queries de leitura (useQuery/useInfiniteQuery), a criação de audiência é uma mutation que:
+
+- Envia dados ao servidor (POST)
+- Invalida o cache de audiências no sucesso (`AUDIENCES_QUERY_KEY`)
+- Gerencia estados de `isPending` e `isError` automaticamente
+
+### 2.3 Description enviada como string vazia
+
+O campo `description` do payload é enviado como string vazia por decisão do produto. O campo visual não foi adicionado ao modal nesta iteração.
+
+---
+
+## 3. Solução Implementada
+
+### 3.1 Endpoint
+
+```
+POST /audiences
+Authorization: Bearer <access_token>
+Content-Type: application/json
+```
+
+### 3.2 Payload
+
+```json
+{
+  "name": "Tech Communities",
+  "description": "",
+  "subreddit_names": ["python", "javascript", "rust"]
+}
+```
+
+### 3.3 Resposta esperada (201)
+
+```json
+{
+  "id": "<uuid>",
+  "name": "Tech Communities",
+  "description": "",
+  "user_id": "<id-do-token>",
+  "communities_count": 3
+}
+```
+
+### 3.4 Fluxo
+
+1. Usuário abre o modal, preenche o nome e seleciona comunidades
+2. Clica "Create Audience"
+3. `useCreateAudience` (useMutation) chama `CreateAudienceUseCase.execute()`
+4. Use case delega para `AudienceRepository.createAudience()`
+5. Repository faz `POST /audiences` via `HttpClient.post()` (Bearer token injetado automaticamente)
+6. Sucesso (201): modal fecha, store reseta, lista de audiências é invalidada via React Query
+7. Erro: o botão volta ao estado normal (React Query gerencia `isPending`)
+
+---
+
+## 4. Arquitetura
+
+```
+SelectAudienceModal (UI)
+  └── Audiences page (onCreateAudience callback)
+        └── useCreateAudience() hook (useMutation)
+              └── CreateAudienceUseCase.execute()
+                    └── AudienceRepository.createAudience()
+                          └── HttpClient.post('audiences', payload)
+                                └── Bearer token (automático via beforeRequest hook)
+```
+
+---
+
+## 5. Arquivos Criados
+
+| Arquivo | Descrição |
+|---------|-----------|
+| `src/modules/audience/domain/use-cases/create-audience.use-case.ts` | Interface `ICreateAudienceUseCase` + tipos `CreateAudienceParams` e `CreateAudienceResult` |
+| `src/modules/audience/application/use-cases/create-audience-use-case/index.ts` | Implementação `CreateAudienceUseCase` |
+| `src/modules/audience/application/hooks/useCreateAudience.ts` | Hook `useCreateAudience` com `useMutation` + invalidação de cache |
+
+## 6. Arquivos Modificados
+
+| Arquivo | Alteração |
+|---------|-----------|
+| `src/modules/audience/domain/repositories/audience.repository.ts` | Adicionado `createAudience()` na interface `IAudienceRepository` |
+| `src/modules/audience/domain/use-cases/index.ts` | Export da nova interface e tipos |
+| `src/modules/audience/application/use-cases/index.ts` | Export da classe `CreateAudienceUseCase` |
+| `src/modules/audience/application/hooks/index.ts` | Export do hook `useCreateAudience` |
+| `src/modules/audience/infra/repositories/audience.repository.ts` | Implementação de `createAudience()` com `httpClient.post()` |
+| `src/modules/shared/infra/container/types.ts` | Symbol `CreateAudienceUseCase` |
+| `src/modules/shared/infra/container/container.ts` | Binding do `CreateAudienceUseCase` no Inversify |
+| `src/pages/Audiences.tsx` | Integração com `useCreateAudience` substituindo o `console.log` |
+
+---
+
+## 7. Dependências
+
+Nenhuma nova dependência adicionada. Utiliza as bibliotecas já existentes:
+- `@tanstack/react-query` (useMutation)
+- `ky` (HTTP client)
+- `inversify` (DI container)
+- `zustand` (store existente)

--- a/src/modules/audience/application/hooks/index.ts
+++ b/src/modules/audience/application/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useListGenericAudiences, AUDIENCES_QUERY_KEY } from './useListGenericAudiences'
 export { useFetchDefaultAudiences, DEFAULT_AUDIENCES_QUERY_KEY } from './useFetchDefaultAudiences'
 export { useGetAudienceTemplateById, AUDIENCE_TEMPLATE_QUERY_KEY } from './useGetAudienceTemplateById'
+export { useCreateAudience } from './useCreateAudience'

--- a/src/modules/audience/application/hooks/useCreateAudience.ts
+++ b/src/modules/audience/application/hooks/useCreateAudience.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { ICreateAudienceUseCase, CreateAudienceParams } from '@/modules/audience/domain/use-cases'
+import { AUDIENCES_QUERY_KEY } from './useListGenericAudiences'
+
+const createAudienceUseCase = container.get<ICreateAudienceUseCase>(TYPES.CreateAudienceUseCase)
+
+export function useCreateAudience() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (params: CreateAudienceParams) =>
+      createAudienceUseCase.execute(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: AUDIENCES_QUERY_KEY })
+    },
+  })
+}

--- a/src/modules/audience/application/use-cases/create-audience-use-case/index.ts
+++ b/src/modules/audience/application/use-cases/create-audience-use-case/index.ts
@@ -1,0 +1,10 @@
+import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
+import type { ICreateAudienceUseCase, CreateAudienceParams, CreateAudienceResult } from '@/modules/audience/domain/use-cases'
+
+export class CreateAudienceUseCase implements ICreateAudienceUseCase {
+  constructor(private readonly audienceRepository: IAudienceRepository) {}
+
+  async execute(params: CreateAudienceParams): Promise<CreateAudienceResult> {
+    return this.audienceRepository.createAudience(params)
+  }
+}

--- a/src/modules/audience/application/use-cases/index.ts
+++ b/src/modules/audience/application/use-cases/index.ts
@@ -1,3 +1,4 @@
 export { ListGenericAudiencesUseCases } from './list-generic-audiences-use-cases'
 export { FetchDefaultAudiencesUseCase } from './fetch-default-audiences-use-case'
 export { GetAudienceTemplateByIdUseCase } from './get-audience-template-by-id-use-case'
+export { CreateAudienceUseCase } from './create-audience-use-case'

--- a/src/modules/audience/domain/repositories/audience.repository.ts
+++ b/src/modules/audience/domain/repositories/audience.repository.ts
@@ -1,9 +1,11 @@
 import type { Audience } from "../entities/Audience.entity";
 import type { AudienceTemplate } from "../entities/AudienceTemplate.entity";
+import type { CreateAudienceParams, CreateAudienceResult } from "../use-cases/create-audience.use-case";
 
 export interface IAudienceRepository {
   listGenericAudiences(): Promise<Audience[]>
   getAudienceById(id: string): Promise<Audience | null>
   fetchDefaultAudiences(): Promise<AudienceTemplate[]>
   getAudienceTemplateById(id: string): Promise<AudienceTemplate | null>
+  createAudience(params: CreateAudienceParams): Promise<CreateAudienceResult>
 }

--- a/src/modules/audience/domain/use-cases/create-audience.use-case.ts
+++ b/src/modules/audience/domain/use-cases/create-audience.use-case.ts
@@ -1,0 +1,17 @@
+export interface CreateAudienceParams {
+  name: string
+  description: string
+  subreddit_names: string[]
+}
+
+export interface CreateAudienceResult {
+  id: string
+  name: string
+  description: string
+  user_id: string
+  communities_count: number
+}
+
+export interface ICreateAudienceUseCase {
+  execute(params: CreateAudienceParams): Promise<CreateAudienceResult>
+}

--- a/src/modules/audience/domain/use-cases/index.ts
+++ b/src/modules/audience/domain/use-cases/index.ts
@@ -1,3 +1,4 @@
 export type { IListGenericAudiencesUseCase } from './list-generic-audiences.use-case'
 export type { IFetchDefaultAudiencesUseCase } from './fetch-default-audiences.use-case'
 export type { IGetAudienceTemplateByIdUseCase } from './get-audience-template-by-id.use-case'
+export type { ICreateAudienceUseCase, CreateAudienceParams, CreateAudienceResult } from './create-audience.use-case'

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -2,6 +2,7 @@ import type { HttpClient } from '@/modules/shared'
 import { Audience } from '../../domain/entities/Audience.entity'
 import { AudienceTemplate } from '../../domain/entities/AudienceTemplate.entity'
 import type { IAudienceRepository } from '../../domain/repositories/audience.repository'
+import type { CreateAudienceParams, CreateAudienceResult } from '../../domain/use-cases/create-audience.use-case'
 
 interface AudienceTemplateResponse {
   id: string
@@ -84,5 +85,9 @@ export class AudienceRepository implements IAudienceRepository {
     } catch {
       return null
     }
+  }
+
+  async createAudience(params: CreateAudienceParams): Promise<CreateAudienceResult> {
+    return this.httpClient.post<CreateAudienceResult>('audiences', params)
   }
 }

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -3,8 +3,8 @@ import { TYPES } from './types'
 import { KyHttpClient, type HttpClient } from '../http'
 import { AudienceRepository } from '@/modules/audience/infra/repositories'
 import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
-import { ListGenericAudiencesUseCases, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase } from '@/modules/audience/application/use-cases'
-import type { IListGenericAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase } from '@/modules/audience/domain/use-cases'
+import { ListGenericAudiencesUseCases, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase } from '@/modules/audience/application/use-cases'
+import type { IListGenericAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase } from '@/modules/audience/domain/use-cases'
 import { CommunityRepository } from '@/modules/community/infra/repositories'
 import type { ICommunityRepository } from '@/modules/community/domain/repositories'
 import { BrowseCommunitiesUseCase } from '@/modules/community/application/use-cases'
@@ -36,6 +36,11 @@ container.bind<IFetchDefaultAudiencesUseCase>(TYPES.FetchDefaultAudiencesUseCase
 container.bind<IGetAudienceTemplateByIdUseCase>(TYPES.GetAudienceTemplateByIdUseCase).toDynamicValue(() => {
   const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
   return new GetAudienceTemplateByIdUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<ICreateAudienceUseCase>(TYPES.CreateAudienceUseCase).toDynamicValue(() => {
+  const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
+  return new CreateAudienceUseCase(audienceRepository)
 }).inSingletonScope()
 
 container.bind<ICommunityRepository>(TYPES.CommunityRepository).toDynamicValue(() => {

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -4,6 +4,7 @@ export const TYPES = {
   ListGenericAudiencesUseCase: Symbol.for('ListGenericAudiencesUseCase'),
   FetchDefaultAudiencesUseCase: Symbol.for('FetchDefaultAudiencesUseCase'),
   GetAudienceTemplateByIdUseCase: Symbol.for('GetAudienceTemplateByIdUseCase'),
+  CreateAudienceUseCase: Symbol.for('CreateAudienceUseCase'),
   CommunityRepository: Symbol.for('CommunityRepository'),
   BrowseCommunitiesUseCase: Symbol.for('BrowseCommunitiesUseCase'),
   AuthRepository: Symbol.for('AuthRepository'),

--- a/src/pages/Audiences.tsx
+++ b/src/pages/Audiences.tsx
@@ -4,7 +4,7 @@ import { gsap } from '@/lib/gsap'
 import { useReducedMotion } from '@/hooks'
 import { AudienceCard, AddAudienceCard } from '@/components/audiences'
 import { SelectAudienceModal } from '@/components/shared'
-import { useFetchDefaultAudiences } from '@/modules/audience/application/hooks'
+import { useFetchDefaultAudiences, useCreateAudience } from '@/modules/audience/application/hooks'
 import { useCreateAudienceStore } from '@/modules/audience/application/store'
 
 type SortOption = 'subreddits' | 'name'
@@ -17,6 +17,7 @@ export function Audiences() {
   const [sortBy, setSortBy] = useState<SortOption>('name')
   const [viewMode, setViewMode] = useState<ViewMode>('grid')
   const { openModal, closeModal } = useCreateAudienceStore()
+  const createAudienceMutation = useCreateAudience()
 
   const { data: templates } = useFetchDefaultAudiences()
   
@@ -177,9 +178,20 @@ export function Audiences() {
 
       <SelectAudienceModal
         onCreateAudience={(name, selectedCommunityNames) => {
-          console.log('Creating audience:', name, 'with communities:', selectedCommunityNames)
-          closeModal()
+          createAudienceMutation.mutate(
+            {
+              name,
+              description: '',
+              subreddit_names: selectedCommunityNames,
+            },
+            {
+              onSuccess: () => {
+                closeModal()
+              },
+            }
+          )
         }}
+        isLoading={createAudienceMutation.isPending}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- Implement `POST /audiences` API integration following the existing DDD + Clean Architecture pattern
- Add full stack: domain interface, application use case, infra repository, DI binding, React Query mutation hook
- Integrate in `SelectAudienceModal` and `Audiences` page with loading state and auto-close on success
- Payload: `{ name, description, subreddit_names }` -> Response: `{ id, name, description, user_id, communities_count }`

## Test plan
- [ ] Open the Audiences page and click "Add Audience"
- [ ] Select communities, enter a name, and click "Create Audience"
- [ ] Verify the `POST /audiences` request is sent with correct payload and Bearer token
- [ ] Verify the modal closes on success (201) and the audience list refreshes
- [ ] Verify loading spinner appears while the request is in progress
- [ ] Verify error scenarios (network failure, 401) are handled gracefully

Closes #20