### PR TITLE
feat: implement real-time notification system with SSE

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -4,11 +4,13 @@ import { gsap } from '@/lib/gsap'
 import { Sidebar } from './Sidebar'
 import { Topbar } from './Topbar'
 import { useReducedMotion } from '@/hooks'
+import { useNotificationSSE } from '@/modules/notifications'
 
 export function MainLayout() {
   const contentRef = useRef<HTMLDivElement>(null)
   const location = useLocation()
   const prefersReducedMotion = useReducedMotion()
+  useNotificationSSE()
 
   useEffect(() => {
     if (!contentRef.current || prefersReducedMotion) return

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   User,
   Link2,
   Smartphone,
+  Bell,
   Settings,
   HelpCircle,
   LogOut,
@@ -29,6 +30,7 @@ const navItems = [
   { icon: User, path: '/customers', label: 'Customers' },
   { icon: Link2, path: '/integrations', label: 'Integrations' },
   { icon: Smartphone, path: '/mobile', label: 'Mobile' },
+  { icon: Bell, path: '/notifications', label: 'Notifications' },
 ]
 
 const bottomItems = [

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -14,6 +14,8 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useThemeStore } from '@/modules/shared'
 import { useAuthStore, useLogout } from '@/modules/auth'
+import { useUnreadCount, useNotificationStore } from '@/modules/notifications'
+import { NotificationDropdown } from '@/components/notifications'
 import { useReducedMotion } from '@/hooks'
 
 const pageNames: Record<string, string> = {
@@ -29,6 +31,7 @@ const pageNames: Record<string, string> = {
   '/settings': 'Settings',
   '/help': 'Help',
   '/profile': 'Profile',
+  '/notifications': 'Notifications',
 }
 
 export function Topbar() {
@@ -41,6 +44,8 @@ export function Topbar() {
   const { user } = useAuthStore()
   const handleLogout = useLogout()
   const prefersReducedMotion = useReducedMotion()
+  useUnreadCount()
+  const unreadCount = useNotificationStore((state) => state.unreadCount)
 
   const userName = user?.getFullName() || 'User'
   const userRole = user?.getIsSuperuser() ? 'Admin' : 'Member'
@@ -63,9 +68,12 @@ export function Topbar() {
   }, [prefersReducedMotion])
 
   useEffect(() => {
-    if (!bellRef.current || prefersReducedMotion) return
+    if (!bellRef.current || prefersReducedMotion || unreadCount === 0) return
 
-    const pulse = gsap.to(bellRef.current?.querySelector('.notification-badge'), {
+    const badge = bellRef.current?.querySelector('.notification-badge')
+    if (!badge) return
+
+    const pulse = gsap.to(badge, {
       scale: 1.3,
       duration: 0.8,
       repeat: -1,
@@ -76,7 +84,7 @@ export function Topbar() {
     return () => {
       pulse.kill()
     }
-  }, [prefersReducedMotion])
+  }, [prefersReducedMotion, unreadCount])
 
   const handleThemeToggle = () => {
     if (!prefersReducedMotion && themeIconRef.current) {
@@ -130,16 +138,20 @@ export function Topbar() {
           )}
         </button>
 
-        <button
-          ref={bellRef}
-          className="relative w-10 h-10 rounded-full flex items-center justify-center text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
-          title="Notifications"
-        >
-          <Bell className="w-5 h-5" />
-          <span className="notification-badge absolute top-1.5 right-1.5 w-4 h-4 bg-red-500 text-white text-xs font-bold rounded-full flex items-center justify-center">
-            3
-          </span>
-        </button>
+        <NotificationDropdown>
+          <button
+            ref={bellRef}
+            className="relative w-10 h-10 rounded-full flex items-center justify-center text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+            title="Notifications"
+          >
+            <Bell className="w-5 h-5" />
+            {unreadCount > 0 && (
+              <span className="notification-badge absolute top-1.5 right-1.5 w-4 h-4 bg-red-500 text-white text-xs font-bold rounded-full flex items-center justify-center">
+                {unreadCount > 9 ? '9+' : unreadCount}
+              </span>
+            )}
+          </button>
+        </NotificationDropdown>
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/src/components/notifications/NotificationCard.tsx
+++ b/src/components/notifications/NotificationCard.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from 'react-i18next'
+import { Check, Clock } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { Notification } from '@/modules/notifications'
+import { NotificationIcon } from './NotificationIcon'
+
+interface NotificationCardProps {
+  notification: Notification
+  onMarkAsRead?: (id: string) => void
+  isMarkingRead?: boolean
+}
+
+function useTimeAgo(dateString: string) {
+  const { t } = useTranslation('notifications')
+
+  const now = new Date()
+  const date = new Date(dateString)
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return t('time.justNow')
+  if (diffMins < 60) return t('time.minutesAgo', { count: diffMins })
+  if (diffHours < 24) return t('time.hoursAgo', { count: diffHours })
+  return t('time.daysAgo', { count: diffDays })
+}
+
+export function NotificationCard({ notification, onMarkAsRead, isMarkingRead }: Readonly<NotificationCardProps>) {
+  const { t } = useTranslation('notifications')
+  const timeAgo = useTimeAgo(notification.getCreatedAt())
+  const isUnread = !notification.getIsRead()
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-4 p-4 rounded-2xl border transition-colors',
+        isUnread
+          ? 'bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-700'
+          : 'bg-gray-50/50 dark:bg-zinc-900/50 border-gray-100 dark:border-zinc-800'
+      )}
+    >
+      <NotificationIcon type={notification.getType()} />
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <h4 className={cn(
+            'text-sm font-semibold truncate',
+            isUnread
+              ? 'text-gray-900 dark:text-white'
+              : 'text-gray-600 dark:text-zinc-400'
+          )}>
+            {notification.getTitle()}
+          </h4>
+          {isUnread && (
+            <span className="w-2 h-2 rounded-full bg-red-500 flex-shrink-0" />
+          )}
+        </div>
+
+        <p className="text-sm text-gray-500 dark:text-zinc-400 mt-0.5 line-clamp-2">
+          {notification.getMessage()}
+        </p>
+
+        {isUnread && onMarkAsRead && (
+          <button
+            onClick={() => onMarkAsRead(notification.getId())}
+            disabled={isMarkingRead}
+            className="flex items-center gap-1.5 mt-2 text-xs font-medium text-lime-600 dark:text-lime-400 hover:text-lime-700 dark:hover:text-lime-300 transition-colors cursor-pointer disabled:opacity-50"
+          >
+            <Check className="w-3.5 h-3.5" />
+            {t('actions.markAsRead')}
+          </button>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1.5 text-xs text-gray-400 dark:text-zinc-500 flex-shrink-0 mt-0.5">
+        <Clock className="w-3.5 h-3.5" />
+        {timeAgo}
+      </div>
+    </div>
+  )
+}

--- a/src/components/notifications/NotificationDropdown.tsx
+++ b/src/components/notifications/NotificationDropdown.tsx
@@ -1,0 +1,126 @@
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { cn } from '@/lib/utils'
+import { useListNotifications, useNotificationStore } from '@/modules/notifications'
+import { Badge } from '@/components/ui'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { NotificationIcon } from './NotificationIcon'
+
+interface NotificationDropdownProps {
+  children: React.ReactNode
+}
+
+function useTimeAgo(dateString: string) {
+  const { t } = useTranslation('notifications')
+
+  const now = new Date()
+  const date = new Date(dateString)
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return t('time.justNow')
+  if (diffMins < 60) return t('time.minutesAgo', { count: diffMins })
+  if (diffHours < 24) return t('time.hoursAgo', { count: diffHours })
+  return t('time.daysAgo', { count: diffDays })
+}
+
+function DropdownNotificationItem({ notification }: Readonly<{ notification: { id: string; type: string; title: string; isRead: boolean; createdAt: string } }>) {
+  const timeAgo = useTimeAgo(notification.createdAt)
+
+  return (
+    <div className="flex items-start gap-3 px-3 py-2.5 rounded-xl hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors">
+      <div className="mt-0.5">
+        {notification.isRead ? (
+          <span className="block w-2 h-2 rounded-full bg-gray-300 dark:bg-zinc-600" />
+        ) : (
+          <span className="block w-2 h-2 rounded-full bg-red-500" />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className={cn(
+          'text-sm truncate',
+          notification.isRead
+            ? 'text-gray-500 dark:text-zinc-400'
+            : 'text-gray-900 dark:text-white font-medium'
+        )}>
+          {notification.title}
+        </p>
+        <p className="text-xs text-gray-400 dark:text-zinc-500 mt-0.5">
+          {timeAgo}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export function NotificationDropdown({ children }: Readonly<NotificationDropdownProps>) {
+  const { t } = useTranslation('notifications')
+  const navigate = useNavigate()
+  const unreadCount = useNotificationStore((state) => state.unreadCount)
+  const { data } = useListNotifications({ limit: 5, offset: 0 })
+
+  const notifications = (data?.notifications ?? []).map((n) => ({
+    id: n.getId(),
+    type: n.getType(),
+    title: n.getTitle(),
+    isRead: n.getIsRead(),
+    createdAt: n.getCreatedAt(),
+  }))
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {children}
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        align="end"
+        className="w-80 bg-white dark:bg-zinc-900 rounded-2xl border-gray-100 dark:border-zinc-800 p-3"
+      >
+        <div className="flex items-center justify-between mb-2 px-1">
+          <h3 className="text-sm font-bold text-gray-900 dark:text-white">
+            {t('dropdown.title')}
+          </h3>
+          {unreadCount > 0 && (
+            <Badge variant="info" size="sm">
+              {t('dropdown.newCount', { count: unreadCount })}
+            </Badge>
+          )}
+        </div>
+
+        <div className="max-h-72 overflow-y-auto">
+          {notifications.length === 0 ? (
+            <div className="py-6 text-center">
+              <NotificationIcon type="behavioral_pattern_complete" className="mx-auto mb-2" />
+              <p className="text-sm text-gray-500 dark:text-zinc-400">
+                {t('dropdown.empty')}
+              </p>
+            </div>
+          ) : (
+            notifications.map((notification) => (
+              <DropdownNotificationItem
+                key={notification.id}
+                notification={notification}
+              />
+            ))
+          )}
+        </div>
+
+        <div className="border-t border-gray-100 dark:border-zinc-800 mt-2 pt-2">
+          <button
+            onClick={() => navigate('/notifications')}
+            className="w-full text-center text-sm font-medium text-gray-600 dark:text-zinc-300 hover:text-gray-900 dark:hover:text-white py-2 rounded-xl hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+          >
+            {t('dropdown.viewAll')}
+          </button>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/components/notifications/NotificationIcon.tsx
+++ b/src/components/notifications/NotificationIcon.tsx
@@ -1,0 +1,49 @@
+import { CheckCircle, AlertTriangle, Bell, Brain, Search, TrendingUp, Tag, MessageSquare } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { NotificationType } from '@/modules/notifications'
+
+const iconConfig: Record<string, { icon: React.ElementType; bgClass: string; iconClass: string }> = {
+  behavioral_pattern_complete: { icon: Brain, bgClass: 'bg-green-100 dark:bg-green-900/30', iconClass: 'text-green-600 dark:text-green-400' },
+  behavioral_pattern_failed: { icon: Brain, bgClass: 'bg-red-100 dark:bg-red-900/30', iconClass: 'text-red-600 dark:text-red-400' },
+  deep_dive_complete: { icon: Search, bgClass: 'bg-green-100 dark:bg-green-900/30', iconClass: 'text-green-600 dark:text-green-400' },
+  deep_dive_failed: { icon: Search, bgClass: 'bg-red-100 dark:bg-red-900/30', iconClass: 'text-red-600 dark:text-red-400' },
+  pattern_analysis_complete: { icon: TrendingUp, bgClass: 'bg-green-100 dark:bg-green-900/30', iconClass: 'text-green-600 dark:text-green-400' },
+  pattern_analysis_failed: { icon: TrendingUp, bgClass: 'bg-red-100 dark:bg-red-900/30', iconClass: 'text-red-600 dark:text-red-400' },
+  keyword_analysis_complete: { icon: Tag, bgClass: 'bg-green-100 dark:bg-green-900/30', iconClass: 'text-green-600 dark:text-green-400' },
+  keyword_analysis_failed: { icon: Tag, bgClass: 'bg-red-100 dark:bg-red-900/30', iconClass: 'text-red-600 dark:text-red-400' },
+  topic_analysis_complete: { icon: MessageSquare, bgClass: 'bg-green-100 dark:bg-green-900/30', iconClass: 'text-green-600 dark:text-green-400' },
+  topic_analysis_failed: { icon: MessageSquare, bgClass: 'bg-red-100 dark:bg-red-900/30', iconClass: 'text-red-600 dark:text-red-400' },
+}
+
+const defaultConfig = { icon: Bell, bgClass: 'bg-gray-100 dark:bg-zinc-800', iconClass: 'text-gray-500 dark:text-zinc-400' }
+
+interface NotificationIconProps {
+  type: NotificationType
+  className?: string
+}
+
+export function NotificationIcon({ type, className }: Readonly<NotificationIconProps>) {
+  const config = iconConfig[type] ?? defaultConfig
+  const Icon = config.icon
+
+  return (
+    <div
+      className={cn(
+        'w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0',
+        config.bgClass,
+        className
+      )}
+    >
+      <Icon className={cn('w-5 h-5', config.iconClass)} />
+    </div>
+  )
+}
+
+export function NotificationDot({ type }: Readonly<{ type: NotificationType }>) {
+  const isComplete = type.endsWith('_complete')
+  const isFailed = type.endsWith('_failed')
+
+  if (isComplete) return <CheckCircle className="w-4 h-4 text-green-500" />
+  if (isFailed) return <AlertTriangle className="w-4 h-4 text-red-500" />
+  return <Bell className="w-4 h-4 text-gray-400" />
+}

--- a/src/components/notifications/index.ts
+++ b/src/components/notifications/index.ts
@@ -1,0 +1,3 @@
+export { NotificationIcon, NotificationDot } from './NotificationIcon'
+export { NotificationCard } from './NotificationCard'
+export { NotificationDropdown } from './NotificationDropdown'

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -9,6 +9,7 @@ import enDashboard from '@/locales/en/dashboard.json'
 import enAudiences from '@/locales/en/audiences.json'
 import enProfile from '@/locales/en/profile.json'
 import enLanding from '@/locales/en/landing.json'
+import enNotifications from '@/locales/en/notifications.json'
 
 import ptBRCommon from '@/locales/pt-BR/common.json'
 import ptBRAuth from '@/locales/pt-BR/auth.json'
@@ -17,6 +18,7 @@ import ptBRDashboard from '@/locales/pt-BR/dashboard.json'
 import ptBRAudiences from '@/locales/pt-BR/audiences.json'
 import ptBRProfile from '@/locales/pt-BR/profile.json'
 import ptBRLanding from '@/locales/pt-BR/landing.json'
+import ptBRNotifications from '@/locales/pt-BR/notifications.json'
 
 export const defaultNS = 'common'
 
@@ -29,6 +31,7 @@ export const resources = {
     audiences: enAudiences,
     profile: enProfile,
     landing: enLanding,
+    notifications: enNotifications,
   },
   'pt-BR': {
     common: ptBRCommon,
@@ -38,6 +41,7 @@ export const resources = {
     audiences: ptBRAudiences,
     profile: ptBRProfile,
     landing: ptBRLanding,
+    notifications: ptBRNotifications,
   },
 } as const
 

--- a/src/locales/en/notifications.json
+++ b/src/locales/en/notifications.json
@@ -1,0 +1,49 @@
+{
+  "page": {
+    "title": "Notifications",
+    "subtitle": "Stay updated with the latest activity."
+  },
+  "tabs": {
+    "all": "All",
+    "unread": "Unread",
+    "archived": "Archived"
+  },
+  "actions": {
+    "markAsRead": "Mark as read",
+    "markAllAsRead": "Mark all as read"
+  },
+  "dropdown": {
+    "title": "Notifications",
+    "newCount": "{{count}} New",
+    "viewAll": "View All Notifications",
+    "empty": "No new notifications"
+  },
+  "empty": {
+    "all": "No notifications yet",
+    "unread": "All caught up! No unread notifications.",
+    "archived": "No archived notifications"
+  },
+  "types": {
+    "behavioral_pattern_complete": "Behavioral Patterns Ready",
+    "behavioral_pattern_failed": "Behavioral Patterns Failed",
+    "deep_dive_complete": "Deep Dive Ready",
+    "deep_dive_failed": "Deep Dive Failed",
+    "pattern_analysis_complete": "Pattern Analysis Ready",
+    "pattern_analysis_failed": "Pattern Analysis Failed",
+    "keyword_analysis_complete": "Keywords Ready",
+    "keyword_analysis_failed": "Keywords Failed",
+    "topic_analysis_complete": "Topics Ready",
+    "topic_analysis_failed": "Topics Failed"
+  },
+  "time": {
+    "justNow": "Just now",
+    "minutesAgo": "{{count}} min ago",
+    "hoursAgo": "{{count}}h ago",
+    "daysAgo": "{{count}}d ago"
+  },
+  "toast": {
+    "markedAsRead": "Notification marked as read",
+    "allMarkedAsRead": "All notifications marked as read",
+    "error": "Failed to update notification"
+  }
+}

--- a/src/locales/pt-BR/notifications.json
+++ b/src/locales/pt-BR/notifications.json
@@ -1,0 +1,49 @@
+{
+  "page": {
+    "title": "Notificacoes",
+    "subtitle": "Fique por dentro das ultimas atividades."
+  },
+  "tabs": {
+    "all": "Todas",
+    "unread": "Nao lidas",
+    "archived": "Arquivadas"
+  },
+  "actions": {
+    "markAsRead": "Marcar como lida",
+    "markAllAsRead": "Marcar todas como lidas"
+  },
+  "dropdown": {
+    "title": "Notificacoes",
+    "newCount": "{{count}} Novas",
+    "viewAll": "Ver Todas as Notificacoes",
+    "empty": "Nenhuma notificacao nova"
+  },
+  "empty": {
+    "all": "Nenhuma notificacao ainda",
+    "unread": "Tudo em dia! Nenhuma notificacao nao lida.",
+    "archived": "Nenhuma notificacao arquivada"
+  },
+  "types": {
+    "behavioral_pattern_complete": "Padroes Comportamentais Prontos",
+    "behavioral_pattern_failed": "Padroes Comportamentais Falharam",
+    "deep_dive_complete": "Deep Dive Pronto",
+    "deep_dive_failed": "Deep Dive Falhou",
+    "pattern_analysis_complete": "Analise de Padroes Pronta",
+    "pattern_analysis_failed": "Analise de Padroes Falhou",
+    "keyword_analysis_complete": "Keywords Prontas",
+    "keyword_analysis_failed": "Keywords Falharam",
+    "topic_analysis_complete": "Topicos Prontos",
+    "topic_analysis_failed": "Topicos Falharam"
+  },
+  "time": {
+    "justNow": "Agora mesmo",
+    "minutesAgo": "{{count}} min atras",
+    "hoursAgo": "{{count}}h atras",
+    "daysAgo": "{{count}}d atras"
+  },
+  "toast": {
+    "markedAsRead": "Notificacao marcada como lida",
+    "allMarkedAsRead": "Todas as notificacoes marcadas como lidas",
+    "error": "Erro ao atualizar notificacao"
+  }
+}

--- a/src/modules/notifications/application/hooks/useNotificationSSE.ts
+++ b/src/modules/notifications/application/hooks/useNotificationSSE.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '@/modules/auth'
+import { toast } from '@/hooks/useToast'
+import { NotificationSSEService } from '../../infra/services/sse.service'
+import { useNotificationStore } from '../store/notification.store'
+import { NOTIFICATIONS_QUERY_KEY, UNREAD_COUNT_QUERY_KEY } from './useNotifications'
+
+export function useNotificationSSE() {
+  const sseRef = useRef<NotificationSSEService | null>(null)
+  const { isAuthenticated } = useAuthStore()
+  const queryClient = useQueryClient()
+  const incrementUnreadCount = useNotificationStore((state) => state.incrementUnreadCount)
+  const addRealtimeNotification = useNotificationStore((state) => state.addRealtimeNotification)
+  const setSSEConnected = useNotificationStore((state) => state.setSSEConnected)
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      if (sseRef.current) {
+        sseRef.current.disconnect()
+        sseRef.current = null
+        setSSEConnected(false)
+      }
+      return
+    }
+
+    const sseService = new NotificationSSEService()
+    sseRef.current = sseService
+
+    sseService.connect({
+      onNotification: (notification) => {
+        addRealtimeNotification(notification)
+        incrementUnreadCount()
+        queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_QUERY_KEY })
+        queryClient.invalidateQueries({ queryKey: UNREAD_COUNT_QUERY_KEY })
+
+        toast({
+          title: notification.getTitle(),
+          description: notification.getMessage(),
+          variant: notification.isSuccess() ? 'success' : 'destructive',
+        })
+      },
+      onOpen: () => {
+        setSSEConnected(true)
+      },
+      onError: () => {
+        setSSEConnected(false)
+      },
+    })
+
+    return () => {
+      sseService.disconnect()
+      setSSEConnected(false)
+    }
+  }, [isAuthenticated, queryClient, incrementUnreadCount, addRealtimeNotification, setSSEConnected])
+}

--- a/src/modules/notifications/application/hooks/useNotifications.ts
+++ b/src/modules/notifications/application/hooks/useNotifications.ts
@@ -1,0 +1,62 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IListNotificationsUseCase, IGetUnreadCountUseCase, IMarkNotificationReadUseCase, IMarkAllReadUseCase } from '../../domain/use-cases'
+import type { ListNotificationsParams } from '../../domain/repositories'
+import { useNotificationStore } from '../store/notification.store'
+
+const listNotificationsUseCase = container.get<IListNotificationsUseCase>(TYPES.ListNotificationsUseCase)
+const getUnreadCountUseCase = container.get<IGetUnreadCountUseCase>(TYPES.GetUnreadCountUseCase)
+const markNotificationReadUseCase = container.get<IMarkNotificationReadUseCase>(TYPES.MarkNotificationReadUseCase)
+const markAllReadUseCase = container.get<IMarkAllReadUseCase>(TYPES.MarkAllReadUseCase)
+
+export const NOTIFICATIONS_QUERY_KEY = ['notifications'] as const
+export const UNREAD_COUNT_QUERY_KEY = ['notifications', 'unread-count'] as const
+
+export function useListNotifications(params: ListNotificationsParams) {
+  return useQuery({
+    queryKey: [...NOTIFICATIONS_QUERY_KEY, params],
+    queryFn: () => listNotificationsUseCase.execute(params),
+  })
+}
+
+export function useUnreadCount() {
+  const setUnreadCount = useNotificationStore((state) => state.setUnreadCount)
+
+  return useQuery({
+    queryKey: [...UNREAD_COUNT_QUERY_KEY],
+    queryFn: async () => {
+      const count = await getUnreadCountUseCase.execute()
+      setUnreadCount(count)
+      return count
+    },
+    refetchInterval: 60000,
+  })
+}
+
+export function useMarkAsRead() {
+  const queryClient = useQueryClient()
+  const decrementUnreadCount = useNotificationStore((state) => state.decrementUnreadCount)
+
+  return useMutation({
+    mutationFn: (id: string) => markNotificationReadUseCase.execute(id),
+    onSuccess: () => {
+      decrementUnreadCount()
+      queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: UNREAD_COUNT_QUERY_KEY })
+    },
+  })
+}
+
+export function useMarkAllAsRead() {
+  const queryClient = useQueryClient()
+  const resetUnreadCount = useNotificationStore((state) => state.resetUnreadCount)
+
+  return useMutation({
+    mutationFn: () => markAllReadUseCase.execute(),
+    onSuccess: () => {
+      resetUnreadCount()
+      queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: UNREAD_COUNT_QUERY_KEY })
+    },
+  })
+}

--- a/src/modules/notifications/application/store/notification.store.ts
+++ b/src/modules/notifications/application/store/notification.store.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand'
+import type { Notification } from '../../domain/entities'
+
+interface NotificationState {
+  unreadCount: number
+  isSSEConnected: boolean
+  realtimeNotifications: Notification[]
+
+  setUnreadCount: (count: number) => void
+  incrementUnreadCount: () => void
+  decrementUnreadCount: () => void
+  addRealtimeNotification: (notification: Notification) => void
+  setSSEConnected: (connected: boolean) => void
+  clearRealtimeNotifications: () => void
+  resetUnreadCount: () => void
+}
+
+export const useNotificationStore = create<NotificationState>()((set) => ({
+  unreadCount: 0,
+  isSSEConnected: false,
+  realtimeNotifications: [],
+
+  setUnreadCount: (count) => set({ unreadCount: count }),
+  incrementUnreadCount: () => set((state) => ({ unreadCount: state.unreadCount + 1 })),
+  decrementUnreadCount: () => set((state) => ({ unreadCount: Math.max(0, state.unreadCount - 1) })),
+  addRealtimeNotification: (notification) =>
+    set((state) => ({
+      realtimeNotifications: [notification, ...state.realtimeNotifications].slice(0, 20),
+    })),
+  setSSEConnected: (connected) => set({ isSSEConnected: connected }),
+  clearRealtimeNotifications: () => set({ realtimeNotifications: [] }),
+  resetUnreadCount: () => set({ unreadCount: 0 }),
+}))

--- a/src/modules/notifications/application/use-cases/get-unread-count/index.ts
+++ b/src/modules/notifications/application/use-cases/get-unread-count/index.ts
@@ -1,0 +1,10 @@
+import type { INotificationRepository } from '../../../domain/repositories'
+import type { IGetUnreadCountUseCase } from '../../../domain/use-cases'
+
+export class GetUnreadCountUseCase implements IGetUnreadCountUseCase {
+  constructor(private readonly notificationRepository: INotificationRepository) {}
+
+  async execute(): Promise<number> {
+    return this.notificationRepository.getUnreadCount()
+  }
+}

--- a/src/modules/notifications/application/use-cases/index.ts
+++ b/src/modules/notifications/application/use-cases/index.ts
@@ -1,0 +1,4 @@
+export { ListNotificationsUseCase } from './list-notifications'
+export { GetUnreadCountUseCase } from './get-unread-count'
+export { MarkNotificationReadUseCase } from './mark-notification-read'
+export { MarkAllReadUseCase } from './mark-all-read'

--- a/src/modules/notifications/application/use-cases/list-notifications/index.ts
+++ b/src/modules/notifications/application/use-cases/list-notifications/index.ts
@@ -1,0 +1,10 @@
+import type { INotificationRepository, ListNotificationsParams, ListNotificationsResult } from '../../../domain/repositories'
+import type { IListNotificationsUseCase } from '../../../domain/use-cases'
+
+export class ListNotificationsUseCase implements IListNotificationsUseCase {
+  constructor(private readonly notificationRepository: INotificationRepository) {}
+
+  async execute(params: ListNotificationsParams): Promise<ListNotificationsResult> {
+    return this.notificationRepository.listNotifications(params)
+  }
+}

--- a/src/modules/notifications/application/use-cases/mark-all-read/index.ts
+++ b/src/modules/notifications/application/use-cases/mark-all-read/index.ts
@@ -1,0 +1,10 @@
+import type { INotificationRepository } from '../../../domain/repositories'
+import type { IMarkAllReadUseCase } from '../../../domain/use-cases'
+
+export class MarkAllReadUseCase implements IMarkAllReadUseCase {
+  constructor(private readonly notificationRepository: INotificationRepository) {}
+
+  async execute(): Promise<void> {
+    return this.notificationRepository.markAllAsRead()
+  }
+}

--- a/src/modules/notifications/application/use-cases/mark-notification-read/index.ts
+++ b/src/modules/notifications/application/use-cases/mark-notification-read/index.ts
@@ -1,0 +1,10 @@
+import type { INotificationRepository } from '../../../domain/repositories'
+import type { IMarkNotificationReadUseCase } from '../../../domain/use-cases'
+
+export class MarkNotificationReadUseCase implements IMarkNotificationReadUseCase {
+  constructor(private readonly notificationRepository: INotificationRepository) {}
+
+  async execute(id: string): Promise<void> {
+    return this.notificationRepository.markAsRead(id)
+  }
+}

--- a/src/modules/notifications/domain/entities/index.ts
+++ b/src/modules/notifications/domain/entities/index.ts
@@ -1,0 +1,2 @@
+export { Notification } from './notification.entity'
+export type { NotificationProps, NotificationType, NotificationMetadata } from './notification.entity'

--- a/src/modules/notifications/domain/entities/notification.entity.ts
+++ b/src/modules/notifications/domain/entities/notification.entity.ts
@@ -1,0 +1,113 @@
+export type NotificationType =
+  | 'behavioral_pattern_complete'
+  | 'behavioral_pattern_failed'
+  | 'deep_dive_complete'
+  | 'deep_dive_failed'
+  | 'pattern_analysis_complete'
+  | 'pattern_analysis_failed'
+  | 'keyword_analysis_complete'
+  | 'keyword_analysis_failed'
+  | 'topic_analysis_complete'
+  | 'topic_analysis_failed'
+
+export interface NotificationMetadata {
+  audience_id?: string
+  topic_id?: string
+  topic_name?: string
+  analysis_id?: string
+  [key: string]: unknown
+}
+
+export interface NotificationProps {
+  id: string
+  userId: string
+  type: NotificationType
+  title: string
+  message: string
+  metadata: NotificationMetadata
+  isRead: boolean
+  createdAt: string
+  readAt: string | null
+}
+
+export class Notification {
+  private readonly id: string
+  private readonly userId: string
+  private readonly type: NotificationType
+  private readonly title: string
+  private readonly message: string
+  private readonly metadata: NotificationMetadata
+  private readonly isRead: boolean
+  private readonly createdAt: string
+  private readonly readAt: string | null
+
+  constructor(props: NotificationProps) {
+    this.id = props.id
+    this.userId = props.userId
+    this.type = props.type
+    this.title = props.title
+    this.message = props.message
+    this.metadata = props.metadata
+    this.isRead = props.isRead
+    this.createdAt = props.createdAt
+    this.readAt = props.readAt
+  }
+
+  getId(): string {
+    return this.id
+  }
+
+  getUserId(): string {
+    return this.userId
+  }
+
+  getType(): NotificationType {
+    return this.type
+  }
+
+  getTitle(): string {
+    return this.title
+  }
+
+  getMessage(): string {
+    return this.message
+  }
+
+  getMetadata(): NotificationMetadata {
+    return this.metadata
+  }
+
+  getIsRead(): boolean {
+    return this.isRead
+  }
+
+  getCreatedAt(): string {
+    return this.createdAt
+  }
+
+  getReadAt(): string | null {
+    return this.readAt
+  }
+
+  isSuccess(): boolean {
+    return this.type.endsWith('_complete')
+  }
+
+  isFailure(): boolean {
+    return this.type.endsWith('_failed')
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      userId: this.userId,
+      type: this.type,
+      title: this.title,
+      message: this.message,
+      metadata: this.metadata,
+      isRead: this.isRead,
+      createdAt: this.createdAt,
+      readAt: this.readAt,
+    }
+  }
+}

--- a/src/modules/notifications/domain/repositories/index.ts
+++ b/src/modules/notifications/domain/repositories/index.ts
@@ -1,0 +1,1 @@
+export type { INotificationRepository, ListNotificationsParams, ListNotificationsResult } from './notification.repository'

--- a/src/modules/notifications/domain/repositories/notification.repository.ts
+++ b/src/modules/notifications/domain/repositories/notification.repository.ts
@@ -1,0 +1,19 @@
+import type { Notification } from '../entities'
+
+export interface ListNotificationsParams {
+  limit?: number
+  offset?: number
+  unread_only?: boolean
+}
+
+export interface ListNotificationsResult {
+  notifications: Notification[]
+  total: number
+}
+
+export interface INotificationRepository {
+  listNotifications(params: ListNotificationsParams): Promise<ListNotificationsResult>
+  getUnreadCount(): Promise<number>
+  markAsRead(id: string): Promise<void>
+  markAllAsRead(): Promise<void>
+}

--- a/src/modules/notifications/domain/use-cases/get-unread-count.use-case.ts
+++ b/src/modules/notifications/domain/use-cases/get-unread-count.use-case.ts
@@ -1,0 +1,3 @@
+export interface IGetUnreadCountUseCase {
+  execute(): Promise<number>
+}

--- a/src/modules/notifications/domain/use-cases/index.ts
+++ b/src/modules/notifications/domain/use-cases/index.ts
@@ -1,0 +1,4 @@
+export type { IListNotificationsUseCase } from './list-notifications.use-case'
+export type { IGetUnreadCountUseCase } from './get-unread-count.use-case'
+export type { IMarkNotificationReadUseCase } from './mark-notification-read.use-case'
+export type { IMarkAllReadUseCase } from './mark-all-read.use-case'

--- a/src/modules/notifications/domain/use-cases/list-notifications.use-case.ts
+++ b/src/modules/notifications/domain/use-cases/list-notifications.use-case.ts
@@ -1,0 +1,5 @@
+import type { ListNotificationsParams, ListNotificationsResult } from '../repositories'
+
+export interface IListNotificationsUseCase {
+  execute(params: ListNotificationsParams): Promise<ListNotificationsResult>
+}

--- a/src/modules/notifications/domain/use-cases/mark-all-read.use-case.ts
+++ b/src/modules/notifications/domain/use-cases/mark-all-read.use-case.ts
@@ -1,0 +1,3 @@
+export interface IMarkAllReadUseCase {
+  execute(): Promise<void>
+}

--- a/src/modules/notifications/domain/use-cases/mark-notification-read.use-case.ts
+++ b/src/modules/notifications/domain/use-cases/mark-notification-read.use-case.ts
@@ -1,0 +1,3 @@
+export interface IMarkNotificationReadUseCase {
+  execute(id: string): Promise<void>
+}

--- a/src/modules/notifications/index.ts
+++ b/src/modules/notifications/index.ts
@@ -1,0 +1,12 @@
+export { Notification } from './domain/entities'
+export type { NotificationProps, NotificationType, NotificationMetadata } from './domain/entities'
+export type { INotificationRepository, ListNotificationsParams, ListNotificationsResult } from './domain/repositories'
+export type { IListNotificationsUseCase, IGetUnreadCountUseCase, IMarkNotificationReadUseCase, IMarkAllReadUseCase } from './domain/use-cases'
+
+export { NotificationRepository } from './infra/repositories'
+export { NotificationSSEService } from './infra/services/sse.service'
+
+export { ListNotificationsUseCase, GetUnreadCountUseCase, MarkNotificationReadUseCase, MarkAllReadUseCase } from './application/use-cases'
+export { useListNotifications, useUnreadCount, useMarkAsRead, useMarkAllAsRead, NOTIFICATIONS_QUERY_KEY, UNREAD_COUNT_QUERY_KEY } from './application/hooks/useNotifications'
+export { useNotificationSSE } from './application/hooks/useNotificationSSE'
+export { useNotificationStore } from './application/store/notification.store'

--- a/src/modules/notifications/infra/repositories/index.ts
+++ b/src/modules/notifications/infra/repositories/index.ts
@@ -1,0 +1,1 @@
+export { NotificationRepository } from './notification.repository'

--- a/src/modules/notifications/infra/repositories/notification.repository.ts
+++ b/src/modules/notifications/infra/repositories/notification.repository.ts
@@ -1,0 +1,62 @@
+import type { HttpClient } from '@/modules/shared'
+import { Notification, type NotificationProps } from '../../domain/entities'
+import type { INotificationRepository, ListNotificationsParams, ListNotificationsResult } from '../../domain/repositories'
+
+export class NotificationRepository implements INotificationRepository {
+  constructor(private readonly httpClient: HttpClient) {}
+
+  async listNotifications(params: ListNotificationsParams): Promise<ListNotificationsResult> {
+    const searchParams = new URLSearchParams()
+    if (params.limit !== undefined) searchParams.set('limit', String(params.limit))
+    if (params.offset !== undefined) searchParams.set('offset', String(params.offset))
+    if (params.unread_only !== undefined) searchParams.set('unread_only', String(params.unread_only))
+
+    const query = searchParams.toString()
+    const url = query ? `notifications?${query}` : 'notifications'
+
+    const response = await this.httpClient.get<{
+      notifications: Array<{
+        id: string
+        user_id: string
+        type: string
+        title: string
+        message: string
+        metadata: Record<string, unknown>
+        is_read: boolean
+        created_at: string
+        read_at: string | null
+      }>
+      total: number
+    }>(url)
+
+    const notifications = (response.notifications ?? []).map(
+      (n) =>
+        new Notification({
+          id: n.id,
+          userId: n.user_id,
+          type: n.type as NotificationProps['type'],
+          title: n.title,
+          message: n.message,
+          metadata: n.metadata,
+          isRead: n.is_read,
+          createdAt: n.created_at,
+          readAt: n.read_at,
+        })
+    )
+
+    return { notifications, total: response.total ?? notifications.length }
+  }
+
+  async getUnreadCount(): Promise<number> {
+    const response = await this.httpClient.get<{ count: number }>('notifications/unread-count')
+    return response.count ?? 0
+  }
+
+  async markAsRead(id: string): Promise<void> {
+    await this.httpClient.patch<void>(`notifications/${id}/read`)
+  }
+
+  async markAllAsRead(): Promise<void> {
+    await this.httpClient.patch<void>('notifications/read-all')
+  }
+}

--- a/src/modules/notifications/infra/services/sse.service.ts
+++ b/src/modules/notifications/infra/services/sse.service.ts
@@ -1,0 +1,74 @@
+import { Notification, type NotificationProps } from '../../domain/entities'
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+export interface SSECallbacks {
+  onNotification: (notification: Notification) => void
+  onOpen?: () => void
+  onError?: (error: Event) => void
+}
+
+export class NotificationSSEService {
+  private eventSource: EventSource | null = null
+
+  connect(callbacks: SSECallbacks): void {
+    this.disconnect()
+
+    const token = localStorage.getItem('access_token')
+    if (!token) return
+
+    const url = `${API_BASE_URL}/notifications/stream?token=${token}`
+    this.eventSource = new EventSource(url)
+
+    this.eventSource.onopen = () => {
+      callbacks.onOpen?.()
+    }
+
+    this.eventSource.addEventListener('notification', (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data) as {
+          id: string
+          user_id: string
+          type: string
+          title: string
+          message: string
+          metadata: Record<string, unknown>
+          is_read: boolean
+          created_at: string
+          read_at: string | null
+        }
+
+        const notification = new Notification({
+          id: data.id,
+          userId: data.user_id,
+          type: data.type as NotificationProps['type'],
+          title: data.title,
+          message: data.message,
+          metadata: data.metadata,
+          isRead: data.is_read,
+          createdAt: data.created_at,
+          readAt: data.read_at,
+        })
+
+        callbacks.onNotification(notification)
+      } catch {
+        // Silently ignore parse errors
+      }
+    })
+
+    this.eventSource.onerror = (error) => {
+      callbacks.onError?.(error)
+    }
+  }
+
+  disconnect(): void {
+    if (this.eventSource) {
+      this.eventSource.close()
+      this.eventSource = null
+    }
+  }
+
+  isConnected(): boolean {
+    return this.eventSource?.readyState === EventSource.OPEN
+  }
+}

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -13,6 +13,10 @@ import { AuthRepository } from '@/modules/auth/infra/repositories'
 import type { IAuthRepository } from '@/modules/auth/domain/repositories'
 import { LoginUseCase, RegisterUseCase, RefreshTokenUseCase, GetMeUseCase, UpdateProfileUseCase, UpdateLanguageUseCase } from '@/modules/auth/application/use-cases'
 import type { ILoginUseCase, IRegisterUseCase, IRefreshTokenUseCase, IGetMeUseCase, IUpdateProfileUseCase, IUpdateLanguageUseCase } from '@/modules/auth/domain/use-cases'
