### PR TITLE
feat: topic ask Q&A frontend integration

### DIFF
--- a/src/components/audiences/detail/TopicDetailPanel.tsx
+++ b/src/components/audiences/detail/TopicDetailPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useLayoutEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { TrendingUp, Search, Sparkles, Heart, MessageSquare, Loader2, AlertCircle, RefreshCw } from 'lucide-react'
+import { TrendingUp, Search, Sparkles, Heart, MessageSquare, MessageCircleQuestion, Loader2, AlertCircle, RefreshCw } from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { useReducedMotion } from '@/hooks'
 import { Button } from '@/components/ui/button'
@@ -31,6 +31,7 @@ import {
   PainPointsSection,
   SentimentOpportunitiesSection,
 } from './sentiment'
+import { TopicAskSection } from './ask'
 
 export interface TopicSubreddit {
   name: string
@@ -60,6 +61,7 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
   const [deepDiveActive, setDeepDiveActive] = useState(false)
   const [patternsActive, setPatternsActive] = useState(false)
   const [sentimentActive, setSentimentActive] = useState(false)
+  const [askActive, setAskActive] = useState(false)
   const [currentTopicId, setCurrentTopicId] = useState<string | null>(null)
 
   const triggerDeepDive = useTriggerTopicDeepDive()
@@ -102,6 +104,7 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
       setDeepDiveActive(false)
       setPatternsActive(false)
       setSentimentActive(false)
+      setAskActive(false)
       setCurrentTopicId(topic?.id ?? null)
     }
   }, [topic?.id, currentTopicId])
@@ -111,6 +114,7 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
     setDeepDiveActive(true)
     setPatternsActive(false)
     setSentimentActive(false)
+    setAskActive(false)
   }
 
   const handleRetry = () => {
@@ -123,6 +127,7 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
     setPatternsActive(true)
     setDeepDiveActive(false)
     setSentimentActive(false)
+    setAskActive(false)
   }
 
   const handlePatternsRetry = () => {
@@ -135,6 +140,15 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
     setSentimentActive(true)
     setDeepDiveActive(false)
     setPatternsActive(false)
+    setAskActive(false)
+  }
+
+  const handleAsk = () => {
+    if (!topic) return
+    setAskActive(true)
+    setDeepDiveActive(false)
+    setPatternsActive(false)
+    setSentimentActive(false)
   }
 
   const handleSentimentRetry = () => {
@@ -269,11 +283,12 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
                 {sentimentLabel}
               </Button>
               <Button
-                variant="outline"
+                variant={askActive ? 'primary' : 'outline'}
                 size="sm"
                 className="gap-1.5"
+                onClick={handleAsk}
               >
-                <Sparkles className="w-3.5 h-3.5" />
+                <MessageCircleQuestion className="w-3.5 h-3.5" />
                 {t('topicDetail.ask')}
               </Button>
             </div>
@@ -493,6 +508,13 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
                     <DemandSignalsSection signals={patternsData.getDemandSignals()} />
                   </div>
                 )}
+              </div>
+            )}
+
+            {/* Ask Q&A Section */}
+            {askActive && (
+              <div className="mt-6 border-t border-gray-100 dark:border-zinc-800">
+                <TopicAskSection audienceId={audienceId} topicId={topic.id} />
               </div>
             )}
 

