### PR TITLE
fix: resolve notification badge, dropdown UX, and topic analysis issues

### DIFF
--- a/src/components/audiences/detail/TopicDetailPanel.tsx
+++ b/src/components/audiences/detail/TopicDetailPanel.tsx
@@ -85,7 +85,7 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
   const handleBrowseAll = () => {
     if (!topic) return
     setDeepDiveActive(true)
-    triggerDeepDive.mutate({ audienceId, topicId: topic.id })
+    setPatternsActive(false)
   }
 
   const handleRetry = () => {
@@ -96,7 +96,7 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
   const handlePatterns = () => {
     if (!topic) return
     setPatternsActive(true)
-    triggerPatterns.mutate({ audienceId, topicId: topic.id })
+    setDeepDiveActive(false)
   }
 
   const handlePatternsRetry = () => {

--- a/src/components/audiences/detail/deep-dive/DeepDiveProductsSection.tsx
+++ b/src/components/audiences/detail/deep-dive/DeepDiveProductsSection.tsx
@@ -22,9 +22,9 @@ export function DeepDiveProductsSection({ products }: Readonly<DeepDiveProductsS
         <span className="ml-2 text-xs text-gray-500 dark:text-zinc-400">{products.length}</span>
       </h4>
       <div className="space-y-3">
-        {products.map((product) => (
+        {products.map((product, index) => (
           <div
-            key={product.name}
+            key={`${product.name}-${index}`}
             className="p-3 rounded-lg bg-gray-50 dark:bg-zinc-800"
           >
             <div className="flex items-center gap-2 mb-1">

--- a/src/components/notifications/NotificationDropdown.tsx
+++ b/src/components/notifications/NotificationDropdown.tsx
@@ -1,8 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { cn } from '@/lib/utils'
-import { useListNotifications, useNotificationStore } from '@/modules/notifications'
-import { Badge } from '@/components/ui'
+import { Check } from 'lucide-react'
+import { useListNotifications, useMarkAsRead, useMarkAllAsRead, useNotificationStore } from '@/modules/notifications'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -30,30 +29,39 @@ function useTimeAgo(dateString: string) {
   return t('time.daysAgo', { count: diffDays })
 }
 
-function DropdownNotificationItem({ notification }: Readonly<{ notification: { id: string; type: string; title: string; isRead: boolean; createdAt: string } }>) {
+interface DropdownNotificationItemProps {
+  notification: { id: string; type: string; title: string; isRead: boolean; createdAt: string }
+  onMarkAsRead: (id: string) => void
+  isMarkingRead: boolean
+}
+
+function DropdownNotificationItem({ notification, onMarkAsRead, isMarkingRead }: Readonly<DropdownNotificationItemProps>) {
+  const { t } = useTranslation('notifications')
   const timeAgo = useTimeAgo(notification.createdAt)
 
   return (
     <div className="flex items-start gap-3 px-3 py-2.5 rounded-xl hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors">
       <div className="mt-0.5">
-        {notification.isRead ? (
-          <span className="block w-2 h-2 rounded-full bg-gray-300 dark:bg-zinc-600" />
-        ) : (
-          <span className="block w-2 h-2 rounded-full bg-red-500" />
-        )}
+        <span className="block w-2 h-2 rounded-full bg-red-500" />
       </div>
       <div className="flex-1 min-w-0">
-        <p className={cn(
-          'text-sm truncate',
-          notification.isRead
-            ? 'text-gray-500 dark:text-zinc-400'
-            : 'text-gray-900 dark:text-white font-medium'
-        )}>
+        <p className="text-sm truncate text-gray-900 dark:text-white font-medium">
           {notification.title}
         </p>
         <p className="text-xs text-gray-400 dark:text-zinc-500 mt-0.5">
           {timeAgo}
         </p>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onMarkAsRead(notification.id)
+          }}
+          disabled={isMarkingRead}
+          className="flex items-center gap-1 mt-1 text-xs font-medium text-lime-600 dark:text-lime-400 hover:text-lime-700 dark:hover:text-lime-300 transition-colors cursor-pointer disabled:opacity-50"
+        >
+          <Check className="w-3 h-3" />
+          {t('actions.markAsRead')}
+        </button>
       </div>
     </div>
   )
@@ -63,7 +71,9 @@ export function NotificationDropdown({ children }: Readonly<NotificationDropdown
   const { t } = useTranslation('notifications')
   const navigate = useNavigate()
   const unreadCount = useNotificationStore((state) => state.unreadCount)
-  const { data } = useListNotifications({ limit: 5, offset: 0 })
+  const { data } = useListNotifications({ limit: 5, offset: 0, unread_only: true })
+  const markAsRead = useMarkAsRead()
+  const markAllAsRead = useMarkAllAsRead()
 
   const notifications = (data?.notifications ?? []).map((n) => ({
     id: n.getId(),
@@ -88,9 +98,13 @@ export function NotificationDropdown({ children }: Readonly<NotificationDropdown
             {t('dropdown.title')}
           </h3>
           {unreadCount > 0 && (
-            <Badge variant="info" size="sm">
-              {t('dropdown.newCount', { count: unreadCount })}
-            </Badge>
+            <button
+              onClick={() => markAllAsRead.mutate()}
+              disabled={markAllAsRead.isPending}
+              className="text-xs font-medium text-lime-600 dark:text-lime-400 hover:text-lime-700 dark:hover:text-lime-300 transition-colors cursor-pointer disabled:opacity-50"
+            >
+              {t('actions.markAllAsRead')}
+            </button>
           )}
         </div>
 
@@ -107,6 +121,8 @@ export function NotificationDropdown({ children }: Readonly<NotificationDropdown
               <DropdownNotificationItem
                 key={notification.id}
                 notification={notification}
+                onMarkAsRead={(id) => markAsRead.mutate(id)}
+                isMarkingRead={markAsRead.isPending}
               />
             ))
           )}

--- a/src/modules/notifications/application/hooks/useNotificationSSE.ts
+++ b/src/modules/notifications/application/hooks/useNotificationSSE.ts
@@ -2,9 +2,32 @@ import { useEffect, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '@/modules/auth'
 import { toast } from '@/hooks/useToast'
+import { TOPIC_DEEP_DIVE_QUERY_KEY } from '@/modules/audience/application/hooks/useGetTopicDeepDive'
+import { TOPIC_BEHAVIORAL_PATTERNS_QUERY_KEY } from '@/modules/audience/application/hooks/useGetTopicBehavioralPatterns'
 import { NotificationSSEService } from '../../infra/services/sse.service'
+import type { Notification } from '../../domain/entities'
 import { useNotificationStore } from '../store/notification.store'
 import { NOTIFICATIONS_QUERY_KEY, UNREAD_COUNT_QUERY_KEY } from './useNotifications'
+
+function invalidateAnalysisQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+  notification: Notification,
+) {
+  const metadata = notification.getMetadata()
+  const audienceId = metadata.audience_id
+  const topicId = metadata.topic_id
+  const type = notification.getType()
+
+  if (!audienceId || !topicId) return
+
+  if (type === 'deep_dive_complete' || type === 'deep_dive_failed') {
+    queryClient.invalidateQueries({ queryKey: TOPIC_DEEP_DIVE_QUERY_KEY(audienceId, topicId) })
+  }
+
+  if (type === 'behavioral_pattern_complete' || type === 'behavioral_pattern_failed') {
+    queryClient.invalidateQueries({ queryKey: TOPIC_BEHAVIORAL_PATTERNS_QUERY_KEY(audienceId, topicId) })
+  }
+}
 
 export function useNotificationSSE() {
   const sseRef = useRef<NotificationSSEService | null>(null)
@@ -33,6 +56,7 @@ export function useNotificationSSE() {
         incrementUnreadCount()
         queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_QUERY_KEY })
         queryClient.invalidateQueries({ queryKey: UNREAD_COUNT_QUERY_KEY })
+        invalidateAnalysisQueries(queryClient, notification)
 
         toast({
           title: notification.getTitle(),

--- a/src/modules/notifications/infra/repositories/notification.repository.ts
+++ b/src/modules/notifications/infra/repositories/notification.repository.ts
@@ -48,8 +48,8 @@ export class NotificationRepository implements INotificationRepository {
   }
 
   async getUnreadCount(): Promise<number> {
-    const response = await this.httpClient.get<{ count: number }>('notifications/unread-count')
-    return response.count ?? 0
+    const response = await this.httpClient.get<{ unread_count: number }>('notifications/unread-count')
+    return response.unread_count ?? 0
   }
 
   async markAsRead(id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- **Notification badge not showing**: Fixed API response field mismatch (`count` → `unread_count`) in the notification repository, which caused the unread badge to never appear in the Topbar
- **Notification dropdown improvements**: Show only unread notifications, added mark as read (individual and mark all) actions directly in the dropdown
- **Topic analysis re-triggering**: Browse All and Patterns buttons no longer trigger a new `POST /refresh` on every click — they now only fetch the current status via GET, preventing unnecessary reprocessing
- **SSE → analysis query sync**: When an SSE notification arrives (e.g. `deep_dive_complete`), the corresponding analysis query is automatically invalidated so the UI exits the loading state immediately
- **Toggle between sections**: Browse All and Patterns now work exclusively — activating one deactivates the other
- **Duplicate key warning**: Fixed React duplicate key warning in `DeepDiveProductsSection` for products with the same name

## Test plan
- [ ] Verify unread notification badge appears in the Topbar when there are unread notifications
- [ ] Open notification dropdown and confirm only unread notifications are listed
- [ ] Mark individual notification as read from the dropdown and verify it disappears
- [ ] Click "Mark all as read" and verify all notifications are cleared
- [ ] Click Browse All on a topic that already has a ready analysis — should show data without reprocessing
- [ ] Click Patterns while Browse All is visible — should toggle to Patterns section
- [ ] Trigger a new analysis and verify the UI updates automatically when the SSE notification arrives