### PR TITLE
feat: connect topics tab to backend API

### DIFF
--- a/docs/issue-43-connect-topics-api.md
+++ b/docs/issue-43-connect-topics-api.md
@@ -27,9 +27,17 @@ A entidade `Topic` armazena todos os campos do backend. No componente, ela e tra
 - **TopicTableItem** — para a tabela (id, name, growth, frequency, frequencyUnit, subreddits como string[])
 - **TopicDetail** — para o painel de detalhes ao clicar (inclui description e subreddits com postCount)
 
-### 2.3 Loading state
+### 2.3 Paginacao com infinite scroll
 
-Enquanto os dados sao carregados, um spinner e exibido no lugar da tabela de topicos, mantendo o padrao visual do projeto.
+O endpoint suporta paginacao via `?limit=200&offset=0`. Implementamos infinite scroll seguindo o padrao ja existente no projeto:
+- **Hook:** `useInfiniteQuery` do React Query (mesmo padrao de `useBrowseCommunities`)
+- **UI:** `IntersectionObserver` com elemento sentinel no final da lista (mesmo padrao de `SelectAudienceModal`)
+- **PAGE_SIZE:** 200 topicos por pagina
+- O repositorio calcula `hasMore` comparando `offset + topics.length < total_topics`
+
+### 2.4 Loading state
+
+Enquanto os dados sao carregados, um spinner e exibido no lugar da tabela de topicos, mantendo o padrao visual do projeto. Durante o carregamento de paginas adicionais (infinite scroll), um spinner menor aparece no final da lista.
 
 ---
 
@@ -39,7 +47,14 @@ Enquanto os dados sao carregados, um spinner e exibido no lugar da tabela de top
 
 | Metodo | URL | Descricao |
 |--------|-----|-----------|
-| GET | `/audiences/{audience_id}/topics` | Buscar topicos da audiencia |
+| GET | `/audiences/{audience_id}/topics?limit=200&offset=0` | Buscar topicos da audiencia com paginacao |
+
+**Query Params:**
+
+| Param | Tipo | Default | Descricao |
+|-------|------|---------|-----------|
+| `limit` | number | 200 | Quantidade de topicos por pagina |
+| `offset` | number | 0 | Offset para paginacao |
 
 **Response:**
 
@@ -71,11 +86,17 @@ Enquanto os dados sao carregados, um spinner e exibido no lugar da tabela de top
 
 ```
 AudienceDetail Page
-  └── useGetAudienceTopics(audienceId)
+  └── useGetAudienceTopics(audienceId)  [useInfiniteQuery, PAGE_SIZE=200]
         └── GetAudienceTopicsUseCase
-              └── AudienceRepository.getAudienceTopics()
-                    └── GET /audiences/{id}/topics
+              └── AudienceRepository.getAudienceTopics({ limit, offset })
+                    └── GET /audiences/{id}/topics?limit=200&offset=0
                           └── Mapeia snake_case → Topic entity
+                          └── Calcula hasMore: offset + topics.length < total_topics
+
+TopicsTable Component
+  └── IntersectionObserver (sentinelRef)
+        └── onLoadMore() → fetchNextPage()
+              └── Proxima pagina: offset += PAGE_SIZE
 ```
 
 ### 3.3 Mapeamento de campos API → UI
@@ -102,7 +123,7 @@ AudienceDetail Page
 | `src/modules/audience/domain/entities/Topic.entity.ts` | Entidade Topic com getters e toJSON |
 | `src/modules/audience/domain/use-cases/get-audience-topics.use-case.ts` | Interface `IGetAudienceTopicsUseCase`, params e result types |
 | `src/modules/audience/application/use-cases/get-audience-topics-use-case/index.ts` | Implementacao do use-case |
-| `src/modules/audience/application/hooks/useGetAudienceTopics.ts` | Hook React Query com `useQuery` |
+| `src/modules/audience/application/hooks/useGetAudienceTopics.ts` | Hook React Query com `useInfiniteQuery` e paginacao offset-based |
 
 ---
 
@@ -112,13 +133,14 @@ AudienceDetail Page
 |---------|-----------|
 | `src/modules/audience/domain/use-cases/index.ts` | Export dos novos tipos |
 | `src/modules/audience/domain/repositories/audience.repository.ts` | Novo metodo `getAudienceTopics` na interface |
-| `src/modules/audience/infra/repositories/audience.repository.ts` | Implementacao HTTP com interfaces de resposta API e mapeamento para entidade |
+| `src/modules/audience/infra/repositories/audience.repository.ts` | Implementacao HTTP com interfaces de resposta API, mapeamento para entidade, paginacao com `limit`/`offset` e calculo de `hasMore` |
 | `src/modules/audience/application/use-cases/index.ts` | Export do `GetAudienceTopicsUseCase` |
 | `src/modules/audience/application/hooks/index.ts` | Export do `useGetAudienceTopics` e `AUDIENCE_TOPICS_QUERY_KEY` |
 | `src/modules/shared/infra/container/types.ts` | Novo symbol `GetAudienceTopicsUseCase` |
 | `src/modules/shared/infra/container/container.ts` | Binding do use-case no container Inversify |
-| `src/pages/AudienceDetail.tsx` | Chamada do hook `useGetAudienceTopics`, passagem de props (topics, totalTopics, isLoadingTopics) |
-| `src/components/audiences/detail/AudienceDetailTabs.tsx` | Novas props, remocao do import de mock `topicsData`, mapeamento Topic entity → TopicTableItem/TopicDetail, loading state |
+| `src/pages/AudienceDetail.tsx` | Chamada do hook `useGetAudienceTopics` com `useInfiniteQuery`, `flatMap` das pages, passagem de props de paginacao |
+| `src/components/audiences/detail/AudienceDetailTabs.tsx` | Novas props (incluindo scroll), remocao do import de mock, mapeamento Topic entity → TopicTableItem/TopicDetail, loading state |
+| `src/components/audiences/detail/TopicsTable.tsx` | Novas props (onLoadMore, hasMore, isLoadingMore), IntersectionObserver com sentinel, scroll container com max-h-[900px] |
 
 ---
 

