### PR TITLE
feat: wire up community suggestion action buttons

### DIFF
--- a/docs/issue-41-community-suggestion-actions.md
+++ b/docs/issue-41-community-suggestion-actions.md
@@ -1,0 +1,121 @@
+# Issue #41 — Conectar botoes "Add to Audience" e "Not Relevant" nas sugestoes de comunidades
+
+**Issue:** https://github.com/robsonmvieira/oraculo-frontend/issues/41
+**PR:** https://github.com/robsonmvieira/oraculo-frontend/pull/42
+**Branch:** `feat/community-suggestion-actions`
+**Status:** Implementada
+
+---
+
+## 1. Motivacao
+
+Na aba Subreddits da pagina de detalhes da audiencia, a secao "Similar Communities" exibia cards de sugestao com dois botoes — **Add to Audience** e **Not Relevant** — que nao tinham nenhuma acao conectada. Eram puramente visuais.
+
+O objetivo era conectar ambos os botoes a logica de negocio:
+- **Add to Audience** → adicionar a comunidade a audiencia do usuario via endpoint existente
+- **Not Relevant** → enviar feedback negativo ao backend para que a comunidade nao apareca mais nas sugestoes
+
+---
+
+## 2. Decisoes de Design
+
+### 2.1 Novo use-case: MarkCommunityNotRelevant
+
+Criado um use-case completo seguindo o padrao Clean Architecture do projeto (domain interface → application implementation → repository → DI container), pois a acao de "Not Relevant" nao existia no sistema.
+
+### 2.2 Reutilizacao do AddCommunityToAudience
+
+O botao "Add to Audience" reutiliza o hook `useAddCommunityToAudience` ja existente, sem necessidade de criar infraestrutura nova.
+
+### 2.3 Optimistic Update para Not Relevant
+
+Como o endpoint `POST /feedback/community` pode demorar, foi implementado optimistic update com React Query:
+- O card e removido instantaneamente da lista ao clicar
+- Se a requisicao falhar, o card e restaurado (rollback) e um toast de erro aparece
+- Isso previne cliques duplicados e melhora a experiencia do usuario
+
+### 2.4 Alinhamento dos cards com flex
+
+Os cards de sugestao estavam desalinhados quando as descricoes tinham tamanhos diferentes. Corrigido com `flex flex-col` no container, `flex-1` na descricao e `mt-auto` nos botoes.
+
+---
+
+## 3. Solucao Implementada
+
+### 3.1 Endpoints utilizados
+
+| Metodo | URL | Descricao |
+|--------|-----|-----------|
+| POST | `/audiences/{audience_id}/communities` | Adicionar comunidade a audiencia (ja existia) |
+| POST | `/feedback/community` | Enviar feedback de "not relevant" (novo) |
+
+**Body do feedback:**
+
+```json
+{
+  "subreddit_name": "emailmarketing",
+  "feedback": "not_relevant",
+  "context_type": "audience",
+  "context_id": "uuid-da-audiencia"
+}
+```
+
+### 3.2 Arquitetura — Fluxo de dados
+
+```
+AudienceDetail Page (UI)
+  ├── handleAddToAudience(subredditName)
+  │     └── useAddCommunityToAudience → AddCommunityToAudienceUseCase
+  │           └── AudienceRepository.addCommunityToAudience()
+  │                 └── POST /audiences/{id}/communities
+  │
+  └── handleMarkNotRelevant(subredditName)
+        └── useMarkCommunityNotRelevant (optimistic update)
+              └── MarkCommunityNotRelevantUseCase
+                    └── AudienceRepository.markCommunityNotRelevant()
+                          └── POST /feedback/community
+```
+
+### 3.3 Propagacao de callbacks na arvore de componentes
+
+```
+AudienceDetail
+  └── AudienceDetailTabs (onAddToAudience, onMarkNotRelevant)
+        └── SubredditsTabContent (onAddToAudience, onMarkNotRelevant)
+              └── SimilarCommunitiesGrid (onAddToAudience, onMarkNotRelevant)
+                    └── Buttons com onClick
+```
+
+---
+
+## 4. Arquivos Criados
+
+| Arquivo | Descricao |
+|---------|-----------|
+| `src/modules/audience/domain/use-cases/mark-community-not-relevant.use-case.ts` | Interface do domain: `IMarkCommunityNotRelevantUseCase` e `MarkCommunityNotRelevantParams` |
+| `src/modules/audience/application/use-cases/mark-community-not-relevant-use-case/index.ts` | Implementacao do use-case |
+| `src/modules/audience/application/hooks/useMarkCommunityNotRelevant.ts` | Hook React Query com `useMutation` e optimistic update |
+
+---
+
+## 5. Arquivos Modificados
+
+| Arquivo | Alteracao |
+|---------|-----------|
+| `src/modules/audience/domain/use-cases/index.ts` | Export dos novos tipos |
+| `src/modules/audience/domain/repositories/audience.repository.ts` | Novo metodo `markCommunityNotRelevant` na interface |
+| `src/modules/audience/infra/repositories/audience.repository.ts` | Implementacao do `markCommunityNotRelevant` com POST |
+| `src/modules/audience/application/use-cases/index.ts` | Export do `MarkCommunityNotRelevantUseCase` |
+| `src/modules/audience/application/hooks/index.ts` | Export do `useMarkCommunityNotRelevant` |
+| `src/modules/shared/infra/container/types.ts` | Novo symbol `MarkCommunityNotRelevantUseCase` |
+| `src/modules/shared/infra/container/container.ts` | Binding do use-case no container Inversify |
+| `src/components/audiences/detail/SimilarCommunitiesGrid.tsx` | Props `onAddToAudience` e `onMarkNotRelevant`, onClick nos botoes, fix de alinhamento com flex |
+| `src/components/audiences/detail/SubredditsTabContent.tsx` | Repasse dos callbacks para `SimilarCommunitiesGrid` |
+| `src/components/audiences/detail/AudienceDetailTabs.tsx` | Repasse dos callbacks para `SubredditsTabContent` |
+| `src/pages/AudienceDetail.tsx` | Import dos hooks, criacao dos handlers, passagem de props |
+
+---
+
+## 6. Dependencias
+
+Nenhuma nova dependencia adicionada.

