### PR TITLE
feat: dynamic data, animation fix, and logout functionality

### DIFF
--- a/src/components/audiences/UserAudiencesSection.tsx
+++ b/src/components/audiences/UserAudiencesSection.tsx
@@ -65,6 +65,12 @@ export function UserAudiencesSection({
     return () => ctx.revert()
   }, [audiences.length, prefersReducedMotion])
 
+  useEffect(() => {
+    return () => {
+      hasAnimated.current = false
+    }
+  }, [])
+
   if (audiences.length === 0) return null
 
   return (

--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/audiences/detail'
 import type { TopicDetail, ThemeDetail } from '@/components/audiences/detail'
 import type { SimilarCommunity } from './SimilarCommunitiesGrid'
+import type { AudienceStats, RadarData } from './AboutAudiencePanel'
 import type { SubredditDetail } from '@/data/audienceDetails'
 import type { Keyword } from '@/modules/audience/domain/entities/Keyword.entity'
 import type { Topic } from '@/modules/audience/domain/entities/Topic.entity'
@@ -21,6 +22,8 @@ export interface AudienceDetailTabsProps {
   subredditsData: readonly SubredditDetail[]
   communitiesCount: number
   audienceName: string
+  audienceStats: AudienceStats
+  radarData: RadarData
   keywords: Keyword[]
   isLoadingKeywords: boolean
   isUserAudience: boolean
@@ -42,6 +45,8 @@ export function AudienceDetailTabs({
   subredditsData,
   communitiesCount,
   audienceName,
+  audienceStats,
+  radarData,
   keywords,
   isLoadingKeywords,
   isUserAudience,
@@ -118,6 +123,8 @@ export function AudienceDetailTabs({
           subredditsData={subredditsData}
           communitiesCount={communitiesCount}
           audienceName={audienceName}
+          audienceStats={audienceStats}
+          radarData={radarData}
           similarCommunities={similarCommunities}
           isLoadingSuggestions={isLoadingSuggestions}
           onAddToAudience={onAddToAudience}

--- a/src/components/audiences/detail/SubredditsTabContent.tsx
+++ b/src/components/audiences/detail/SubredditsTabContent.tsx
@@ -3,11 +3,14 @@ import { AboutAudiencePanel } from './AboutAudiencePanel'
 import { SimilarCommunitiesGrid } from './SimilarCommunitiesGrid'
 import type { SubredditDetail } from '@/data/audienceDetails'
 import type { SimilarCommunity } from './SimilarCommunitiesGrid'
+import type { AudienceStats, RadarData } from './AboutAudiencePanel'
 
 export interface SubredditsTabContentProps {
   subredditsData: readonly SubredditDetail[]
   communitiesCount: number
   audienceName: string
+  audienceStats: AudienceStats
+  radarData: RadarData
   similarCommunities: readonly SimilarCommunity[]
   isLoadingSuggestions?: boolean
   onAddToAudience?: (subredditName: string) => void
@@ -18,6 +21,8 @@ export function SubredditsTabContent({
   subredditsData,
   communitiesCount,
   audienceName,
+  audienceStats,
+  radarData,
   similarCommunities,
   isLoadingSuggestions,
   onAddToAudience,
@@ -32,20 +37,9 @@ export function SubredditsTabContent({
         />
         <div className="w-[280px] shrink-0">
           <AboutAudiencePanel
-            stats={{
-              type: 'Curated Audience',
-              totalMembers: 24_200_000,
-              monthlyGrowth: 0.8,
-            }}
-            radarData={{
-              age: 65,
-              reach: 80,
-              size: 90,
-              activity: 75,
-              growth: 60,
-            }}
+            stats={audienceStats}
+            radarData={radarData}
             audienceName={audienceName}
-            comparisonName="r/parrots"
           />
         </div>
       </div>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
 import { gsap } from '@/lib/gsap'
 import { cn } from '@/lib/utils'
 import { useReducedMotion } from '@/hooks'
+import { useLogout } from '@/modules/auth'
 
 const navItems = [
   { icon: Home, path: '/dashboard', label: 'Dashboard' },
@@ -40,6 +41,7 @@ export function Sidebar() {
   const iconsRef = useRef<HTMLDivElement>(null)
   const prefersReducedMotion = useReducedMotion()
   const location = useLocation()
+  const handleLogout = useLogout()
 
   useEffect(() => {
     if (!sidebarRef.current || !iconsRef.current || prefersReducedMotion) return
@@ -136,7 +138,8 @@ export function Sidebar() {
         ))}
 
         <button
-          className="w-10 h-10 rounded-xl flex items-center justify-center text-gray-400 hover:text-red-400 hover:bg-red-400/10 transition-colors duration-300 mt-4"
+          onClick={handleLogout}
+          className="cursor-pointer w-10 h-10 rounded-xl flex items-center justify-center text-gray-400 hover:text-red-400 hover:bg-red-400/10 transition-colors duration-300 mt-4"
           title="Logout"
         >
           <LogOut className="w-5 h-5" />

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { useThemeStore } from '@/modules/shared'
-import { useAuthStore } from '@/modules/auth'
+import { useAuthStore, useLogout } from '@/modules/auth'
 import { useReducedMotion } from '@/hooks'
 
 const pageNames: Record<string, string> = {
@@ -39,6 +39,7 @@ export function Topbar() {
   const navigate = useNavigate()
   const { theme, toggleTheme } = useThemeStore()
   const { user } = useAuthStore()
+  const handleLogout = useLogout()
   const prefersReducedMotion = useReducedMotion()
 
   const userName = user?.getFullName() || 'User'
@@ -193,6 +194,7 @@ export function Topbar() {
 
             <DropdownMenuItem
               variant="destructive"
+              onClick={handleLogout}
               className="gap-3 px-3 py-2.5 rounded-xl cursor-pointer"
             >
               <LogOut className="w-4 h-4" />

--- a/src/modules/audience/domain/entities/Audience.entity.ts
+++ b/src/modules/audience/domain/entities/Audience.entity.ts
@@ -112,6 +112,10 @@ export class Audience {
     return this.growth_week
   }
 
+  getGrowthMonth(): number | null {
+    return this.growth_month ?? null
+  }
+
   toJSON(): object {
     return {
       id: this.id,

--- a/src/modules/auth/application/hooks/index.ts
+++ b/src/modules/auth/application/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useLogin } from './useLogin'
+export { useLogout } from './useLogout'
 export { useGetMe, AUTH_ME_QUERY_KEY } from './useGetMe'

--- a/src/modules/auth/application/hooks/useLogout.ts
+++ b/src/modules/auth/application/hooks/useLogout.ts
@@ -1,0 +1,15 @@
+import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '../store'
+
+export function useLogout() {
+  const logout = useAuthStore((state) => state.logout)
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  return () => {
+    logout()
+    queryClient.clear()
+    navigate('/login')
+  }
+}

--- a/src/modules/auth/application/index.ts
+++ b/src/modules/auth/application/index.ts
@@ -1,3 +1,3 @@
 export { LoginUseCase, RegisterUseCase, RefreshTokenUseCase, GetMeUseCase } from './use-cases'
-export { useLogin, useGetMe, AUTH_ME_QUERY_KEY } from './hooks'
+export { useLogin, useLogout, useGetMe, AUTH_ME_QUERY_KEY } from './hooks'
 export { useAuthStore } from './store'

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,5 +1,5 @@
 export { AuthTokens, AuthUser } from './domain'
 export type { IAuthRepository, ILoginUseCase, IRegisterUseCase, IRefreshTokenUseCase, IGetMeUseCase } from './domain'
 export { LoginUseCase, RegisterUseCase, RefreshTokenUseCase, GetMeUseCase } from './application'
-export { useLogin, useGetMe, AUTH_ME_QUERY_KEY, useAuthStore } from './application'
+export { useLogin, useLogout, useGetMe, AUTH_ME_QUERY_KEY, useAuthStore } from './application'
 export { AuthRepository } from './infra'

--- a/src/pages/AudienceDetail.tsx
+++ b/src/pages/AudienceDetail.tsx
@@ -14,6 +14,7 @@ import { toast } from '@/hooks'
 import { SelectAudienceModal } from '@/components/shared'
 import { Community } from '@/modules/community/domain/entities/Community.entity'
 import type { SimilarCommunity } from '@/components/audiences/detail/SimilarCommunitiesGrid'
+import type { AudienceStats, RadarData } from '@/components/audiences/detail/AboutAudiencePanel'
 
 export function AudienceDetail() {
   const { id } = useParams<{ id: string }>()
@@ -115,6 +116,33 @@ export function AudienceDetail() {
         members: community.subscribers ?? 0,
         monthlyGrowth: community.growth_month ?? 0,
       }))
+
+  const totalMembers = isUserAudience
+    ? userAudience!.getTotalMembers()
+    : audienceTemplate!.getTotalSubscribers()
+
+  const monthlyGrowth = isUserAudience
+    ? (userAudience!.getGrowthMonth() ?? 0)
+    : 0
+
+  const audienceStats: AudienceStats = {
+    type: 'Curated Audience',
+    totalMembers,
+    monthlyGrowth,
+  }
+
+  const maxMembers = Math.max(...subredditsData.map((s) => s.members), 1)
+  const avgGrowth = subredditsData.length > 0
+    ? subredditsData.reduce((sum, s) => sum + s.monthlyGrowth, 0) / subredditsData.length
+    : 0
+
+  const radarData: RadarData = {
+    age: Math.min(Math.round((communitiesCount / 20) * 100), 100),
+    reach: Math.min(Math.round((totalMembers / 50_000_000) * 100), 100),
+    size: Math.min(Math.round((maxMembers / 10_000_000) * 100), 100),
+    activity: Math.min(Math.round(avgGrowth * 50), 100),
+    growth: Math.min(Math.round(monthlyGrowth * 50), 100),
+  }
 
   const keywords = keywordsData?.keywords ?? []
 
@@ -221,6 +249,8 @@ export function AudienceDetail() {
           subredditsData={subredditsData}
           communitiesCount={communitiesCount}
           audienceName={audienceName}
+          audienceStats={audienceStats}
+          radarData={radarData}
           keywords={keywords}
           isLoadingKeywords={isLoadingKeywords}
           isUserAudience={isUserAudience}


### PR DESCRIPTION
## Summary

- **#47** - Substitui dados hardcoded por dados dinâmicos no `SubredditsTabContent` (AboutAudiencePanel agora usa totalMembers, monthlyGrowth e radarData reais da API)
- **#48** - Corrige bug onde a seção "Your Audiences" desaparecia ao navegar de volta da página de detalhe (reset do ref `hasAnimated` no unmount)
- **#49** - Corrige botões de logout sem funcionalidade na Topbar e Sidebar (novo hook `useLogout` + onClick handlers)

## Test plan

- [ ] Navegar para detalhe de audiência → aba Subreddits → verificar que "About this audience" exibe dados reais (totalMembers, growth)
- [ ] Navegar para detalhe e voltar para listagem → verificar que "Your Audiences" aparece normalmente
- [ ] Clicar no botão de logout no menu do avatar (Topbar) → deve redirecionar para `/login`
- [ ] Clicar no botão de logout na Sidebar → deve redirecionar para `/login`
- [ ] Após logout, verificar que tokens foram removidos do localStorage

Closes #47, closes #48, closes #49