--- a/docs/issue-43-connect-topics-api.md
+++ b/docs/issue-43-connect-topics-api.md
@@ -1,0 +1,127 @@
+# Issue #43 — Conectar tab Topics na pagina de detalhes da audiencia com endpoint do backend
+
+**Issue:** https://github.com/robsonmvieira/oraculo-frontend/issues/43
+**PR:** https://github.com/robsonmvieira/oraculo-frontend/pull/44
+**Branch:** `feat/connect-topics-api`
+**Status:** Implementada
+
+---
+
+## 1. Motivacao
+
+A tab **Topics** na pagina de detalhes de uma audiencia exibia dados hardcoded importados de `src/data/audienceDetailMocks.ts`. O count no tab trigger estava fixo em `200`, e a lista de topicos era estatica, sem conexao com o backend.
+
+O objetivo era conectar a tab ao endpoint `GET /audiences/{audience_id}/topics` para exibir dados reais, seguindo o mesmo padrao Clean Architecture usado nas issues anteriores (#37 keywords, #39 suggestions, #41 actions).
+
+---
+
+## 2. Decisoes de Design
+
+### 2.1 Entidade Topic com mapeamento de periodo
+
+A API retorna `mention_period` como string (`"month"`, `"week"`, `"day"`), mas os componentes UI usam o formato abreviado (`"mo"`, `"week"`, `"day"`). O mapeamento e feito no componente `AudienceDetailTabs` ao transformar a entidade em `TopicTableItem` e `TopicDetail`.
+
+### 2.2 Mapeamento duplo: tabela e painel de detalhes
+
+A entidade `Topic` armazena todos os campos do backend. No componente, ela e transformada em dois formatos:
+- **TopicTableItem** — para a tabela (id, name, growth, frequency, frequencyUnit, subreddits como string[])
+- **TopicDetail** — para o painel de detalhes ao clicar (inclui description e subreddits com postCount)
+
+### 2.3 Loading state
+
+Enquanto os dados sao carregados, um spinner e exibido no lugar da tabela de topicos, mantendo o padrao visual do projeto.
+
+---
+
+## 3. Solucao Implementada
+
+### 3.1 Endpoint utilizado
+
+| Metodo | URL | Descricao |
+|--------|-----|-----------|
+| GET | `/audiences/{audience_id}/topics` | Buscar topicos da audiencia |
+
+**Response:**
+
+```json
+{
+  "status": "ready",
+  "analysis_id": "uuid",
+  "total_topics": 559,
+  "completed_at": "2026-02-21T18:25:38.305359+00:00",
+  "topics": [
+    {
+      "id": "uuid",
+      "name": "Social Media Growth Strategies",
+      "description": "Discussions on effective methods...",
+      "growth_percentage": 200.0,
+      "mention_frequency": 15.0,
+      "mention_period": "month",
+      "post_count": 20,
+      "communities": [
+        { "name": "SocialMediaMarketing", "post_count": 15 }
+      ],
+      "rank": 1
+    }
+  ]
+}
+```
+
+### 3.2 Arquitetura — Fluxo de dados
+
+```
+AudienceDetail Page
+  └── useGetAudienceTopics(audienceId)
+        └── GetAudienceTopicsUseCase
+              └── AudienceRepository.getAudienceTopics()
+                    └── GET /audiences/{id}/topics
+                          └── Mapeia snake_case → Topic entity
+```
+
+### 3.3 Mapeamento de campos API → UI
+
+| API (snake_case) | Entity (camelCase) | TopicTableItem | TopicDetail |
+|------------------|--------------------|----------------|-------------|
+| `id` | `id` | `id` | `id` |
+| `name` | `name` | `name` | `name` |
+| `growth_percentage` | `growthPercentage` | `growth` | `growth` |
+| `mention_frequency` | `mentionFrequency` | `frequency` | `frequency` |
+| `mention_period` | `mentionPeriod` | `frequencyUnit`* | `frequencyUnit`* |
+| `description` | `description` | — | `description` |
+| `communities[].name` | `communities[].name` | `subreddits[]` | `subreddits[].name` |
+| `communities[].post_count` | `communities[].postCount` | — | `subreddits[].postCount` |
+
+*`"month"` → `"mo"`, `"week"` → `"week"`, `"day"` → `"day"`
+
+---
+
+## 4. Arquivos Criados
+
+| Arquivo | Descricao |
+|---------|-----------|
+| `src/modules/audience/domain/entities/Topic.entity.ts` | Entidade Topic com getters e toJSON |
+| `src/modules/audience/domain/use-cases/get-audience-topics.use-case.ts` | Interface `IGetAudienceTopicsUseCase`, params e result types |
+| `src/modules/audience/application/use-cases/get-audience-topics-use-case/index.ts` | Implementacao do use-case |
+| `src/modules/audience/application/hooks/useGetAudienceTopics.ts` | Hook React Query com `useQuery` |
+
+---
+
+## 5. Arquivos Modificados
+
+| Arquivo | Alteracao |
+|---------|-----------|
+| `src/modules/audience/domain/use-cases/index.ts` | Export dos novos tipos |
+| `src/modules/audience/domain/repositories/audience.repository.ts` | Novo metodo `getAudienceTopics` na interface |
+| `src/modules/audience/infra/repositories/audience.repository.ts` | Implementacao HTTP com interfaces de resposta API e mapeamento para entidade |
+| `src/modules/audience/application/use-cases/index.ts` | Export do `GetAudienceTopicsUseCase` |
+| `src/modules/audience/application/hooks/index.ts` | Export do `useGetAudienceTopics` e `AUDIENCE_TOPICS_QUERY_KEY` |
+| `src/modules/shared/infra/container/types.ts` | Novo symbol `GetAudienceTopicsUseCase` |
+| `src/modules/shared/infra/container/container.ts` | Binding do use-case no container Inversify |
+| `src/pages/AudienceDetail.tsx` | Chamada do hook `useGetAudienceTopics`, passagem de props (topics, totalTopics, isLoadingTopics) |
+| `src/components/audiences/detail/AudienceDetailTabs.tsx` | Novas props, remocao do import de mock `topicsData`, mapeamento Topic entity → TopicTableItem/TopicDetail, loading state |
+
+---
+
+## 6. Dependencias
+
+Nenhuma nova dependencia adicionada.

--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -32,6 +32,9 @@ export interface AudienceDetailTabsProps {
   topics: Topic[]
   totalTopics: number
   isLoadingTopics: boolean
+  onLoadMoreTopics: () => void
+  hasMoreTopics: boolean
+  isLoadingMoreTopics: boolean
 }
 
 export function AudienceDetailTabs({
@@ -50,6 +53,9 @@ export function AudienceDetailTabs({
   topics,
   totalTopics,
   isLoadingTopics,
+  onLoadMoreTopics,
+  hasMoreTopics,
+  isLoadingMoreTopics,
 }: Readonly<AudienceDetailTabsProps>) {
   const [activeTab, setActiveTab] = useState('search')
   const [selectedTopic, setSelectedTopic] = useState<TopicDetail | null>(null)
@@ -130,6 +136,9 @@ export function AudienceDetailTabs({
               topics={topicTableItems}
               totalCount={totalTopics}
               selectedTopicId={selectedTopic?.id}
+              onLoadMore={onLoadMoreTopics}
+              hasMore={hasMoreTopics}
+              isLoadingMore={isLoadingMoreTopics}
               onTopicSelect={(topic) => {
                 const fullTopic = topics.find((t) => t.getId() === topic.id)
                 if (fullTopic) {

--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -13,7 +13,8 @@ import type { TopicDetail, ThemeDetail } from '@/components/audiences/detail'
 import type { SimilarCommunity } from './SimilarCommunitiesGrid'
 import type { SubredditDetail } from '@/data/audienceDetails'
 import type { Keyword } from '@/modules/audience/domain/entities/Keyword.entity'
-import { themesGridData, themesDetailData, topicsData } from '@/data/audienceDetailMocks'
+import type { Topic } from '@/modules/audience/domain/entities/Topic.entity'
+import { themesGridData, themesDetailData } from '@/data/audienceDetailMocks'
 
 export interface AudienceDetailTabsProps {
   contentRef: RefObject<HTMLDivElement | null>
@@ -28,6 +29,9 @@ export interface AudienceDetailTabsProps {
   onAddCommunity: () => void
   onAddToAudience?: (subredditName: string) => void
   onMarkNotRelevant?: (subredditName: string) => void
+  topics: Topic[]
+  totalTopics: number
+  isLoadingTopics: boolean
 }
 
 export function AudienceDetailTabs({
@@ -43,10 +47,26 @@ export function AudienceDetailTabs({
   onAddCommunity,
   onAddToAudience,
   onMarkNotRelevant,
+  topics,
+  totalTopics,
+  isLoadingTopics,
 }: Readonly<AudienceDetailTabsProps>) {
   const [activeTab, setActiveTab] = useState('search')
   const [selectedTopic, setSelectedTopic] = useState<TopicDetail | null>(null)
   const [selectedTheme, setSelectedTheme] = useState<ThemeDetail | null>(null)
+
+  const topicTableItems = topics.map((topic) => {
+    const period = topic.getMentionPeriod()
+    const frequencyUnit: 'day' | 'week' | 'mo' = period === 'month' ? 'mo' : period === 'week' ? 'week' : 'day'
+    return {
+      id: topic.getId(),
+      name: topic.getName(),
+      growth: topic.getGrowthPercentage(),
+      frequency: topic.getMentionFrequency(),
+      frequencyUnit,
+      subreddits: topic.getCommunities().map((c) => c.name),
+    }
+  })
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
@@ -57,7 +77,7 @@ export function AudienceDetailTabs({
         <TabsTrigger value="subreddits" count={communitiesCount}>
           Subreddits
         </TabsTrigger>
-        <TabsTrigger value="topics" count={200}>
+        <TabsTrigger value="topics" count={totalTopics}>
           Topics
         </TabsTrigger>
         <TabsTrigger value="themes">
@@ -100,30 +120,41 @@ export function AudienceDetailTabs({
       </TabsContent>
 
       <TabsContent value="topics" className="mt-6">
-        <div className="flex gap-6">
-          <TopicsTable
-            topics={topicsData}
-            totalCount={200}
-            selectedTopicId={selectedTopic?.id}
-            onTopicSelect={(topic) => {
-              const fullTopic = topicsData.find((t) => t.id === topic.id)
-              if (fullTopic) {
-                setSelectedTopic({
-                  id: fullTopic.id,
-                  name: fullTopic.name,
-                  frequency: fullTopic.frequency,
-                  frequencyUnit: fullTopic.frequencyUnit,
-                  growth: fullTopic.growth,
-                  description: fullTopic.description,
-                  subreddits: fullTopic.subredditCounts,
-                })
-              }
-            }}
-          />
-          <div className="w-1/2 shrink-0">
-            <TopicDetailPanel topic={selectedTopic} />
+        {isLoadingTopics ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="w-8 h-8 border-4 border-lime border-t-transparent rounded-full animate-spin" />
           </div>
-        </div>
+        ) : (
+          <div className="flex gap-6">
+            <TopicsTable
+              topics={topicTableItems}
+              totalCount={totalTopics}
+              selectedTopicId={selectedTopic?.id}
+              onTopicSelect={(topic) => {
+                const fullTopic = topics.find((t) => t.getId() === topic.id)
+                if (fullTopic) {
+                  const period = fullTopic.getMentionPeriod()
+                  const frequencyUnit: 'day' | 'week' | 'mo' = period === 'month' ? 'mo' : period === 'week' ? 'week' : 'day'
+                  setSelectedTopic({
+                    id: fullTopic.getId(),
+                    name: fullTopic.getName(),
+                    frequency: fullTopic.getMentionFrequency(),
+                    frequencyUnit,
+                    growth: fullTopic.getGrowthPercentage(),
+                    description: fullTopic.getDescription(),
+                    subreddits: fullTopic.getCommunities().map((c) => ({
+                      name: c.name,
+                      postCount: c.postCount,
+                    })),
+                  })
+                }
+              }}
+            />
+            <div className="w-1/2 shrink-0">
+              <TopicDetailPanel topic={selectedTopic} />
+            </div>
+          </div>
+        )}
       </TabsContent>
 
       <TabsContent value="themes" className="mt-6">

--- a/src/components/audiences/detail/TopicsTable.tsx
+++ b/src/components/audiences/detail/TopicsTable.tsx
@@ -208,7 +208,7 @@ export function TopicsTable({
         </div>
       </div>
 
-      <div ref={scrollContainerRef} className="max-h-[600px] overflow-y-auto">
+      <div ref={scrollContainerRef} className="max-h-[900px] overflow-y-auto">
         <div ref={listRef} className="space-y-2">
           {sortedTopics.map((topic) => (
             <button

--- a/src/components/audiences/detail/TopicsTable.tsx
+++ b/src/components/audiences/detail/TopicsTable.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { Search, ChevronDown, TrendingUp } from 'lucide-react'
+import { Search, ChevronDown, TrendingUp, Loader2 } from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { useReducedMotion } from '@/hooks'
 
@@ -17,6 +17,9 @@ export interface TopicsTableProps {
   totalCount: number
   selectedTopicId?: string | null
   onTopicSelect?: (topic: TopicTableItem) => void
+  onLoadMore?: () => void
+  hasMore?: boolean
+  isLoadingMore?: boolean
 }
 
 type SortOption = 'growth' | 'frequency' | 'name'
@@ -74,12 +77,35 @@ export function TopicsTable({
   totalCount,
   selectedTopicId,
   onTopicSelect,
+  onLoadMore,
+  hasMore,
+  isLoadingMore,
 }: Readonly<TopicsTableProps>) {
   const [searchQuery, setSearchQuery] = useState('')
   const [sortBy, setSortBy] = useState<SortOption>('growth')
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
   const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    const root = scrollContainerRef.current
+    if (!sentinel || !root) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !isLoadingMore) {
+          onLoadMore?.()
+        }
+      },
+      { root, threshold: 0.1 }
+    )
+
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasMore, isLoadingMore, onLoadMore])
 
   const sortOptions: { value: SortOption; label: string }[] = [
     { value: 'growth', label: 'Growth' },
@@ -182,58 +208,68 @@ export function TopicsTable({
         </div>
       </div>
 
-      <div ref={listRef} className="space-y-2">
-        {sortedTopics.map((topic) => (
-          <button
-            type="button"
-            key={topic.id}
-            onClick={() => onTopicSelect?.(topic)}
-            className={`w-full text-left bg-white dark:bg-zinc-800 border rounded-xl p-4 transition-colors cursor-pointer ${
-              selectedTopicId === topic.id
-                ? 'border-lime'
-                : 'border-gray-200 dark:border-zinc-700 hover:border-lime dark:hover:border-lime'
-            }`}
-          >
-            <div className="flex items-center gap-4">
-              <p className="font-semibold text-gray-900 dark:text-white truncate w-32 shrink-0">
-                {topic.name}
-              </p>
+      <div ref={scrollContainerRef} className="max-h-[600px] overflow-y-auto">
+        <div ref={listRef} className="space-y-2">
+          {sortedTopics.map((topic) => (
+            <button
+              type="button"
+              key={topic.id}
+              onClick={() => onTopicSelect?.(topic)}
+              className={`w-full text-left bg-white dark:bg-zinc-800 border rounded-xl p-4 transition-colors cursor-pointer ${
+                selectedTopicId === topic.id
+                  ? 'border-lime'
+                  : 'border-gray-200 dark:border-zinc-700 hover:border-lime dark:hover:border-lime'
+              }`}
+            >
+              <div className="flex items-center gap-4">
+                <p className="font-semibold text-gray-900 dark:text-white truncate w-32 shrink-0">
+                  {topic.name}
+                </p>
 
-              <div className="flex items-center gap-4 flex-1 justify-end">
-                <div className="w-[70px] shrink-0">
-                  <Sparkline growth={topic.growth} />
-                </div>
+                <div className="flex items-center gap-4 flex-1 justify-end">
+                  <div className="w-[70px] shrink-0">
+                    <Sparkline growth={topic.growth} />
+                  </div>
 
-                <div className="flex items-center gap-1 text-green-500 text-sm font-medium w-16 shrink-0">
-                  <TrendingUp className="w-4 h-4" />
-                  <span>{topic.growth}%</span>
-                </div>
+                  <div className="flex items-center gap-1 text-green-500 text-sm font-medium w-16 shrink-0">
+                    <TrendingUp className="w-4 h-4" />
+                    <span>{topic.growth}%</span>
+                  </div>
 
-                <div className="text-sm text-right w-64 shrink-0 truncate">
-                  <span className="text-lime font-semibold">
-                    {topic.frequency} / {topic.frequencyUnit}
-                  </span>
-                  <span className="text-gray-500 dark:text-zinc-400"> in </span>
-                  <span className="text-gray-700 dark:text-zinc-300">
-                    {topic.subreddits.slice(0, 2).join(', ')}
-                  </span>
-                  {topic.subreddits.length > 2 && (
-                    <span className="text-gray-400 dark:text-zinc-500">
-                      , and {topic.subreddits.length - 2} others
+                  <div className="text-sm text-right w-64 shrink-0 truncate">
+                    <span className="text-lime font-semibold">
+                      {topic.frequency} / {topic.frequencyUnit}
                     </span>
-                  )}
+                    <span className="text-gray-500 dark:text-zinc-400"> in </span>
+                    <span className="text-gray-700 dark:text-zinc-300">
+                      {topic.subreddits.slice(0, 2).join(', ')}
+                    </span>
+                    {topic.subreddits.length > 2 && (
+                      <span className="text-gray-400 dark:text-zinc-500">
+                        , and {topic.subreddits.length - 2} others
+                      </span>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
-          </button>
-        ))}
-      </div>
-
-      {sortedTopics.length === 0 && (
-        <div className="py-8 text-center text-gray-500 dark:text-zinc-400 bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700">
-          No topics found
+            </button>
+          ))}
         </div>
-      )}
+
+        {sortedTopics.length === 0 && (
+          <div className="py-8 text-center text-gray-500 dark:text-zinc-400 bg-white dark:bg-zinc-800 rounded-xl border border-gray-200 dark:border-zinc-700">
+            No topics found
+          </div>
+        )}
+
+        <div ref={sentinelRef}>
+          {isLoadingMore && (
+            <div className="flex justify-center py-4">
+              <Loader2 className="w-5 h-5 animate-spin text-gray-400" />
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/modules/audience/application/hooks/index.ts
+++ b/src/modules/audience/application/hooks/index.ts
@@ -10,3 +10,4 @@ export { useGetAudienceSuggestions, AUDIENCE_SUGGESTIONS_QUERY_KEY } from './use
 export { useDeleteAudience } from './useDeleteAudience'
 export { useGetAudienceKeywords, AUDIENCE_KEYWORDS_QUERY_KEY } from './useGetAudienceKeywords'
 export { useMarkCommunityNotRelevant } from './useMarkCommunityNotRelevant'
+export { useGetAudienceTopics, AUDIENCE_TOPICS_QUERY_KEY } from './useGetAudienceTopics'

--- a/src/modules/audience/application/hooks/useGetAudienceTopics.ts
+++ b/src/modules/audience/application/hooks/useGetAudienceTopics.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IGetAudienceTopicsUseCase } from '@/modules/audience/domain/use-cases'
+
+const getAudienceTopicsUseCase = container.get<IGetAudienceTopicsUseCase>(
+  TYPES.GetAudienceTopicsUseCase
+)
+
+export const AUDIENCE_TOPICS_QUERY_KEY = (audienceId: string) => ['audience-topics', audienceId] as const
+
+export function useGetAudienceTopics(audienceId: string) {
+  return useQuery({
+    queryKey: AUDIENCE_TOPICS_QUERY_KEY(audienceId),
+    queryFn: () => getAudienceTopicsUseCase.execute({ audienceId }),
+    enabled: !!audienceId,
+  })
+}

--- a/src/modules/audience/application/hooks/useGetAudienceTopics.ts
+++ b/src/modules/audience/application/hooks/useGetAudienceTopics.ts
@@ -1,17 +1,27 @@
-import { useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { container, TYPES } from '@/modules/shared'
-import type { IGetAudienceTopicsUseCase } from '@/modules/audience/domain/use-cases'
+import type { IGetAudienceTopicsUseCase, GetAudienceTopicsResult } from '@/modules/audience/domain/use-cases'
 
 const getAudienceTopicsUseCase = container.get<IGetAudienceTopicsUseCase>(
   TYPES.GetAudienceTopicsUseCase
 )
 
+const PAGE_SIZE = 200
+
 export const AUDIENCE_TOPICS_QUERY_KEY = (audienceId: string) => ['audience-topics', audienceId] as const
 
 export function useGetAudienceTopics(audienceId: string) {
-  return useQuery({
+  return useInfiniteQuery<GetAudienceTopicsResult, Error>({
     queryKey: AUDIENCE_TOPICS_QUERY_KEY(audienceId),
-    queryFn: () => getAudienceTopicsUseCase.execute({ audienceId }),
+    queryFn: ({ pageParam = 0 }) =>
+      getAudienceTopicsUseCase.execute({
+        audienceId,
+        offset: pageParam as number,
+        limit: PAGE_SIZE,
+      }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.offset + lastPage.limit : undefined,
     enabled: !!audienceId,
   })
 }

--- a/src/modules/audience/application/use-cases/get-audience-topics-use-case/index.ts
+++ b/src/modules/audience/application/use-cases/get-audience-topics-use-case/index.ts
@@ -1,0 +1,10 @@
+import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
+import type { IGetAudienceTopicsUseCase, GetAudienceTopicsParams, GetAudienceTopicsResult } from '@/modules/audience/domain/use-cases'
+
+export class GetAudienceTopicsUseCase implements IGetAudienceTopicsUseCase {
+  constructor(private readonly audienceRepository: IAudienceRepository) {}
+
+  async execute(params: GetAudienceTopicsParams): Promise<GetAudienceTopicsResult> {
+    return this.audienceRepository.getAudienceTopics(params)
+  }
+}

--- a/src/modules/audience/application/use-cases/index.ts
+++ b/src/modules/audience/application/use-cases/index.ts
@@ -10,3 +10,4 @@ export { GetAudienceSuggestionsUseCase } from './get-audience-suggestions-use-ca
 export { DeleteAudienceUseCase } from './delete-audience-use-case'
 export { GetAudienceKeywordsUseCase } from './get-audience-keywords-use-case'
 export { MarkCommunityNotRelevantUseCase } from './mark-community-not-relevant-use-case'
+export { GetAudienceTopicsUseCase } from './get-audience-topics-use-case'

--- a/src/modules/audience/domain/entities/Topic.entity.ts
+++ b/src/modules/audience/domain/entities/Topic.entity.ts
@@ -1,0 +1,90 @@
+interface TopicCommunity {
+  name: string
+  postCount: number
+}
+
+interface TopicProps {
+  id: string
+  name: string
+  description: string
+  growthPercentage: number
+  mentionFrequency: number
+  mentionPeriod: string
+  postCount: number
+  communities: TopicCommunity[]
+  rank: number
+}
+
+export class Topic {
+  private readonly id: string
+  private readonly name: string
+  private readonly description: string
+  private readonly growthPercentage: number
+  private readonly mentionFrequency: number
+  private readonly mentionPeriod: string
+  private readonly postCount: number
+  private readonly communities: TopicCommunity[]
+  private readonly rank: number
+
+  constructor({ id, name, description, growthPercentage, mentionFrequency, mentionPeriod, postCount, communities, rank }: TopicProps) {
+    this.id = id
+    this.name = name
+    this.description = description
+    this.growthPercentage = growthPercentage
+    this.mentionFrequency = mentionFrequency
+    this.mentionPeriod = mentionPeriod
+    this.postCount = postCount
+    this.communities = communities
+    this.rank = rank
+  }
+
+  getId(): string {
+    return this.id
+  }
+
+  getName(): string {
+    return this.name
+  }
+
+  getDescription(): string {
+    return this.description
+  }
+
+  getGrowthPercentage(): number {
+    return this.growthPercentage
+  }
+
+  getMentionFrequency(): number {
+    return this.mentionFrequency
+  }
+
+  getMentionPeriod(): string {
+    return this.mentionPeriod
+  }
+
+  getPostCount(): number {
+    return this.postCount
+  }
+
+  getCommunities(): TopicCommunity[] {
+    return this.communities
+  }
+
+  getRank(): number {
+    return this.rank
+  }
+
+  toJSON(): object {
+    return {
+      id: this.id,
+      name: this.name,
+      description: this.description,
+      growthPercentage: this.growthPercentage,
+      mentionFrequency: this.mentionFrequency,
+      mentionPeriod: this.mentionPeriod,
+      postCount: this.postCount,
+      communities: this.communities,
+      rank: this.rank,
+    }
+  }
+}

--- a/src/modules/audience/domain/repositories/audience.repository.ts
+++ b/src/modules/audience/domain/repositories/audience.repository.ts
@@ -8,6 +8,7 @@ import type { GetAudienceSuggestionsParams, GetAudienceSuggestionsResult } from 
 import type { DeleteAudienceParams, DeleteAudienceResult } from "../use-cases/delete-audience.use-case";
 import type { GetAudienceKeywordsParams, GetAudienceKeywordsResult } from "../use-cases/get-audience-keywords.use-case";
 import type { MarkCommunityNotRelevantParams } from "../use-cases/mark-community-not-relevant.use-case";
+import type { GetAudienceTopicsParams, GetAudienceTopicsResult } from "../use-cases/get-audience-topics.use-case";
 
 export interface IAudienceRepository {
   listUserAudiences(): Promise<Audience[]>
@@ -22,4 +23,5 @@ export interface IAudienceRepository {
   deleteAudience(params: DeleteAudienceParams): Promise<DeleteAudienceResult>
   getAudienceKeywords(params: GetAudienceKeywordsParams): Promise<GetAudienceKeywordsResult>
   markCommunityNotRelevant(params: MarkCommunityNotRelevantParams): Promise<void>
+  getAudienceTopics(params: GetAudienceTopicsParams): Promise<GetAudienceTopicsResult>
 }

--- a/src/modules/audience/domain/use-cases/get-audience-topics.use-case.ts
+++ b/src/modules/audience/domain/use-cases/get-audience-topics.use-case.ts
@@ -1,0 +1,17 @@
+import type { Topic } from '../entities/Topic.entity'
+
+export interface GetAudienceTopicsParams {
+  audienceId: string
+}
+
+export interface GetAudienceTopicsResult {
+  status: string
+  analysisId: string
+  totalTopics: number
+  completedAt: string
+  topics: Topic[]
+}
+
+export interface IGetAudienceTopicsUseCase {
+  execute(params: GetAudienceTopicsParams): Promise<GetAudienceTopicsResult>
+}

--- a/src/modules/audience/domain/use-cases/get-audience-topics.use-case.ts
+++ b/src/modules/audience/domain/use-cases/get-audience-topics.use-case.ts
@@ -2,6 +2,8 @@ import type { Topic } from '../entities/Topic.entity'
 
 export interface GetAudienceTopicsParams {
   audienceId: string
+  limit?: number
+  offset?: number
 }
 
 export interface GetAudienceTopicsResult {
@@ -10,6 +12,9 @@ export interface GetAudienceTopicsResult {
   totalTopics: number
   completedAt: string
   topics: Topic[]
+  limit: number
+  offset: number
+  hasMore: boolean
 }
 
 export interface IGetAudienceTopicsUseCase {

--- a/src/modules/audience/domain/use-cases/index.ts
+++ b/src/modules/audience/domain/use-cases/index.ts
@@ -10,3 +10,4 @@ export type { IGetAudienceSuggestionsUseCase, GetAudienceSuggestionsParams, Audi
 export type { IDeleteAudienceUseCase, DeleteAudienceParams, DeleteAudienceResult } from './delete-audience.use-case'
 export type { IGetAudienceKeywordsUseCase, GetAudienceKeywordsParams, GetAudienceKeywordsResult } from './get-audience-keywords.use-case'
 export type { IMarkCommunityNotRelevantUseCase, MarkCommunityNotRelevantParams } from './mark-community-not-relevant.use-case'
+export type { IGetAudienceTopicsUseCase, GetAudienceTopicsParams, GetAudienceTopicsResult } from './get-audience-topics.use-case'

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -10,7 +10,9 @@ import type { GetAudienceSuggestionsParams, GetAudienceSuggestionsResult } from 
 import type { DeleteAudienceParams, DeleteAudienceResult } from '../../domain/use-cases/delete-audience.use-case'
 import type { GetAudienceKeywordsParams, GetAudienceKeywordsResult } from '../../domain/use-cases/get-audience-keywords.use-case'
 import type { MarkCommunityNotRelevantParams } from '../../domain/use-cases/mark-community-not-relevant.use-case'
+import type { GetAudienceTopicsParams, GetAudienceTopicsResult } from '../../domain/use-cases/get-audience-topics.use-case'
 import { Keyword } from '../../domain/entities/Keyword.entity'
+import { Topic } from '../../domain/entities/Topic.entity'
 
 interface AudienceTemplateResponse {
   id: string
@@ -72,6 +74,31 @@ interface AudienceKeywordsApiResponse {
   total_keywords: number
   completed_at: string
   keywords: AudienceKeywordApiItem[]
+}
+
+interface AudienceTopicCommunityApiItem {
+  name: string
+  post_count: number
+}
+
+interface AudienceTopicApiItem {
+  id: string
+  name: string
+  description: string
+  growth_percentage: number
+  mention_frequency: number
+  mention_period: string
+  post_count: number
+  communities: AudienceTopicCommunityApiItem[]
+  rank: number
+}
+
+interface AudienceTopicsApiResponse {
+  status: string
+  analysis_id: string
+  total_topics: number
+  completed_at: string
+  topics: AudienceTopicApiItem[]
 }
 
 interface AudienceSuggestionsApiResponse {
@@ -237,5 +264,31 @@ export class AudienceRepository implements IAudienceRepository {
       context_type: 'audience',
       context_id: params.audienceId,
     })
+  }
+
+  async getAudienceTopics(params: GetAudienceTopicsParams): Promise<GetAudienceTopicsResult> {
+    const response = await this.httpClient.get<AudienceTopicsApiResponse>(
+      `audiences/${params.audienceId}/topics`
+    )
+    return {
+      status: response.status,
+      analysisId: response.analysis_id,
+      totalTopics: response.total_topics,
+      completedAt: response.completed_at,
+      topics: response.topics.map((t) => new Topic({
+        id: t.id,
+        name: t.name,
+        description: t.description,
+        growthPercentage: t.growth_percentage,
+        mentionFrequency: t.mention_frequency,
+        mentionPeriod: t.mention_period,
+        postCount: t.post_count,
+        communities: t.communities.map((c) => ({
+          name: c.name,
+          postCount: c.post_count,
+        })),
+        rank: t.rank,
+      })),
+    }
   }
 }

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -267,28 +267,34 @@ export class AudienceRepository implements IAudienceRepository {
   }
 
   async getAudienceTopics(params: GetAudienceTopicsParams): Promise<GetAudienceTopicsResult> {
+    const limit = params.limit ?? 200
+    const offset = params.offset ?? 0
     const response = await this.httpClient.get<AudienceTopicsApiResponse>(
-      `audiences/${params.audienceId}/topics`
+      `audiences/${params.audienceId}/topics?limit=${limit}&offset=${offset}`
     )
+    const topics = response.topics.map((t) => new Topic({
+      id: t.id,
+      name: t.name,
+      description: t.description,
+      growthPercentage: t.growth_percentage,
+      mentionFrequency: t.mention_frequency,
+      mentionPeriod: t.mention_period,
+      postCount: t.post_count,
+      communities: t.communities.map((c) => ({
+        name: c.name,
+        postCount: c.post_count,
+      })),
+      rank: t.rank,
+    }))
     return {
       status: response.status,
       analysisId: response.analysis_id,
       totalTopics: response.total_topics,
       completedAt: response.completed_at,
-      topics: response.topics.map((t) => new Topic({
-        id: t.id,
-        name: t.name,
-        description: t.description,
-        growthPercentage: t.growth_percentage,
-        mentionFrequency: t.mention_frequency,
-        mentionPeriod: t.mention_period,
-        postCount: t.post_count,
-        communities: t.communities.map((c) => ({
-          name: c.name,
-          postCount: c.post_count,
-        })),
-        rank: t.rank,
-      })),
+      topics,
+      limit,
+      offset,
+      hasMore: offset + topics.length < response.total_topics,
     }
   }
 }

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -3,8 +3,8 @@ import { TYPES } from './types'
 import { KyHttpClient, type HttpClient } from '../http'
 import { AudienceRepository } from '@/modules/audience/infra/repositories'
 import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
-import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase, MarkCommunityNotRelevantUseCase } from '@/modules/audience/application/use-cases'
-import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase, IMarkCommunityNotRelevantUseCase } from '@/modules/audience/domain/use-cases'
+import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase, MarkCommunityNotRelevantUseCase, GetAudienceTopicsUseCase } from '@/modules/audience/application/use-cases'
+import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase, IMarkCommunityNotRelevantUseCase, IGetAudienceTopicsUseCase } from '@/modules/audience/domain/use-cases'
 import { CommunityRepository } from '@/modules/community/infra/repositories'
 import type { ICommunityRepository } from '@/modules/community/domain/repositories'
 import { BrowseCommunitiesUseCase } from '@/modules/community/application/use-cases'
@@ -81,6 +81,11 @@ container.bind<IGetAudienceKeywordsUseCase>(TYPES.GetAudienceKeywordsUseCase).to
 container.bind<IMarkCommunityNotRelevantUseCase>(TYPES.MarkCommunityNotRelevantUseCase).toDynamicValue(() => {
   const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
   return new MarkCommunityNotRelevantUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<IGetAudienceTopicsUseCase>(TYPES.GetAudienceTopicsUseCase).toDynamicValue(() => {
+  const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
+  return new GetAudienceTopicsUseCase(audienceRepository)
 }).inSingletonScope()
 
 container.bind<ICommunityRepository>(TYPES.CommunityRepository).toDynamicValue(() => {

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -13,6 +13,7 @@ export const TYPES = {
   DeleteAudienceUseCase: Symbol.for('DeleteAudienceUseCase'),
   GetAudienceKeywordsUseCase: Symbol.for('GetAudienceKeywordsUseCase'),
   MarkCommunityNotRelevantUseCase: Symbol.for('MarkCommunityNotRelevantUseCase'),
+  GetAudienceTopicsUseCase: Symbol.for('GetAudienceTopicsUseCase'),
   CommunityRepository: Symbol.for('CommunityRepository'),
   BrowseCommunitiesUseCase: Symbol.for('BrowseCommunitiesUseCase'),
   AuthRepository: Symbol.for('AuthRepository'),

--- a/src/pages/AudienceDetail.tsx
+++ b/src/pages/AudienceDetail.tsx
@@ -8,7 +8,7 @@ import {
   AudienceDetailTabs,
   DeleteAudienceModal,
 } from '@/components/audiences/detail'
-import { useGetAudienceTemplateById, useGetAudienceById, useUpdateAudience, useDeleteAudience, useGetAudienceKeywords, useGetAudienceSuggestions, useAddCommunityToAudience, useMarkCommunityNotRelevant } from '@/modules/audience/application/hooks'
+import { useGetAudienceTemplateById, useGetAudienceById, useUpdateAudience, useDeleteAudience, useGetAudienceKeywords, useGetAudienceSuggestions, useAddCommunityToAudience, useMarkCommunityNotRelevant, useGetAudienceTopics } from '@/modules/audience/application/hooks'
 import { useCreateAudienceStore } from '@/modules/audience/application/store'
 import { toast } from '@/hooks'
 import { SelectAudienceModal } from '@/components/shared'
@@ -37,6 +37,7 @@ export function AudienceDetail() {
   const { data: userAudience, isLoading: isLoadingUser, error: errorUser } = useGetAudienceById(isUserAudience ? (id ?? '') : '')
   const { data: keywordsData, isLoading: isLoadingKeywords } = useGetAudienceKeywords(id ?? '')
   const { data: suggestionsData, isLoading: isLoadingSuggestions } = useGetAudienceSuggestions(id)
+  const { data: topicsData, isLoading: isLoadingTopics } = useGetAudienceTopics(id ?? '')
 
   const isLoading = isUserAudience ? isLoadingUser : isLoadingTemplate
   const error = isUserAudience ? errorUser : errorTemplate
@@ -222,6 +223,9 @@ export function AudienceDetail() {
           onAddCommunity={handleEdit}
           onAddToAudience={handleAddToAudience}
           onMarkNotRelevant={handleMarkNotRelevant}
+          topics={topicsData?.topics ?? []}
+          totalTopics={topicsData?.totalTopics ?? 0}
+          isLoadingTopics={isLoadingTopics}
         />
       </div>
 

--- a/src/pages/AudienceDetail.tsx
+++ b/src/pages/AudienceDetail.tsx
@@ -37,7 +37,13 @@ export function AudienceDetail() {
   const { data: userAudience, isLoading: isLoadingUser, error: errorUser } = useGetAudienceById(isUserAudience ? (id ?? '') : '')
   const { data: keywordsData, isLoading: isLoadingKeywords } = useGetAudienceKeywords(id ?? '')
   const { data: suggestionsData, isLoading: isLoadingSuggestions } = useGetAudienceSuggestions(id)
-  const { data: topicsData, isLoading: isLoadingTopics } = useGetAudienceTopics(id ?? '')
+  const {
+    data: topicsData,
+    isLoading: isLoadingTopics,
+    fetchNextPage: fetchNextTopics,
+    hasNextPage: hasMoreTopics,
+    isFetchingNextPage: isLoadingMoreTopics,
+  } = useGetAudienceTopics(id ?? '')
 
   const isLoading = isUserAudience ? isLoadingUser : isLoadingTemplate
   const error = isUserAudience ? errorUser : errorTemplate
@@ -223,9 +229,12 @@ export function AudienceDetail() {
           onAddCommunity={handleEdit}
           onAddToAudience={handleAddToAudience}
           onMarkNotRelevant={handleMarkNotRelevant}
-          topics={topicsData?.topics ?? []}
-          totalTopics={topicsData?.totalTopics ?? 0}
+          topics={topicsData?.pages.flatMap((p) => p.topics) ?? []}
+          totalTopics={topicsData?.pages[0]?.totalTopics ?? 0}
           isLoadingTopics={isLoadingTopics}
+          onLoadMoreTopics={fetchNextTopics}
+          hasMoreTopics={hasMoreTopics ?? false}
+          isLoadingMoreTopics={isLoadingMoreTopics}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Conecta a tab Topics na página de detalhes da audiência ao endpoint `GET /audiences/{audience_id}/topics`
- Substitui dados mock por dados dinâmicos do backend seguindo o padrão Clean Architecture (Entity → Use Case → Repository → Hook → Component)
- Adiciona loading state enquanto os dados são carregados

## Arquivos criados
- `src/modules/audience/domain/entities/Topic.entity.ts` — Entidade Topic
- `src/modules/audience/domain/use-cases/get-audience-topics.use-case.ts` — Interface do use-case
- `src/modules/audience/application/use-cases/get-audience-topics-use-case/index.ts` — Implementação do use-case
- `src/modules/audience/application/hooks/useGetAudienceTopics.ts` — Hook React Query

## Arquivos modificados
- `src/modules/audience/domain/repositories/audience.repository.ts` — Método `getAudienceTopics` na interface
- `src/modules/audience/infra/repositories/audience.repository.ts` — Implementação HTTP + mapeamento snake_case → camelCase
- `src/modules/shared/infra/container/types.ts` — Symbol do use-case
- `src/modules/shared/infra/container/container.ts` — Binding Inversify
- `src/modules/audience/domain/use-cases/index.ts` — Export do tipo
- `src/modules/audience/application/use-cases/index.ts` — Export da classe
- `src/modules/audience/application/hooks/index.ts` — Export do hook
- `src/pages/AudienceDetail.tsx` — Chamada do hook e passagem de props
- `src/components/audiences/detail/AudienceDetailTabs.tsx` — Consumo de dados reais, remoção do mock

## Test plan
- [ ] Navegar para detalhes de uma audiência → tab Topics
- [ ] Verificar loading spinner durante fetch
- [ ] Verificar que tópicos da API aparecem na tabela
- [ ] Clicar em um tópico → painel de detalhes exibe dados corretos
- [ ] Busca e ordenação funcionam com dados reais
- [ ] Count no tab reflete `total_topics` da API
- [ ] Build sem erros (`npm run build`)

Closes #43