### PR TITLE
feat: smooth GSAP animation for user audiences section

### DIFF
--- a/docs/issue-45-gsap-user-audiences-animation.md
+++ b/docs/issue-45-gsap-user-audiences-animation.md
@@ -1,0 +1,77 @@
+# Issue #45 — Animacao GSAP suave para entrada da secao Your Audiences
+
+**Issue:** https://github.com/robsonmvieira/oraculo-frontend/issues/45
+**PR:** https://github.com/robsonmvieira/oraculo-frontend/pull/46
+**Branch:** `feat/gsap-user-audiences-animation`
+**Status:** In Review
+
+---
+
+## 1. Motivacao
+
+Na tela de audiencias existem duas secoes:
+- **Find Audiences** (templates) — carrega primeiro
+- **Your Audiences** (do usuario) — carrega depois
+
+Quando as audiencias do usuario chegavam, a secao `Your Audiences` aparecia abruptamente na tela. O componente `UserAudiencesSection` retornava `null` enquanto nao havia dados e, ao receber os dados, entrava no DOM sem nenhuma transicao visual.
+
+O objetivo era adicionar uma animacao GSAP para que a secao entre de forma suave, evitando a aparicao abrupta.
+
+---
+
+## 2. Decisoes de Design
+
+### 2.1 Animacao encapsulada no componente
+
+Em vez de manter a logica de animacao centralizada no `Audiences.tsx` (pagina pai), a animacao do user grid foi movida para dentro do proprio `UserAudiencesSection`. Isso garante que a animacao roda no momento exato em que o componente monta (quando os dados chegam), eliminando o problema de timing.
+
+### 2.2 Dupla animacao: secao + cards
+
+A animacao e feita em duas camadas:
+- **Secao inteira** — fade in (`opacity: 0 → 1`) + slide up (`y: 40 → 0`) com `duration: 0.6s`
+- **Cards individuais** — stagger de `0.06s` com `delay: 0.15s`, criando efeito cascata
+
+### 2.3 Animacao unica via `hasAnimated` ref
+
+Um `useRef(false)` garante que a animacao roda apenas uma vez (na primeira carga dos dados). Recarregamentos subsequentes (ex: cache do React Query) nao disparam a animacao novamente.
+
+### 2.4 Acessibilidade
+
+A animacao respeita a preferencia `prefers-reduced-motion` do sistema operacional via hook `useReducedMotion` ja existente no projeto.
+
+---
+
+## 3. Solucao Implementada
+
+### 3.1 Fluxo da animacao
+
+```
+UserAudiencesSection monta (audiences.length > 0)
+  └── useEffect detecta dados
+        ├── Anima <section> (fade + slide up)
+        └── Anima children do [data-user-grid] (stagger)
+```
+
+### 3.2 Parametros GSAP
+
+| Alvo | Propriedade | De | Para | Duracao | Delay | Ease |
+|------|-------------|-----|------|---------|-------|------|
+| `<section>` | opacity | 0 | 1 | 0.6s | 0 | power2.out |
+| `<section>` | y | 40 | 0 | 0.6s | 0 | power2.out |
+| Cards (children) | opacity | 0 | 1 | 0.5s | 0.15s | power2.out |
+| Cards (children) | y | 30 | 0 | 0.5s | stagger 0.06s | power2.out |
+
+---
+
+## 4. Arquivos Modificados
+
+| Arquivo | Alteracao |
+|---------|-----------|
+| `src/components/audiences/UserAudiencesSection.tsx` | Adicionada animacao GSAP na montagem; removida prop `gridRef`; adicionado `data-user-grid` no grid; `style={{ opacity: 0 }}` inicial na section |
+| `src/pages/Audiences.tsx` | Removida ref `userGridRef`; removida chamada `animate(userGridRef.current)` do useEffect; animacao agora cobre apenas templates; adicionado cleanup com `gsap.context` |
+
+---
+
+## 5. Dependencias
+
+Nenhuma nova dependencia adicionada. Utiliza GSAP (`gsap@^3.14.2`) e `@gsap/react@^2.1.2` ja presentes no projeto.

--- a/src/components/audiences/UserAudiencesSection.tsx
+++ b/src/components/audiences/UserAudiencesSection.tsx
@@ -1,4 +1,6 @@
-import type { RefObject } from 'react'
+import { useRef, useEffect } from 'react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
 import { AudienceCard, AddAudienceCard } from './AudienceCard'
 import { gridClassName } from './audiences.types'
 import type { AudienceDisplayItem, ViewMode } from './audiences.types'