--- a/src/components/audiences/detail/ask/TopicAskSection.tsx
+++ b/src/components/audiences/detail/ask/TopicAskSection.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Send, Loader2, AlertCircle, Info, Zap } from 'lucide-react'
+import { Button } from '@/components/ui'
+import { Badge } from '@/components/ui/badge'
+import { useAskTopic } from '@/modules/audience/application/hooks'
+import type { TopicAskResponse } from '@/modules/audience/domain/entities/TopicAskResponse.entity'
+
+interface TopicAskSectionProps {
+  audienceId: string
+  topicId: string
+}
+
+export function TopicAskSection({ audienceId, topicId }: Readonly<TopicAskSectionProps>) {
+  const { t } = useTranslation('audiences')
+  const [question, setQuestion] = useState('')
+  const [lastResponse, setLastResponse] = useState<TopicAskResponse | null>(null)
+  const askTopic = useAskTopic()
+
+  const trimmedQuestion = question.trim()
+  const isValid = trimmedQuestion.length >= 3
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!isValid || askTopic.isPending) return
+
+    askTopic.mutate(
+      { audienceId, topicId, question: trimmedQuestion },
+      {
+        onSuccess: (data) => {
+          setLastResponse(data)
+          setQuestion('')
+        },
+      }
+    )
+  }
+
+  return (
+    <div className="pt-4">
+      <h4 className="font-semibold text-sm text-gray-900 dark:text-white mb-3">
+        {t('topicDetail.askTitle')}
+      </h4>
+
+      <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
+        <input
+          type="text"
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder={t('topicDetail.askPlaceholder')}
+          maxLength={500}
+          disabled={askTopic.isPending}
+          className="flex-1 h-9 px-3 text-sm rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-lime focus:border-transparent disabled:opacity-50"
+        />
+        <Button
+          type="submit"
+          variant="primary"
+          size="sm"
+          disabled={!isValid || askTopic.isPending}
+          className="gap-1.5"
+        >
+          {askTopic.isPending ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            <Send className="w-3.5 h-3.5" />
+          )}
+          {askTopic.isPending ? t('topicDetail.askSending') : t('topicDetail.askSend')}
+        </Button>
+      </form>
+
+      {trimmedQuestion.length > 0 && trimmedQuestion.length < 3 && (
+        <p className="text-xs text-amber-500 mb-3">
+          {t('topicDetail.askMinLength')}
+        </p>
+      )}
+
+      {askTopic.isError && (
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-950/30 mb-4">
+          <AlertCircle className="w-4 h-4 text-red-500 shrink-0" />
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {t('topicDetail.askError')}
+          </p>
+        </div>
+      )}
+
+      {lastResponse && (
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              variant={lastResponse.getContextQuality() === 'rich' ? 'success' : 'warning'}
+              size="sm"
+            >
+              {lastResponse.getContextQuality() === 'rich'
+                ? t('topicDetail.askContextRich')
+                : t('topicDetail.askContextLimited')}
+            </Badge>
+            {lastResponse.isCached() && (
+              <Badge variant="info" size="sm">
+                <Zap className="w-3 h-3" />
+                {t('topicDetail.askCached')}
+              </Badge>
+            )}
+          </div>
+
+          <div className="p-4 rounded-lg bg-gray-50 dark:bg-zinc-800/50 border border-gray-100 dark:border-zinc-700">
+            <p className="text-sm text-gray-700 dark:text-zinc-300 leading-relaxed whitespace-pre-line">
+              {lastResponse.getAnswer()}
+            </p>
+          </div>
+
+          {lastResponse.getSuggestion() && (
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-100 dark:border-amber-900/30">
+              <Info className="w-4 h-4 text-amber-500 shrink-0 mt-0.5" />
+              <div>
+                <p className="text-xs font-medium text-amber-700 dark:text-amber-400 mb-0.5">
+                  {t('topicDetail.askSuggestion')}
+                </p>
+                <p className="text-xs text-amber-600 dark:text-amber-300">
+                  {lastResponse.getSuggestion()}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/audiences/detail/ask/index.ts
+++ b/src/components/audiences/detail/ask/index.ts
@@ -1,0 +1,1 @@
+export { TopicAskSection } from './TopicAskSection'

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -149,7 +149,17 @@
     "negativeDrivers": "Negative Drivers",
     "tensionPoints": "Tension Points",
     "painPoints": "Pain Points",
-    "sentimentOpportunities": "Opportunities"
+    "sentimentOpportunities": "Opportunities",
+    "askTitle": "Ask about this topic",
+    "askPlaceholder": "Ask a question about this topic...",
+    "askSend": "Send",
+    "askSending": "Thinking...",
+    "askError": "Failed to get an answer. Please try again.",
+    "askContextRich": "Rich context",
+    "askContextLimited": "Limited context",
+    "askCached": "Cached",
+    "askSuggestion": "Suggestion",
+    "askMinLength": "Question must be at least 3 characters"
   },
   "tabs": {
     "search": "Search",

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -149,7 +149,17 @@
     "negativeDrivers": "Drivers Negativos",
     "tensionPoints": "Pontos de Tensão",
     "painPoints": "Pontos de Dor",
-    "sentimentOpportunities": "Oportunidades"
+    "sentimentOpportunities": "Oportunidades",
+    "askTitle": "Perguntar sobre este tópico",
+    "askPlaceholder": "Faça uma pergunta sobre este tópico...",
+    "askSend": "Enviar",
+    "askSending": "Pensando...",
+    "askError": "Não foi possível obter uma resposta. Tente novamente.",
+    "askContextRich": "Contexto rico",
+    "askContextLimited": "Contexto limitado",
+    "askCached": "Em cache",
+    "askSuggestion": "Sugestão",
+    "askMinLength": "A pergunta deve ter pelo menos 3 caracteres"
   },
   "tabs": {
     "search": "Buscar",

--- a/src/modules/audience/application/hooks/index.ts
+++ b/src/modules/audience/application/hooks/index.ts
@@ -17,3 +17,4 @@ export { useGetTopicBehavioralPatterns, TOPIC_BEHAVIORAL_PATTERNS_QUERY_KEY } fr
 export { useTriggerTopicBehavioralPatterns } from './useTriggerTopicBehavioralPatterns'
 export { useGetTopicSentiment, TOPIC_SENTIMENT_QUERY_KEY } from './useGetTopicSentiment'
 export { useTriggerTopicSentiment } from './useTriggerTopicSentiment'
+export { useAskTopic } from './useAskTopic'

--- a/src/modules/audience/application/hooks/useAskTopic.ts
+++ b/src/modules/audience/application/hooks/useAskTopic.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IAskTopicUseCase, AskTopicParams } from '@/modules/audience/domain/use-cases'
+
+const askTopicUseCase = container.get<IAskTopicUseCase>(TYPES.AskTopicUseCase)
+
+export function useAskTopic() {
+  return useMutation({
+    mutationFn: (params: AskTopicParams) => askTopicUseCase.execute(params),
+  })
+}

--- a/src/modules/audience/application/use-cases/ask-topic-use-case/index.ts
+++ b/src/modules/audience/application/use-cases/ask-topic-use-case/index.ts
@@ -1,0 +1,10 @@
+import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
+import type { IAskTopicUseCase, AskTopicParams, AskTopicResult } from '@/modules/audience/domain/use-cases'
+
+export class AskTopicUseCase implements IAskTopicUseCase {
+  constructor(private readonly audienceRepository: IAudienceRepository) {}
+
+  async execute(params: AskTopicParams): Promise<AskTopicResult> {
+    return this.audienceRepository.askTopic(params)
+  }
+}

--- a/src/modules/audience/application/use-cases/index.ts
+++ b/src/modules/audience/application/use-cases/index.ts
@@ -17,3 +17,4 @@ export { GetTopicBehavioralPatternsUseCase } from './get-topic-behavioral-patter
 export { TriggerTopicBehavioralPatternsUseCase } from './trigger-topic-behavioral-patterns-use-case'
 export { GetTopicSentimentUseCase } from './get-topic-sentiment-use-case'
 export { TriggerTopicSentimentUseCase } from './trigger-topic-sentiment-use-case'
+export { AskTopicUseCase } from './ask-topic-use-case'

--- a/src/modules/audience/domain/entities/TopicAskResponse.entity.ts
+++ b/src/modules/audience/domain/entities/TopicAskResponse.entity.ts
@@ -1,0 +1,52 @@
+export type TopicAskContextQuality = 'rich' | 'limited'
+
+interface TopicAskResponseProps {
+  answer: string
+  contextQuality: TopicAskContextQuality
+  sourcesUsed: string[]
+  cached: boolean
+  topicName: string
+  suggestion: string | null
+}
+
+export class TopicAskResponse {
+  private readonly answer: string
+  private readonly contextQuality: TopicAskContextQuality
+  private readonly sourcesUsed: string[]
+  private readonly cached: boolean
+  private readonly topicName: string
+  private readonly suggestion: string | null
+
+  constructor({ answer, contextQuality, sourcesUsed, cached, topicName, suggestion }: TopicAskResponseProps) {
+    this.answer = answer
+    this.contextQuality = contextQuality
+    this.sourcesUsed = sourcesUsed
+    this.cached = cached
+    this.topicName = topicName
+    this.suggestion = suggestion
+  }
+
+  getAnswer(): string {
+    return this.answer
+  }
+
+  getContextQuality(): TopicAskContextQuality {
+    return this.contextQuality
+  }
+
+  getSourcesUsed(): string[] {
+    return this.sourcesUsed
+  }
+
+  isCached(): boolean {
+    return this.cached
+  }
+
+  getTopicName(): string {
+    return this.topicName
+  }
+
+  getSuggestion(): string | null {
+    return this.suggestion
+  }
+}

--- a/src/modules/audience/domain/repositories/audience.repository.ts
+++ b/src/modules/audience/domain/repositories/audience.repository.ts
@@ -15,6 +15,7 @@ import type { GetTopicBehavioralPatternsParams, GetTopicBehavioralPatternsResult
 import type { TriggerTopicBehavioralPatternsParams, TriggerTopicBehavioralPatternsResult } from "../use-cases/trigger-topic-behavioral-patterns.use-case";
 import type { GetTopicSentimentParams, GetTopicSentimentResult } from "../use-cases/get-topic-sentiment.use-case";
 import type { TriggerTopicSentimentParams, TriggerTopicSentimentResult } from "../use-cases/trigger-topic-sentiment.use-case";
+import type { AskTopicParams, AskTopicResult } from "../use-cases/ask-topic.use-case";
 
 export interface IAudienceRepository {
   listUserAudiences(): Promise<Audience[]>
@@ -36,4 +37,5 @@ export interface IAudienceRepository {
   triggerTopicBehavioralPatterns(params: TriggerTopicBehavioralPatternsParams): Promise<TriggerTopicBehavioralPatternsResult>
   getTopicSentiment(params: GetTopicSentimentParams): Promise<GetTopicSentimentResult>
   triggerTopicSentiment(params: TriggerTopicSentimentParams): Promise<TriggerTopicSentimentResult>
+  askTopic(params: AskTopicParams): Promise<AskTopicResult>
 }

--- a/src/modules/audience/domain/use-cases/ask-topic.use-case.ts
+++ b/src/modules/audience/domain/use-cases/ask-topic.use-case.ts
@@ -1,0 +1,13 @@
+import type { TopicAskResponse } from '../entities/TopicAskResponse.entity'
+
+export interface AskTopicParams {
+  audienceId: string
+  topicId: string
+  question: string
+}
+
+export type AskTopicResult = TopicAskResponse
+
+export interface IAskTopicUseCase {
+  execute(params: AskTopicParams): Promise<AskTopicResult>
+}

--- a/src/modules/audience/domain/use-cases/index.ts
+++ b/src/modules/audience/domain/use-cases/index.ts
@@ -17,3 +17,4 @@ export type { IGetTopicBehavioralPatternsUseCase, GetTopicBehavioralPatternsPara
 export type { ITriggerTopicBehavioralPatternsUseCase, TriggerTopicBehavioralPatternsParams, TriggerTopicBehavioralPatternsResult } from './trigger-topic-behavioral-patterns.use-case'
 export type { IGetTopicSentimentUseCase, GetTopicSentimentParams, GetTopicSentimentResult, TopicSentimentStatus } from './get-topic-sentiment.use-case'
 export type { ITriggerTopicSentimentUseCase, TriggerTopicSentimentParams, TriggerTopicSentimentResult } from './trigger-topic-sentiment.use-case'
+export type { IAskTopicUseCase, AskTopicParams, AskTopicResult } from './ask-topic.use-case'

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -17,11 +17,13 @@ import type { GetTopicBehavioralPatternsParams, GetTopicBehavioralPatternsResult
 import type { TriggerTopicBehavioralPatternsParams, TriggerTopicBehavioralPatternsResult } from '../../domain/use-cases/trigger-topic-behavioral-patterns.use-case'
 import type { GetTopicSentimentParams, GetTopicSentimentResult, TopicSentimentStatus } from '../../domain/use-cases/get-topic-sentiment.use-case'
 import type { TriggerTopicSentimentParams, TriggerTopicSentimentResult } from '../../domain/use-cases/trigger-topic-sentiment.use-case'
+import type { AskTopicParams, AskTopicResult } from '../../domain/use-cases/ask-topic.use-case'
 import { Keyword } from '../../domain/entities/Keyword.entity'
 import { Topic } from '../../domain/entities/Topic.entity'
 import { TopicDeepDive } from '../../domain/entities/TopicDeepDive.entity'
 import { TopicBehavioralPattern } from '../../domain/entities/TopicBehavioralPattern.entity'
 import { TopicSentiment } from '../../domain/entities/TopicSentiment.entity'
+import { TopicAskResponse } from '../../domain/entities/TopicAskResponse.entity'
 
 interface AudienceTemplateResponse {
   id: string
@@ -264,6 +266,15 @@ interface TriggerSentimentApiResponse {
   status: string
   analysis_id: string
   message?: string
+}
+
+interface TopicAskApiResponse {
+  answer: string
+  context_quality: string
+  sources_used: string[]
+  cached: boolean
+  topic_name: string
+  suggestion: string | null
 }
 
 export class AudienceRepository implements IAudienceRepository {
@@ -674,5 +685,21 @@ export class AudienceRepository implements IAudienceRepository {
       status: response.status,
       analysisId: response.analysis_id,
     }
+  }
+
+  async askTopic(params: AskTopicParams): Promise<AskTopicResult> {
+    const response = await this.httpClient.post<TopicAskApiResponse>(
+      `audiences/${params.audienceId}/topics/${params.topicId}/ask`,
+      { question: params.question }
+    )
+
+    return new TopicAskResponse({
+      answer: response.answer,
+      contextQuality: response.context_quality as 'rich' | 'limited',
+      sourcesUsed: response.sources_used,
+      cached: response.cached,
+      topicName: response.topic_name,
+      suggestion: response.suggestion,
+    })
   }
 }

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -3,8 +3,8 @@ import { TYPES } from './types'
 import { KyHttpClient, type HttpClient } from '../http'
 import { AudienceRepository } from '@/modules/audience/infra/repositories'
 import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
-import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase, MarkCommunityNotRelevantUseCase, GetAudienceTopicsUseCase, GetTopicDeepDiveUseCase, TriggerTopicDeepDiveUseCase, GetTopicBehavioralPatternsUseCase, TriggerTopicBehavioralPatternsUseCase, GetTopicSentimentUseCase, TriggerTopicSentimentUseCase } from '@/modules/audience/application/use-cases'
-import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase, IMarkCommunityNotRelevantUseCase, IGetAudienceTopicsUseCase, IGetTopicDeepDiveUseCase, ITriggerTopicDeepDiveUseCase, IGetTopicBehavioralPatternsUseCase, ITriggerTopicBehavioralPatternsUseCase, IGetTopicSentimentUseCase, ITriggerTopicSentimentUseCase } from '@/modules/audience/domain/use-cases'
+import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase, MarkCommunityNotRelevantUseCase, GetAudienceTopicsUseCase, GetTopicDeepDiveUseCase, TriggerTopicDeepDiveUseCase, GetTopicBehavioralPatternsUseCase, TriggerTopicBehavioralPatternsUseCase, GetTopicSentimentUseCase, TriggerTopicSentimentUseCase, AskTopicUseCase } from '@/modules/audience/application/use-cases'
+import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase, IMarkCommunityNotRelevantUseCase, IGetAudienceTopicsUseCase, IGetTopicDeepDiveUseCase, ITriggerTopicDeepDiveUseCase, IGetTopicBehavioralPatternsUseCase, ITriggerTopicBehavioralPatternsUseCase, IGetTopicSentimentUseCase, ITriggerTopicSentimentUseCase, IAskTopicUseCase } from '@/modules/audience/domain/use-cases'
 import { CommunityRepository } from '@/modules/community/infra/repositories'
 import type { ICommunityRepository } from '@/modules/community/domain/repositories'
 import { BrowseCommunitiesUseCase } from '@/modules/community/application/use-cases'
@@ -120,6 +120,11 @@ container.bind<IGetTopicSentimentUseCase>(TYPES.GetTopicSentimentUseCase).toDyna
 container.bind<ITriggerTopicSentimentUseCase>(TYPES.TriggerTopicSentimentUseCase).toDynamicValue(() => {
   const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
   return new TriggerTopicSentimentUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<IAskTopicUseCase>(TYPES.AskTopicUseCase).toDynamicValue(() => {
+  const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
+  return new AskTopicUseCase(audienceRepository)
 }).inSingletonScope()
 
 container.bind<ICommunityRepository>(TYPES.CommunityRepository).toDynamicValue(() => {

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -20,6 +20,7 @@ export const TYPES = {
   TriggerTopicBehavioralPatternsUseCase: Symbol.for('TriggerTopicBehavioralPatternsUseCase'),
   GetTopicSentimentUseCase: Symbol.for('GetTopicSentimentUseCase'),
   TriggerTopicSentimentUseCase: Symbol.for('TriggerTopicSentimentUseCase'),
+  AskTopicUseCase: Symbol.for('AskTopicUseCase'),
   CommunityRepository: Symbol.for('CommunityRepository'),
   BrowseCommunitiesUseCase: Symbol.for('BrowseCommunitiesUseCase'),
   AuthRepository: Symbol.for('AuthRepository'),


### PR DESCRIPTION
## Summary
- Implements the **Ask Q&A** feature for audience topics (Issue #72), allowing users to ask free-form questions and receive AI-powered answers based on Deep Dive data
- Follows the existing DDD architecture: domain entity, repository interface/implementation, use case, React Query mutation hook, and UI component
- Connects the existing inactive "Ask" button in `TopicDetailPanel` to the new `TopicAskSection` component with input, loading state, response rendering (context quality badges, cached indicator, suggestion for limited context), and error handling

## Files Created
- `src/modules/audience/domain/entities/TopicAskResponse.entity.ts` — Entity
- `src/modules/audience/domain/use-cases/ask-topic.use-case.ts` — Use case interface
- `src/modules/audience/application/use-cases/ask-topic-use-case/index.ts` — Use case implementation
- `src/modules/audience/application/hooks/useAskTopic.ts` — React Query mutation hook
- `src/components/audiences/detail/ask/TopicAskSection.tsx` — UI component
- `src/components/audiences/detail/ask/index.ts` — Barrel export

## Files Modified
- Repository interface + implementation (added `askTopic()`)
- DI container (types + binding)
- `TopicDetailPanel.tsx` (state, handler, button connection, section rendering)
- i18n translations (EN + PT-BR — 11 keys each)

## Test plan
- [ ] Click "Ask" button on topic detail panel — section opens
- [ ] Type question (min 3 chars) and submit — loading state shows, then response renders
- [ ] Verify context quality badge appears (rich/limited)
- [ ] Submit same question again — cached badge should appear
- [ ] Test with topic without deep dive — limited context + suggestion message
- [ ] Test validation: question < 3 chars shows warning, button disabled
- [ ] Test error state: disconnect backend, submit — error message shows
- [ ] Verify i18n: switch language, all labels translate correctly
- [ ] Switching between Browse All / Patterns / Sentiment / Ask toggles sections correctly

Closes #72