+import { NotificationRepository } from '@/modules/notifications/infra/repositories'
+import type { INotificationRepository } from '@/modules/notifications/domain/repositories'
+import { ListNotificationsUseCase, GetUnreadCountUseCase, MarkNotificationReadUseCase, MarkAllReadUseCase } from '@/modules/notifications/application/use-cases'
+import type { IListNotificationsUseCase, IGetUnreadCountUseCase, IMarkNotificationReadUseCase, IMarkAllReadUseCase } from '@/modules/notifications/domain/use-cases'
 
 const container = new Container()
 
@@ -141,6 +145,31 @@ container.bind<IUpdateProfileUseCase>(TYPES.UpdateProfileUseCase).toDynamicValue
 container.bind<IUpdateLanguageUseCase>(TYPES.UpdateLanguageUseCase).toDynamicValue(() => {
   const authRepository = container.get<IAuthRepository>(TYPES.AuthRepository)
   return new UpdateLanguageUseCase(authRepository)
+}).inSingletonScope()
+
+container.bind<INotificationRepository>(TYPES.NotificationRepository).toDynamicValue(() => {
+  const httpClient = container.get<HttpClient>(TYPES.HttpClient)
+  return new NotificationRepository(httpClient)
+}).inSingletonScope()
+
+container.bind<IListNotificationsUseCase>(TYPES.ListNotificationsUseCase).toDynamicValue(() => {
+  const notificationRepository = container.get<INotificationRepository>(TYPES.NotificationRepository)
+  return new ListNotificationsUseCase(notificationRepository)
+}).inSingletonScope()
+
+container.bind<IGetUnreadCountUseCase>(TYPES.GetUnreadCountUseCase).toDynamicValue(() => {
+  const notificationRepository = container.get<INotificationRepository>(TYPES.NotificationRepository)
+  return new GetUnreadCountUseCase(notificationRepository)
+}).inSingletonScope()
+
+container.bind<IMarkNotificationReadUseCase>(TYPES.MarkNotificationReadUseCase).toDynamicValue(() => {
+  const notificationRepository = container.get<INotificationRepository>(TYPES.NotificationRepository)
+  return new MarkNotificationReadUseCase(notificationRepository)
+}).inSingletonScope()
+
+container.bind<IMarkAllReadUseCase>(TYPES.MarkAllReadUseCase).toDynamicValue(() => {
+  const notificationRepository = container.get<INotificationRepository>(TYPES.NotificationRepository)
+  return new MarkAllReadUseCase(notificationRepository)
 }).inSingletonScope()
 
 export { container }

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -25,4 +25,9 @@ export const TYPES = {
   GetMeUseCase: Symbol.for('GetMeUseCase'),
   UpdateProfileUseCase: Symbol.for('UpdateProfileUseCase'),
   UpdateLanguageUseCase: Symbol.for('UpdateLanguageUseCase'),
+  NotificationRepository: Symbol.for('NotificationRepository'),
+  ListNotificationsUseCase: Symbol.for('ListNotificationsUseCase'),
+  GetUnreadCountUseCase: Symbol.for('GetUnreadCountUseCase'),
+  MarkNotificationReadUseCase: Symbol.for('MarkNotificationReadUseCase'),
+  MarkAllReadUseCase: Symbol.for('MarkAllReadUseCase'),
 } as const

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,0 +1,149 @@
+import { useState, useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { CheckCheck, Bell } from 'lucide-react'
+import { gsap } from '@/lib/gsap'
+import { useReducedMotion } from '@/hooks'
+import { Button } from '@/components/ui'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { NotificationCard } from '@/components/notifications'
+import {
+  useListNotifications,
+  useUnreadCount,
+  useMarkAsRead,
+  useMarkAllAsRead,
+  useNotificationStore,
+} from '@/modules/notifications'
+import { toast } from '@/hooks/useToast'
+
+type TabValue = 'all' | 'unread' | 'archived'
+
+export default function NotificationsPage() {
+  const { t } = useTranslation('notifications')
+  const [activeTab, setActiveTab] = useState<TabValue>('all')
+  const listRef = useRef<HTMLDivElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  const unreadCount = useNotificationStore((state) => state.unreadCount)
+
+  const queryParams = {
+    limit: 50,
+    offset: 0,
+    ...(activeTab === 'unread' ? { unread_only: true } : {}),
+  }
+
+  const { data, isLoading } = useListNotifications(queryParams)
+  useUnreadCount()
+
+  const markAsReadMutation = useMarkAsRead()
+  const markAllAsReadMutation = useMarkAllAsRead()
+
+  const allNotifications = data?.notifications ?? []
+
+  const filteredNotifications = activeTab === 'archived'
+    ? allNotifications.filter((n) => n.getIsRead())
+    : allNotifications
+
+  const handleMarkAsRead = (id: string) => {
+    markAsReadMutation.mutate(id, {
+      onSuccess: () => {
+        toast({ title: t('toast.markedAsRead'), variant: 'success' })
+      },
+      onError: () => {
+        toast({ title: t('toast.error'), variant: 'destructive' })
+      },
+    })
+  }
+
+  const handleMarkAllAsRead = () => {
+    markAllAsReadMutation.mutate(undefined, {
+      onSuccess: () => {
+        toast({ title: t('toast.allMarkedAsRead'), variant: 'success' })
+      },
+      onError: () => {
+        toast({ title: t('toast.error'), variant: 'destructive' })
+      },
+    })
+  }
+
+  useEffect(() => {
+    if (!listRef.current || prefersReducedMotion || isLoading) return
+
+    const cards = listRef.current.querySelectorAll('[data-notification-card]')
+    if (cards.length === 0) return
+
+    const ctx = gsap.context(() => {
+      gsap.from(cards, {
+        y: 20,
+        opacity: 0,
+        duration: 0.3,
+        stagger: 0.05,
+        ease: 'power2.out',
+      })
+    }, listRef)
+
+    return () => ctx.revert()
+  }, [filteredNotifications.length, activeTab, prefersReducedMotion, isLoading])
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+          {t('page.title')}
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-zinc-400 mt-1">
+          {t('page.subtitle')}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as TabValue)}>
+          <TabsList>
+            <TabsTrigger value="all">{t('tabs.all')}</TabsTrigger>
+            <TabsTrigger value="unread" count={unreadCount}>{t('tabs.unread')}</TabsTrigger>
+            <TabsTrigger value="archived">{t('tabs.archived')}</TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        {unreadCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleMarkAllAsRead}
+            disabled={markAllAsReadMutation.isPending}
+            className="gap-2 text-gray-600 dark:text-zinc-300"
+          >
+            <CheckCheck className="w-4 h-4" />
+            {t('actions.markAllAsRead')}
+          </Button>
+        )}
+      </div>
+
+      <div ref={listRef} className="space-y-3">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="w-8 h-8 border-4 border-lime border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : filteredNotifications.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <div className="w-16 h-16 rounded-full bg-gray-100 dark:bg-zinc-800 flex items-center justify-center mb-4">
+              <Bell className="w-8 h-8 text-gray-400 dark:text-zinc-500" />
+            </div>
+            <p className="text-gray-500 dark:text-zinc-400 text-sm">
+              {t(`empty.${activeTab}`)}
+            </p>
+          </div>
+        ) : (
+          filteredNotifications.map((notification) => (
+            <div key={notification.getId()} data-notification-card>
+              <NotificationCard
+                notification={notification}
+                onMarkAsRead={handleMarkAsRead}
+                isMarkingRead={markAsReadMutation.isPending}
+              />
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -9,6 +9,7 @@ const Dashboard = lazy(() => import('@/pages/Dashboard'))
 const Audiences = lazy(() => import('@/pages/Audiences'))
 const AudienceDetail = lazy(() => import('@/pages/AudienceDetail'))
 const ProfilePage = lazy(() => import('@/pages/ProfilePage'))
+const NotificationsPage = lazy(() => import('@/pages/NotificationsPage'))
 const Placeholder = lazy(() => import('@/pages/Placeholder'))
 const NotFound = lazy(() => import('@/pages/NotFound'))
 
@@ -165,6 +166,14 @@ const router = createBrowserRouter([
         element: (
           <Suspense fallback={<PageLoader />}>
             <Placeholder />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'notifications',
+        element: (
+          <Suspense fallback={<PageLoader />}>
+            <NotificationsPage />
           </Suspense>
         ),
       },


### PR DESCRIPTION
## Summary

- Implement full notification module (Clean Architecture) with SSE for real-time notifications from backend (Issue #16)
- Add notification dropdown in Topbar with dynamic unread count badge and recent notifications list
- Add dedicated `/notifications` page with All/Unread/Archived tabs, mark as read actions, and GSAP animations
- Integrate SSE connection lifecycle (auto-connect on auth, disconnect on logout) via MainLayout
- Add i18n support (EN/PT-BR) for all notification UI strings

## Closes #61

## Test plan

- [ ] Verify `npm run build` passes without errors
- [ ] Navigate to `/notifications` route — page renders with tabs and empty state
- [ ] Click bell icon in Topbar — dropdown opens with notification list
- [ ] Badge shows real unread count (hidden when 0, pulses when > 0)
- [ ] SSE connection visible in DevTools Network tab (EventStream) when authenticated
- [ ] Receiving SSE notification updates dropdown, badge count, and shows toast
- [ ] "Mark as read" on individual notification works and updates UI
- [ ] "Mark all as read" clears all unread indicators
- [ ] Tabs filter correctly: All (all), Unread (is_read=false), Archived (is_read=true)
- [ ] i18n switches correctly between EN and PT-BR
- [ ] Dark mode renders correctly for all notification components