@@ -9,7 +11,6 @@ export interface UserAudiencesSectionProps {
   onAddClick: () => void
   onSaveClick: (id: string) => void
   onShareClick: (id: string) => void
-  gridRef?: RefObject<HTMLDivElement | null>
 }
 
 export function UserAudiencesSection({
@@ -18,12 +19,56 @@ export function UserAudiencesSection({
   onAddClick,
   onSaveClick,
   onShareClick,
-  gridRef,
 }: Readonly<UserAudiencesSectionProps>) {
+  const sectionRef = useRef<HTMLElement>(null)
+  const hasAnimated = useRef(false)
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    const section = sectionRef.current
+    if (!section || hasAnimated.current || prefersReducedMotion) return
+
+    if (audiences.length === 0) return
+
+    hasAnimated.current = true
+
+    const ctx = gsap.context(() => {
+      gsap.fromTo(
+        section,
+        { opacity: 0, y: 40 },
+        {
+          opacity: 1,
+          y: 0,
+          duration: 0.6,
+          ease: 'power2.out',
+        }
+      )
+
+      const grid = section.querySelector('[data-user-grid]')
+      if (grid) {
+        gsap.fromTo(
+          Array.from(grid.children),
+          { opacity: 0, y: 30 },
+          {
+            opacity: 1,
+            y: 0,
+            duration: 0.5,
+            stagger: 0.06,
+            delay: 0.15,
+            ease: 'power2.out',
+            clearProps: 'transform',
+          }
+        )
+      }
+    }, section)
+
+    return () => ctx.revert()
+  }, [audiences.length, prefersReducedMotion])
+
   if (audiences.length === 0) return null
 
   return (
-    <section className="space-y-4">
+    <section ref={sectionRef} className="space-y-4" style={{ opacity: 0 }}>
       <div className="flex items-center gap-2">
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
           Your Audiences
@@ -33,7 +78,7 @@ export function UserAudiencesSection({
         </span>
       </div>
 
-      <div ref={gridRef} className={gridClassName(viewMode)}>
+      <div data-user-grid className={gridClassName(viewMode)}>
         {audiences.map((audience) => (
           <AudienceCard
             key={audience.id}

--- a/src/pages/Audiences.tsx
+++ b/src/pages/Audiences.tsx
@@ -9,7 +9,6 @@ import { useCreateAudienceStore } from '@/modules/audience/application/store'
 import { toast } from '@/hooks'
 
 export function Audiences() {
-  const userGridRef = useRef<HTMLDivElement>(null)
   const templatesGridRef = useRef<HTMLDivElement>(null)
   const prefersReducedMotion = useReducedMotion()
   const [searchQuery, setSearchQuery] = useState('')
@@ -64,8 +63,10 @@ export function Audiences() {
   useEffect(() => {
     if (prefersReducedMotion) return
 
-    const animate = (grid: HTMLDivElement | null) => {
-      if (!grid) return
+    const grid = templatesGridRef.current
+    if (!grid) return
+
+    const ctx = gsap.context(() => {
       gsap.fromTo(
         Array.from(grid.children),
         { y: 30, opacity: 0 },
@@ -78,11 +79,10 @@ export function Audiences() {
           clearProps: 'all',
         }
       )
-    }
+    }, grid)
 
-    animate(userGridRef.current)
-    animate(templatesGridRef.current)
-  }, [prefersReducedMotion, userAudiences, filteredTemplates])
+    return () => ctx.revert()
+  }, [prefersReducedMotion, filteredTemplates])
 
   const handleSaveClick = (id: string) => {
     console.log('Save clicked for audience:', id)
@@ -109,7 +109,6 @@ export function Audiences() {
         onAddClick={openModal}
         onSaveClick={handleSaveClick}
         onShareClick={handleShareClick}
-        gridRef={userGridRef}
       />
 
       <TemplateAudiencesSection


### PR DESCRIPTION
## Summary
- Adds a smooth GSAP entrance animation (fade + slide-up) to the "Your Audiences" section when user data loads after templates
- Cards within the grid animate with stagger effect (0.06s) for a cascading appearance
- Respects `prefers-reduced-motion` accessibility preference
- Removes duplicated animation logic from `Audiences.tsx`, encapsulating it within `UserAudiencesSection`

Closes #45

## Test plan
- [ ] Navigate to the Audiences page and verify "Your Audiences" fades in smoothly when data arrives
- [ ] Verify cards animate with stagger (sequential cascade)
- [ ] Enable "Reduce motion" in OS accessibility settings and confirm animation is skipped
- [ ] Verify "Find Audiences" (templates) section still animates independently