### PR TITLE
fix: resolve audience list disappearing and infinite polling on topic analysis

### DIFF
--- a/src/components/audiences/UserAudiencesSection.tsx
+++ b/src/components/audiences/UserAudiencesSection.tsx
@@ -9,20 +9,50 @@ import type { AudienceDisplayItem, ViewMode } from './audiences.types'
 export interface UserAudiencesSectionProps {
   audiences: readonly AudienceDisplayItem[]
   viewMode: ViewMode
+  isLoading?: boolean
   onAddClick: () => void
   onSaveClick: (id: string) => void
   onShareClick: (id: string) => void
 }
 
+function AudienceCardSkeleton() {
+  return (
+    <div className="bg-white dark:bg-zinc-900 rounded-2xl p-6 animate-pulse">
+      <div className="flex items-start justify-between mb-4">
+        <div className="h-5 bg-gray-200 dark:bg-zinc-700 rounded w-2/5" />
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 bg-gray-200 dark:bg-zinc-700 rounded-lg" />
+          <div className="w-8 h-8 bg-gray-200 dark:bg-zinc-700 rounded-lg" />
+        </div>
+      </div>
+      <div className="flex items-center gap-4 mb-4">
+        <div className="h-4 bg-gray-200 dark:bg-zinc-700 rounded w-16" />
+        <div className="h-4 bg-gray-200 dark:bg-zinc-700 rounded w-20" />
+        <div className="h-4 bg-gray-200 dark:bg-zinc-700 rounded w-24" />
+      </div>
+      <div className="flex items-center -space-x-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="w-8 h-8 rounded-full bg-gray-200 dark:bg-zinc-700 border-2 border-white dark:border-zinc-900"
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export function UserAudiencesSection({
   audiences,
   viewMode,
+  isLoading,
   onAddClick,
   onSaveClick,
   onShareClick,
 }: Readonly<UserAudiencesSectionProps>) {
   const sectionRef = useRef<HTMLElement>(null)
   const hasAnimated = useRef(false)
+  const gsapCtxRef = useRef<gsap.Context | null>(null)
   const prefersReducedMotion = useReducedMotion()
 
   useEffect(() => {
@@ -33,7 +63,7 @@ export function UserAudiencesSection({
 
     hasAnimated.current = true
 
-    const ctx = gsap.context(() => {
+    gsapCtxRef.current = gsap.context(() => {
       gsap.fromTo(
         section,
         { opacity: 0, y: 40 },
@@ -62,19 +92,35 @@ export function UserAudiencesSection({
         )
       }
     }, section)
-
-    return () => ctx.revert()
   }, [audiences.length, prefersReducedMotion])
 
   useEffect(() => {
     return () => {
+      gsapCtxRef.current?.revert()
       hasAnimated.current = false
     }
   }, [])
 
   const { t } = useTranslation('audiences')
 
-  if (audiences.length === 0) return null
+  if (!isLoading && audiences.length === 0) return null
+
+  if (isLoading) {
+    return (
+      <section className="space-y-4">
+        <div className="flex items-center gap-2">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+            {t('page.yourAudiences')}
+          </h2>
+        </div>
+        <div className={gridClassName(viewMode)}>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <AudienceCardSkeleton key={i} />
+          ))}
+        </div>
+      </section>
+    )
+  }
 
   return (
     <section ref={sectionRef} className="space-y-4" style={{ opacity: 0 }}>

--- a/src/modules/audience/application/hooks/useGetTopicBehavioralPatterns.ts
+++ b/src/modules/audience/application/hooks/useGetTopicBehavioralPatterns.ts
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { container, TYPES } from '@/modules/shared'
 import type { IGetTopicBehavioralPatternsUseCase, GetTopicBehavioralPatternsResult } from '@/modules/audience/domain/use-cases'
@@ -9,14 +10,27 @@ const getTopicBehavioralPatternsUseCase = container.get<IGetTopicBehavioralPatte
 export const TOPIC_BEHAVIORAL_PATTERNS_QUERY_KEY = (audienceId: string, topicId: string) =>
   ['topic-behavioral-patterns', audienceId, topicId] as const
 
+const MAX_POLL_COUNT = 60
+
 export function useGetTopicBehavioralPatterns(audienceId: string, topicId: string, enabled: boolean) {
+  const pollCountRef = useRef(0)
+
+  useEffect(() => {
+    pollCountRef.current = 0
+  }, [topicId, enabled])
+
   return useQuery<GetTopicBehavioralPatternsResult, Error>({
     queryKey: TOPIC_BEHAVIORAL_PATTERNS_QUERY_KEY(audienceId, topicId),
     queryFn: () => getTopicBehavioralPatternsUseCase.execute({ audienceId, topicId }),
     enabled: !!audienceId && !!topicId && enabled,
     refetchInterval: (query) => {
       const status = query.state.data?.status
-      if (status === 'processing') return 3000
+      if (status === 'processing') {
+        if (pollCountRef.current >= MAX_POLL_COUNT) return false
+        pollCountRef.current++
+        return 3000
+      }
+      pollCountRef.current = 0
       return false
     },
   })

--- a/src/modules/audience/application/hooks/useGetTopicDeepDive.ts
+++ b/src/modules/audience/application/hooks/useGetTopicDeepDive.ts
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { container, TYPES } from '@/modules/shared'
 import type { IGetTopicDeepDiveUseCase, GetTopicDeepDiveResult } from '@/modules/audience/domain/use-cases'
@@ -9,14 +10,27 @@ const getTopicDeepDiveUseCase = container.get<IGetTopicDeepDiveUseCase>(
 export const TOPIC_DEEP_DIVE_QUERY_KEY = (audienceId: string, topicId: string) =>
   ['topic-deep-dive', audienceId, topicId] as const
 
+const MAX_POLL_COUNT = 60
+
 export function useGetTopicDeepDive(audienceId: string, topicId: string, enabled: boolean) {
+  const pollCountRef = useRef(0)
+
+  useEffect(() => {
+    pollCountRef.current = 0
+  }, [topicId, enabled])
+
   return useQuery<GetTopicDeepDiveResult, Error>({
     queryKey: TOPIC_DEEP_DIVE_QUERY_KEY(audienceId, topicId),
     queryFn: () => getTopicDeepDiveUseCase.execute({ audienceId, topicId }),
     enabled: !!audienceId && !!topicId && enabled,
     refetchInterval: (query) => {
       const status = query.state.data?.status
-      if (status === 'processing') return 3000
+      if (status === 'processing') {
+        if (pollCountRef.current >= MAX_POLL_COUNT) return false
+        pollCountRef.current++
+        return 3000
+      }
+      pollCountRef.current = 0
       return false
     },
   })

--- a/src/modules/audience/application/hooks/useGetTopicSentiment.ts
+++ b/src/modules/audience/application/hooks/useGetTopicSentiment.ts
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { container, TYPES } from '@/modules/shared'
 import type { IGetTopicSentimentUseCase, GetTopicSentimentResult } from '@/modules/audience/domain/use-cases'
@@ -9,14 +10,27 @@ const getTopicSentimentUseCase = container.get<IGetTopicSentimentUseCase>(
 export const TOPIC_SENTIMENT_QUERY_KEY = (audienceId: string, topicId: string) =>
   ['topic-sentiment', audienceId, topicId] as const
 
+const MAX_POLL_COUNT = 60
+
 export function useGetTopicSentiment(audienceId: string, topicId: string, enabled: boolean) {
+  const pollCountRef = useRef(0)
+
+  useEffect(() => {
+    pollCountRef.current = 0
+  }, [topicId, enabled])
+
   return useQuery<GetTopicSentimentResult, Error>({
     queryKey: TOPIC_SENTIMENT_QUERY_KEY(audienceId, topicId),
     queryFn: () => getTopicSentimentUseCase.execute({ audienceId, topicId }),
     enabled: !!audienceId && !!topicId && enabled,
     refetchInterval: (query) => {
       const status = query.state.data?.status
-      if (status === 'processing') return 3000
+      if (status === 'processing') {
+        if (pollCountRef.current >= MAX_POLL_COUNT) return false
+        pollCountRef.current++
+        return 3000
+      }
+      pollCountRef.current = 0
       return false
     },
   })

--- a/src/pages/Audiences.tsx
+++ b/src/pages/Audiences.tsx
@@ -19,7 +19,7 @@ export function Audiences() {
   const { openModal, closeModal } = useCreateAudienceStore()
   const createAudienceMutation = useCreateAudience()
 
-  const { data: userAudiencesData } = useListUserAudiences()
+  const { data: userAudiencesData, isLoading: isLoadingUserAudiences } = useListUserAudiences()
   const { data: templates } = useFetchDefaultAudiences()
 
   const userAudiences = (userAudiencesData ?? []).map((audience) => ({
@@ -108,6 +108,7 @@ export function Audiences() {
       <UserAudiencesSection
         audiences={userAudiences}
         viewMode={viewMode}
+        isLoading={isLoadingUserAudiences}
         onAddClick={openModal}
         onSaveClick={handleSaveClick}
         onShareClick={handleShareClick}
@@ -120,7 +121,7 @@ export function Audiences() {
         onSaveClick={handleSaveClick}
         onShareClick={handleShareClick}
         gridRef={templatesGridRef}
-        showAddCard={userAudiences.length === 0}
+        showAddCard={!isLoadingUserAudiences && userAudiences.length === 0}
         onAddClick={openModal}
       />
 


### PR DESCRIPTION
## Summary
- Fix user audiences list disappearing after creating a new audience (GSAP animation cleanup was reverting section opacity)
- Add skeleton loading to UserAudiencesSection to prevent layout shift while data loads
- Add max poll count (60 attempts / ~3min) to deep dive, behavioral patterns, and sentiment hooks to prevent infinite HTTP requests when backend is stuck in processing

## Test plan
- [ ] Create a new audience and verify the user audiences list remains visible
- [ ] Reload the Audiences page and verify skeleton cards appear while user audiences load
- [ ] Trigger a sentiment/deep-dive/behavioral-patterns analysis and verify polling stops after ~3 minutes if backend stays in processing
- [ ] Verify SSE notifications still correctly update analysis results