--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -26,6 +26,8 @@ export interface AudienceDetailTabsProps {
   similarCommunities: SimilarCommunity[]
   isLoadingSuggestions: boolean
   onAddCommunity: () => void
+  onAddToAudience?: (subredditName: string) => void
+  onMarkNotRelevant?: (subredditName: string) => void
 }
 
 export function AudienceDetailTabs({
@@ -39,6 +41,8 @@ export function AudienceDetailTabs({
   similarCommunities,
   isLoadingSuggestions,
   onAddCommunity,
+  onAddToAudience,
+  onMarkNotRelevant,
 }: Readonly<AudienceDetailTabsProps>) {
   const [activeTab, setActiveTab] = useState('search')
   const [selectedTopic, setSelectedTopic] = useState<TopicDetail | null>(null)
@@ -90,6 +94,8 @@ export function AudienceDetailTabs({
           audienceName={audienceName}
           similarCommunities={similarCommunities}
           isLoadingSuggestions={isLoadingSuggestions}
+          onAddToAudience={onAddToAudience}
+          onMarkNotRelevant={onMarkNotRelevant}
         />
       </TabsContent>
 

--- a/src/components/audiences/detail/SimilarCommunitiesGrid.tsx
+++ b/src/components/audiences/detail/SimilarCommunitiesGrid.tsx
@@ -13,6 +13,8 @@ export interface SimilarCommunity {
 export interface SimilarCommunitiesGridProps {
   communities: readonly SimilarCommunity[]
   isLoading?: boolean
+  onAddToAudience?: (subredditName: string) => void
+  onMarkNotRelevant?: (subredditName: string) => void
 }
 
 function SkeletonCard() {
@@ -42,7 +44,7 @@ function SkeletonCard() {
   )
 }
 
-export function SimilarCommunitiesGrid({ communities, isLoading }: Readonly<SimilarCommunitiesGridProps>) {
+export function SimilarCommunitiesGrid({ communities, isLoading, onAddToAudience, onMarkNotRelevant }: Readonly<SimilarCommunitiesGridProps>) {
   if (isLoading) {
     return (
       <div>
@@ -82,7 +84,7 @@ export function SimilarCommunitiesGrid({ communities, isLoading }: Readonly<Simi
         {communities.map((subreddit) => (
           <div
             key={subreddit.id}
-            className="bg-white dark:bg-zinc-900 rounded-2xl p-5"
+            className="bg-white dark:bg-zinc-900 rounded-2xl p-5 flex flex-col"
           >
             <div className="flex items-start gap-4 mb-3">
               <div className="w-14 h-14 rounded-full bg-gray-200 dark:bg-zinc-700 flex items-center justify-center text-lg font-medium text-gray-600 dark:text-zinc-300 shrink-0">
@@ -116,7 +118,7 @@ export function SimilarCommunitiesGrid({ communities, isLoading }: Readonly<Simi
               </span>
             </div>
 
-            <div className="mb-4">
+            <div className="mb-4 flex-1">
               <p className="text-[10px] font-medium text-gray-500 dark:text-zinc-500 uppercase tracking-wide mb-1">
                 Description
               </p>
@@ -125,11 +127,17 @@ export function SimilarCommunitiesGrid({ communities, isLoading }: Readonly<Simi
               </p>
             </div>
 
-            <div className="flex gap-3">
-              <button className="cursor-pointer flex-1 py-2.5 text-sm font-medium text-zinc-900 bg-cyan-400 hover:bg-cyan-500 rounded-lg transition-colors">
+            <div className="flex gap-3 mt-auto">
+              <button
+                className="cursor-pointer flex-1 py-2.5 text-sm font-medium text-zinc-900 bg-cyan-400 hover:bg-cyan-500 rounded-lg transition-colors"
+                onClick={() => onAddToAudience?.(subreddit.id)}
+              >
                 Add to Audience
               </button>
-              <button className="cursor-pointer flex-1 py-2.5 text-sm font-medium text-gray-300 dark:text-zinc-400 bg-gray-700 dark:bg-zinc-700 hover:bg-gray-600 dark:hover:bg-zinc-600 rounded-lg transition-colors">
+              <button
+                className="cursor-pointer flex-1 py-2.5 text-sm font-medium text-gray-300 dark:text-zinc-400 bg-gray-700 dark:bg-zinc-700 hover:bg-gray-600 dark:hover:bg-zinc-600 rounded-lg transition-colors"
+                onClick={() => onMarkNotRelevant?.(subreddit.id)}
+              >
                 Not Relevant
               </button>
             </div>

--- a/src/components/audiences/detail/SubredditsTabContent.tsx
+++ b/src/components/audiences/detail/SubredditsTabContent.tsx
@@ -10,6 +10,8 @@ export interface SubredditsTabContentProps {
   audienceName: string
   similarCommunities: readonly SimilarCommunity[]
   isLoadingSuggestions?: boolean
+  onAddToAudience?: (subredditName: string) => void
+  onMarkNotRelevant?: (subredditName: string) => void
 }
 
 export function SubredditsTabContent({
@@ -18,6 +20,8 @@ export function SubredditsTabContent({
   audienceName,
   similarCommunities,
   isLoadingSuggestions,
+  onAddToAudience,
+  onMarkNotRelevant,
 }: Readonly<SubredditsTabContentProps>) {
   return (
     <div className="space-y-8">
@@ -46,7 +50,7 @@ export function SubredditsTabContent({
         </div>
       </div>
 
-      <SimilarCommunitiesGrid communities={similarCommunities} isLoading={isLoadingSuggestions} />
+      <SimilarCommunitiesGrid communities={similarCommunities} isLoading={isLoadingSuggestions} onAddToAudience={onAddToAudience} onMarkNotRelevant={onMarkNotRelevant} />
     </div>
   )
 }

--- a/src/modules/audience/application/hooks/index.ts
+++ b/src/modules/audience/application/hooks/index.ts
@@ -9,3 +9,4 @@ export { useRemoveCommunityFromAudience } from './useRemoveCommunityFromAudience
 export { useGetAudienceSuggestions, AUDIENCE_SUGGESTIONS_QUERY_KEY } from './useGetAudienceSuggestions'
 export { useDeleteAudience } from './useDeleteAudience'
 export { useGetAudienceKeywords, AUDIENCE_KEYWORDS_QUERY_KEY } from './useGetAudienceKeywords'
+export { useMarkCommunityNotRelevant } from './useMarkCommunityNotRelevant'

--- a/src/modules/audience/application/hooks/useMarkCommunityNotRelevant.ts
+++ b/src/modules/audience/application/hooks/useMarkCommunityNotRelevant.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IMarkCommunityNotRelevantUseCase, MarkCommunityNotRelevantParams, GetAudienceSuggestionsResult } from '@/modules/audience/domain/use-cases'
+import { AUDIENCE_SUGGESTIONS_QUERY_KEY } from './useGetAudienceSuggestions'
+
+const markCommunityNotRelevantUseCase = container.get<IMarkCommunityNotRelevantUseCase>(TYPES.MarkCommunityNotRelevantUseCase)
+
+export function useMarkCommunityNotRelevant() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (params: MarkCommunityNotRelevantParams) =>
+      markCommunityNotRelevantUseCase.execute(params),
+    onMutate: async (variables) => {
+      const queryKey = [...AUDIENCE_SUGGESTIONS_QUERY_KEY, variables.audienceId]
+
+      try {
+        await queryClient.cancelQueries({ queryKey })
+
+        const previous = queryClient.getQueryData<GetAudienceSuggestionsResult>(queryKey)
+
+        if (previous?.suggestions) {
+          queryClient.setQueryData<GetAudienceSuggestionsResult>(queryKey, {
+            ...previous,
+            suggestions: previous.suggestions.filter(
+              (s) => s.subredditName !== variables.subredditName
+            ),
+            filteredByFeedback: (previous.filteredByFeedback ?? 0) + 1,
+          })
+        }
+
+        return { previous, queryKey }
+      } catch {
+        return { previous: undefined, queryKey }
+      }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(context.queryKey, context.previous)
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      queryClient.invalidateQueries({ queryKey: [...AUDIENCE_SUGGESTIONS_QUERY_KEY, variables.audienceId] })
+    },
+  })
+}

--- a/src/modules/audience/application/use-cases/index.ts
+++ b/src/modules/audience/application/use-cases/index.ts
@@ -9,3 +9,4 @@ export { RemoveCommunityFromAudienceUseCase } from './remove-community-from-audi
 export { GetAudienceSuggestionsUseCase } from './get-audience-suggestions-use-case'
 export { DeleteAudienceUseCase } from './delete-audience-use-case'
 export { GetAudienceKeywordsUseCase } from './get-audience-keywords-use-case'
+export { MarkCommunityNotRelevantUseCase } from './mark-community-not-relevant-use-case'

--- a/src/modules/audience/application/use-cases/mark-community-not-relevant-use-case/index.ts
+++ b/src/modules/audience/application/use-cases/mark-community-not-relevant-use-case/index.ts
@@ -1,0 +1,10 @@
+import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
+import type { IMarkCommunityNotRelevantUseCase, MarkCommunityNotRelevantParams } from '@/modules/audience/domain/use-cases'
+
+export class MarkCommunityNotRelevantUseCase implements IMarkCommunityNotRelevantUseCase {
+  constructor(private readonly audienceRepository: IAudienceRepository) {}
+
+  async execute(params: MarkCommunityNotRelevantParams): Promise<void> {
+    return this.audienceRepository.markCommunityNotRelevant(params)
+  }
+}

--- a/src/modules/audience/domain/repositories/audience.repository.ts
+++ b/src/modules/audience/domain/repositories/audience.repository.ts
@@ -7,6 +7,7 @@ import type { RemoveCommunityFromAudienceParams } from "../use-cases/remove-comm
 import type { GetAudienceSuggestionsParams, GetAudienceSuggestionsResult } from "../use-cases/get-audience-suggestions.use-case";
 import type { DeleteAudienceParams, DeleteAudienceResult } from "../use-cases/delete-audience.use-case";
 import type { GetAudienceKeywordsParams, GetAudienceKeywordsResult } from "../use-cases/get-audience-keywords.use-case";
+import type { MarkCommunityNotRelevantParams } from "../use-cases/mark-community-not-relevant.use-case";
 
 export interface IAudienceRepository {
   listUserAudiences(): Promise<Audience[]>
@@ -20,4 +21,5 @@ export interface IAudienceRepository {
   getAudienceSuggestions(params: GetAudienceSuggestionsParams): Promise<GetAudienceSuggestionsResult>
   deleteAudience(params: DeleteAudienceParams): Promise<DeleteAudienceResult>
   getAudienceKeywords(params: GetAudienceKeywordsParams): Promise<GetAudienceKeywordsResult>
+  markCommunityNotRelevant(params: MarkCommunityNotRelevantParams): Promise<void>
 }

--- a/src/modules/audience/domain/use-cases/index.ts
+++ b/src/modules/audience/domain/use-cases/index.ts
@@ -9,3 +9,4 @@ export type { IRemoveCommunityFromAudienceUseCase, RemoveCommunityFromAudiencePa
 export type { IGetAudienceSuggestionsUseCase, GetAudienceSuggestionsParams, AudienceSuggestion, GetAudienceSuggestionsResult } from './get-audience-suggestions.use-case'
 export type { IDeleteAudienceUseCase, DeleteAudienceParams, DeleteAudienceResult } from './delete-audience.use-case'
 export type { IGetAudienceKeywordsUseCase, GetAudienceKeywordsParams, GetAudienceKeywordsResult } from './get-audience-keywords.use-case'
+export type { IMarkCommunityNotRelevantUseCase, MarkCommunityNotRelevantParams } from './mark-community-not-relevant.use-case'

--- a/src/modules/audience/domain/use-cases/mark-community-not-relevant.use-case.ts
+++ b/src/modules/audience/domain/use-cases/mark-community-not-relevant.use-case.ts
@@ -1,0 +1,8 @@
+export interface MarkCommunityNotRelevantParams {
+  subredditName: string
+  audienceId: string
+}
+
+export interface IMarkCommunityNotRelevantUseCase {
+  execute(params: MarkCommunityNotRelevantParams): Promise<void>
+}

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -9,6 +9,7 @@ import type { RemoveCommunityFromAudienceParams } from '../../domain/use-cases/r
 import type { GetAudienceSuggestionsParams, GetAudienceSuggestionsResult } from '../../domain/use-cases/get-audience-suggestions.use-case'
 import type { DeleteAudienceParams, DeleteAudienceResult } from '../../domain/use-cases/delete-audience.use-case'
 import type { GetAudienceKeywordsParams, GetAudienceKeywordsResult } from '../../domain/use-cases/get-audience-keywords.use-case'
+import type { MarkCommunityNotRelevantParams } from '../../domain/use-cases/mark-community-not-relevant.use-case'
 import { Keyword } from '../../domain/entities/Keyword.entity'
 
 interface AudienceTemplateResponse {
@@ -227,5 +228,14 @@ export class AudienceRepository implements IAudienceRepository {
       totalFound: response.total_found,
       filteredByFeedback: response.filtered_by_feedback,
     }
+  }
+
+  async markCommunityNotRelevant(params: MarkCommunityNotRelevantParams): Promise<void> {
+    await this.httpClient.post('feedback/community', {
+      subreddit_name: params.subredditName,
+      feedback: 'not_relevant',
+      context_type: 'audience',
+      context_id: params.audienceId,
+    })
   }
 }

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -3,8 +3,8 @@ import { TYPES } from './types'
 import { KyHttpClient, type HttpClient } from '../http'
 import { AudienceRepository } from '@/modules/audience/infra/repositories'
 import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
-import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase } from '@/modules/audience/application/use-cases'
-import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase } from '@/modules/audience/domain/use-cases'
+import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase, MarkCommunityNotRelevantUseCase } from '@/modules/audience/application/use-cases'
+import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase, IMarkCommunityNotRelevantUseCase } from '@/modules/audience/domain/use-cases'
 import { CommunityRepository } from '@/modules/community/infra/repositories'
 import type { ICommunityRepository } from '@/modules/community/domain/repositories'
 import { BrowseCommunitiesUseCase } from '@/modules/community/application/use-cases'
@@ -76,6 +76,11 @@ container.bind<IDeleteAudienceUseCase>(TYPES.DeleteAudienceUseCase).toDynamicVal
 container.bind<IGetAudienceKeywordsUseCase>(TYPES.GetAudienceKeywordsUseCase).toDynamicValue(() => {
   const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
   return new GetAudienceKeywordsUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<IMarkCommunityNotRelevantUseCase>(TYPES.MarkCommunityNotRelevantUseCase).toDynamicValue(() => {
+  const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
+  return new MarkCommunityNotRelevantUseCase(audienceRepository)
 }).inSingletonScope()
 
 container.bind<ICommunityRepository>(TYPES.CommunityRepository).toDynamicValue(() => {

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -12,6 +12,7 @@ export const TYPES = {
   GetAudienceSuggestionsUseCase: Symbol.for('GetAudienceSuggestionsUseCase'),
   DeleteAudienceUseCase: Symbol.for('DeleteAudienceUseCase'),
   GetAudienceKeywordsUseCase: Symbol.for('GetAudienceKeywordsUseCase'),
+  MarkCommunityNotRelevantUseCase: Symbol.for('MarkCommunityNotRelevantUseCase'),
   CommunityRepository: Symbol.for('CommunityRepository'),
   BrowseCommunitiesUseCase: Symbol.for('BrowseCommunitiesUseCase'),
   AuthRepository: Symbol.for('AuthRepository'),

--- a/src/pages/AudienceDetail.tsx
+++ b/src/pages/AudienceDetail.tsx
@@ -8,7 +8,7 @@ import {
   AudienceDetailTabs,
   DeleteAudienceModal,
 } from '@/components/audiences/detail'
-import { useGetAudienceTemplateById, useGetAudienceById, useUpdateAudience, useDeleteAudience, useGetAudienceKeywords, useGetAudienceSuggestions } from '@/modules/audience/application/hooks'
+import { useGetAudienceTemplateById, useGetAudienceById, useUpdateAudience, useDeleteAudience, useGetAudienceKeywords, useGetAudienceSuggestions, useAddCommunityToAudience, useMarkCommunityNotRelevant } from '@/modules/audience/application/hooks'
 import { useCreateAudienceStore } from '@/modules/audience/application/store'
 import { toast } from '@/hooks'
 import { SelectAudienceModal } from '@/components/shared'
@@ -28,6 +28,8 @@ export function AudienceDetail() {
   const { openEditModal, closeModal } = useCreateAudienceStore()
   const updateAudienceMutation = useUpdateAudience()
   const deleteAudienceMutation = useDeleteAudience()
+  const addCommunityMutation = useAddCommunityToAudience()
+  const markNotRelevantMutation = useMarkCommunityNotRelevant()
 
   const isUserAudience = searchParams.get('type') === 'user'
 
@@ -135,6 +137,43 @@ export function AudienceDetail() {
     openEditModal(audienceId, audienceName, communities)
   }
 
+  const handleAddToAudience = (subredditName: string) => {
+    addCommunityMutation.mutate(
+      { audienceId, subreddit_name: subredditName },
+      {
+        onSuccess: () => {
+          toast({
+            title: 'Community added',
+            description: `${subredditName} has been added to your audience.`,
+            variant: 'success',
+          })
+        },
+        onError: () => {
+          toast({
+            title: 'Failed to add community',
+            description: 'Something went wrong. Please try again.',
+            variant: 'destructive',
+          })
+        },
+      }
+    )
+  }
+
+  const handleMarkNotRelevant = (subredditName: string) => {
+    markNotRelevantMutation.mutate(
+      { subredditName, audienceId },
+      {
+        onError: () => {
+          toast({
+            title: 'Failed to mark as not relevant',
+            description: 'Something went wrong. Please try again.',
+            variant: 'destructive',
+          })
+        },
+      }
+    )
+  }
+
   const handleDelete = () => {
     deleteAudienceMutation.mutate(
       { audienceId },
@@ -181,6 +220,8 @@ export function AudienceDetail() {
           similarCommunities={similarCommunities}
           isLoadingSuggestions={isLoadingSuggestions}
           onAddCommunity={handleEdit}
+          onAddToAudience={handleAddToAudience}
+          onMarkNotRelevant={handleMarkNotRelevant}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Connect **Add to Audience** button to `POST /audiences/:id/communities` endpoint
- Connect **Not Relevant** button to new `POST /feedback/community` endpoint with `not_relevant` feedback
- Implement `MarkCommunityNotRelevant` use-case across all Clean Architecture layers (domain → application → infra → DI)
- Add optimistic update for "Not Relevant" — card removes instantly from UI, rolls back on error
- Fix card alignment in `SimilarCommunitiesGrid` using flex layout for dynamic description text

## Test plan
- [ ] Navigate to audience detail page, Subreddits tab
- [ ] Click "Add to Audience" on a suggestion card → community is added, success toast shown
- [ ] Click "Not Relevant" on a suggestion card → card disappears immediately (optimistic), POST sent to backend
- [ ] Verify error toast appears if backend returns an error
- [ ] Verify cards stay aligned when descriptions have different lengths

Closes #41