### PR TITLE
feat: replace hardcoded topics with dynamic data in overview tab

### DIFF
--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -115,6 +115,9 @@ export function AudienceDetailTabs({
           isUserAudience={isUserAudience}
           onAddCommunity={onAddCommunity}
           onSubredditClick={() => setActiveTab('subreddits')}
+          topics={topics}
+          totalTopics={totalTopics}
+          onTopicClick={() => setActiveTab('topics')}
         />
       </TabsContent>
 

--- a/src/components/audiences/detail/SearchTabContent.tsx
+++ b/src/components/audiences/detail/SearchTabContent.tsx
@@ -7,6 +7,7 @@ import { TopicsList } from './TopicsList'
 import { KeywordTags } from './KeywordTags'
 import type { SubredditDetail } from '@/data/audienceDetails'
 import type { Keyword } from '@/modules/audience/domain/entities/Keyword.entity'
+import type { Topic } from '@/modules/audience/domain/entities/Topic.entity'
 
 export interface SearchTabContentProps {
   contentRef: RefObject<HTMLDivElement | null>
@@ -17,6 +18,9 @@ export interface SearchTabContentProps {
   isUserAudience: boolean
   onAddCommunity: () => void
   onSubredditClick: () => void
+  topics: Topic[]
+  totalTopics: number
+  onTopicClick: () => void
 }
 
 export function SearchTabContent({
@@ -28,6 +32,9 @@ export function SearchTabContent({
   isUserAudience,
   onAddCommunity,
   onSubredditClick,
+  topics,
+  totalTopics,
+  onTopicClick,
 }: Readonly<SearchTabContentProps>) {
   return (
     <div className="space-y-6">
@@ -98,13 +105,14 @@ export function SearchTabContent({
               Topics
             </h3>
             <span className="text-sm text-gray-500 dark:text-zinc-400">
-              200
+              {totalTopics}
             </span>
           </div>
           <TopicsList
-            topics={[]}
-            totalCount={0}
+            topics={topics}
+            totalCount={totalTopics}
             showHeader={false}
+            onTopicClick={onTopicClick}
           />
         </div>
       </div>

--- a/src/components/audiences/detail/TopicsList.tsx
+++ b/src/components/audiences/detail/TopicsList.tsx
@@ -1,22 +1,22 @@
 import { useRef, useEffect } from 'react'
-import { TrendingUp, MessageSquare } from 'lucide-react'
+import { TrendingUp, Tag } from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { cn } from '@/lib/utils'
 import { useReducedMotion } from '@/hooks'
-import { Badge } from '@/components/ui/badge'
-import type { Topic } from '@/data/audienceDetails'
+import type { Topic } from '@/modules/audience/domain/entities/Topic.entity'
 
 export interface TopicsListProps {
   topics: readonly Topic[]
   totalCount: number
   showHeader?: boolean
+  onTopicClick?: () => void
 }
 
-export function TopicsList({ topics, totalCount, showHeader = true }: Readonly<TopicsListProps>) {
+export function TopicsList({ topics, totalCount, showHeader = true, onTopicClick }: Readonly<TopicsListProps>) {
   const listRef = useRef<HTMLUListElement>(null)
   const prefersReducedMotion = useReducedMotion()
 
-  const displayedTopics = topics.slice(0, 6)
+  const displayedTopics = topics.slice(0, 5)
   const remainingCount = totalCount - displayedTopics.length
 
   useEffect(() => {
@@ -49,39 +49,45 @@ export function TopicsList({ topics, totalCount, showHeader = true }: Readonly<T
 
       <ul ref={listRef} className="space-y-1 flex-1">
         {displayedTopics.map((topic) => (
-          <li
-            key={topic.id}
-            className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
-          >
-            <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-zinc-800 flex items-center justify-center">
-              <MessageSquare className="w-4 h-4 text-gray-500 dark:text-zinc-400" />
-            </div>
-            <div className="flex-1 min-w-0">
-              <p className="font-medium text-gray-900 dark:text-white text-sm">
-                {topic.name}
-              </p>
-              <p className="text-xs text-gray-500 dark:text-zinc-400">
-                {topic.postsCount} posts about{' '}
-                <Badge variant="neutral" size="sm">
-                  {topic.relatedKeyword}
-                </Badge>
-              </p>
-            </div>
-            <div
-              className={cn(
-                'flex items-center gap-1 text-xs',
-                topic.growth >= 0 ? 'text-success-light' : 'text-error-light'
-              )}
+          <li key={topic.getId()}>
+            <button
+              type="button"
+              onClick={onTopicClick}
+              className="w-full flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
             >
-              <TrendingUp className="w-3 h-3" />
-              <span>{topic.growth}%</span>
-            </div>
+              <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-zinc-800 flex items-center justify-center">
+                <Tag className="w-4 h-4 text-gray-500 dark:text-zinc-400" />
+              </div>
+              <div className="flex-1 min-w-0 text-left">
+                <p className="font-medium text-gray-900 dark:text-white text-sm">
+                  {topic.getName()}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-zinc-400">
+                  {topic.getPostCount()} posts about{' '}
+                  <span className="font-semibold text-gray-700 dark:text-zinc-300">
+                    {topic.getName()}
+                  </span>
+                </p>
+              </div>
+              <div
+                className={cn(
+                  'flex items-center gap-1 text-xs',
+                  topic.getGrowthPercentage() >= 0 ? 'text-success-light' : 'text-error-light'
+                )}
+              >
+                <TrendingUp className="w-3 h-3" />
+                <span>{topic.getGrowthPercentage()}%</span>
+              </div>
+            </button>
           </li>
         ))}
       </ul>
 
       {remainingCount > 0 && (
-        <button className="cursor-pointer w-full mt-3 py-2 text-sm text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-zinc-300 transition-colors">
+        <button
+          onClick={onTopicClick}
+          className="cursor-pointer w-full mt-3 py-2 text-sm text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-zinc-300 transition-colors"
+        >
           + {remainingCount} more
         </button>
       )}

--- a/src/components/audiences/detail/TopicsTable.tsx
+++ b/src/components/audiences/detail/TopicsTable.tsx
@@ -222,7 +222,7 @@ export function TopicsTable({
               }`}
             >
               <div className="flex items-center gap-4">
-                <p className="font-semibold text-gray-900 dark:text-white truncate w-32 shrink-0">
+                <p className="font-semibold text-gray-900 dark:text-white truncate  shrink-0">
                   {topic.name}
                 </p>
 
@@ -236,7 +236,7 @@ export function TopicsTable({
                     <span>{topic.growth}%</span>
                   </div>
 
-                  <div className="text-sm text-right w-64 shrink-0 truncate">
+                  <div className="text-sm text-right shrink-0 truncate mr-2">
                     <span className="text-lime font-semibold">
                       {topic.frequency} / {topic.frequencyUnit}
                     </span>


### PR DESCRIPTION
## Summary
- Conecta dados reais de tópicos (via `useGetAudienceTopics`) à prévia na aba Search (overview)
- `TopicsList` agora usa a entidade de domínio `Topic` ao invés do tipo mock
- Exibe 5 primeiros tópicos com nome, post count e growth %, com botão "+ X more"
- Clicar em qualquer tópico ou no botão "+ X more" navega para a tab Topics

## Arquivos alterados
- `TopicsList.tsx` — Tipo mock → entidade de domínio, 6→5 itens, ícone Tag, navegação via onClick
- `SearchTabContent.tsx` — Novas props `topics`, `totalTopics`, `onTopicClick`
- `AudienceDetailTabs.tsx` — Passa dados de tópicos e callback para SearchTabContent
- `TopicsTable.tsx` — Ajustes de layout pré-existentes

## Test plan
- [ ] Abrir uma audience e verificar que a aba Search mostra 5 tópicos reais
- [ ] Verificar que o count no header reflete o total dinâmico
- [ ] Clicar em um tópico na prévia e confirmar que navega para a tab Topics
- [ ] Clicar em "+ X more" e confirmar que navega para a tab Topics
- [ ] Verificar que a tab Topics completa continua funcionando normalmente

Closes #51