### PR TITLE
fix: redirect authenticated users away from login page

### DIFF
--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -38,6 +38,20 @@ function AuthRedirect() {
   )
 }
 
+function RedirectIfAuthenticated({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, isHydrated } = useAuthStore()
+
+  if (!isHydrated) {
+    return <PageLoader />
+  }
+
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />
+  }
+
+  return <>{children}</>
+}
+
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isHydrated } = useAuthStore()
 
@@ -60,9 +74,11 @@ const router = createBrowserRouter([
   {
     path: '/login',
     element: (
-      <Suspense fallback={<PageLoader />}>
-        <LoginPage />
-      </Suspense>
+      <RedirectIfAuthenticated>
+        <Suspense fallback={<PageLoader />}>
+          <LoginPage />
+        </Suspense>
+      </RedirectIfAuthenticated>
     ),
   },
   {


### PR DESCRIPTION
## Summary
- Adiciona o guard `RedirectIfAuthenticated` na rota `/login` para redirecionar usuários autenticados automaticamente para `/dashboard`
- Impede que um usuário logado acesse a tela de login sem se deslogar

## Causa Raiz
A rota `/login` não possuía nenhum guard para verificar se o usuário já estava autenticado, permitindo acesso à tela de login mesmo com sessão ativa.

## Solução
- Criado componente `RedirectIfAuthenticated` em `src/router/index.tsx` seguindo o mesmo padrão do `RequireAuth`
- O guard verifica `isHydrated` e `isAuthenticated` do Zustand store antes de renderizar a página

## Test plan
- [ ] Fazer login na aplicação
- [ ] Navegar manualmente para `/login` — deve redirecionar para `/dashboard`
- [ ] Fazer logout e navegar para `/login` — deve exibir a página de login normalmente
- [ ] Acessar `/login` com token expirado — deve exibir a página de login

Closes #26