### PR TITLE
feat: integrate scoring themes with dynamic API data

### DIFF
--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -16,7 +16,9 @@ import type { AudienceStats, RadarData } from './AboutAudiencePanel'
 import type { SubredditDetail } from '@/data/audienceDetails'
 import type { Keyword } from '@/modules/audience/domain/entities/Keyword.entity'
 import type { Topic } from '@/modules/audience/domain/entities/Topic.entity'
+import type { Theme } from '@/modules/audience/domain/entities/Theme.entity'
 import { themesGridData, themesDetailData } from '@/data/audienceDetailMocks'
+import { useGetAudienceThemes, useRefreshAudienceThemes } from '@/modules/audience/application/hooks'
 
 export interface AudienceDetailTabsProps {
   contentRef: RefObject<HTMLDivElement | null>
@@ -40,6 +42,48 @@ export interface AudienceDetailTabsProps {
   hasMoreTopics: boolean
   isLoadingMoreTopics: boolean
   audienceId: string
+}
+
+function mapScoringThemesToDetail(
+  id: string,
+  name: string,
+  themes: Theme[],
+): ThemeDetail {
+  const topTheme = themes[0]
+
+  const subcategories = themes.map((theme) => ({
+    name: theme.getName(),
+    count: theme.getPostCount(),
+  }))
+
+  const keywordMap = new Map<string, number>()
+  for (const theme of themes) {
+    for (const kw of theme.getTopKeywords()) {
+      keywordMap.set(kw.keyword, (keywordMap.get(kw.keyword) ?? 0) + kw.frequency)
+    }
+  }
+  const topics = Array.from(keywordMap.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([keyword, count]) => ({ name: keyword, count }))
+
+  const subredditMap = new Map<string, number>()
+  for (const theme of themes) {
+    for (const sub of theme.getTopSubreddits()) {
+      subredditMap.set(sub.name, (subredditMap.get(sub.name) ?? 0) + sub.postCount)
+    }
+  }
+  const subreddits = Array.from(subredditMap.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([subredditName, count]) => ({ name: subredditName, count }))
+
+  return {
+    id,
+    name,
+    description: topTheme?.getSummary() ?? '',
+    subcategories,
+    topics,
+    subreddits,
+  }
 }
 
 export function AudienceDetailTabs({
@@ -70,6 +114,10 @@ export function AudienceDetailTabs({
   const [selectedTopic, setSelectedTopic] = useState<TopicDetail | null>(null)
   const [selectedTheme, setSelectedTheme] = useState<ThemeDetail | null>(null)
 
+  const weekQuery = useGetAudienceThemes(audienceId, 'week', activeTab === 'themes')
+  const monthQuery = useGetAudienceThemes(audienceId, 'month', activeTab === 'themes')
+  const refreshMutation = useRefreshAudienceThemes()
+
   const topicTableItems = topics.map((topic) => {
     const period = topic.getMentionPeriod()
     const frequencyUnit: 'day' | 'week' | 'mo' = period === 'month' ? 'mo' : period === 'week' ? 'week' : 'day'
@@ -84,6 +132,34 @@ export function AudienceDetailTabs({
       growthTrend: topic.getGrowthTrend(),
     }
   })
+
+  const scoringNameKeys: Record<string, string> = {
+    th1: 'themes.hotDiscussions',
+    th2: 'themes.topContent',
+  }
+
+  const handleThemeSelect = (theme: { id: string; name: string; type: string }) => {
+    if (theme.type === 'scoring') {
+      const window = theme.id === 'th1' ? 'week' as const : 'month' as const
+      const query = window === 'week' ? weekQuery : monthQuery
+      const translatedName = scoringNameKeys[theme.id] ? t(scoringNameKeys[theme.id]) : theme.name
+
+      if (query.data?.status === 'ready' && query.data.data) {
+        setSelectedTheme(mapScoringThemesToDetail(theme.id, translatedName, query.data.data))
+      } else if (query.data?.status === 'no_analysis' || query.data?.status === 'failed') {
+        refreshMutation.mutate({ audienceId, window })
+      }
+    } else {
+      const detailData = themesDetailData[theme.id]
+      if (detailData) {
+        setSelectedTheme({
+          id: theme.id,
+          name: theme.name,
+          ...detailData,
+        })
+      }
+    }
+  }
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
@@ -190,16 +266,7 @@ export function AudienceDetailTabs({
             <ThemesGrid
               themes={themesGridData}
               selectedThemeId={selectedTheme?.id}
-              onThemeSelect={(theme) => {
-                const detailData = themesDetailData[theme.id]
-                if (detailData) {
-                  setSelectedTheme({
-                    id: theme.id,
-                    name: theme.name,
-                    ...detailData,
-                  })
-                }
-              }}
+              onThemeSelect={handleThemeSelect}
             />
           </div>
           <div className="w-1/2 shrink-0">

--- a/src/components/audiences/detail/ThemesGrid.tsx
+++ b/src/components/audiences/detail/ThemesGrid.tsx
@@ -39,6 +39,11 @@ const themeIcons: Record<string, typeof Flame> = {
   News: Newspaper,
 }
 
+const scoringI18nKeys: Record<string, { name: string; description: string }> = {
+  th1: { name: 'themes.hotDiscussions', description: 'themes.weekDescription' },
+  th2: { name: 'themes.topContent', description: 'themes.monthDescription' },
+}
+
 export function ThemesGrid({
   themes,
   selectedThemeId,
@@ -99,6 +104,7 @@ export function ThemesGrid({
         <div ref={scoringRef} className="grid grid-cols-2 gap-4">
           {scoringThemes.map((theme) => {
             const Icon = themeIcons[theme.name] ?? Flame
+            const i18nKeys = scoringI18nKeys[theme.id]
             return (
               <button
                 key={theme.id}
@@ -116,10 +122,10 @@ export function ThemesGrid({
                   </div>
                   <div>
                     <p className="font-medium text-gray-900 dark:text-white">
-                      {theme.name}
+                      {i18nKeys ? t(i18nKeys.name) : theme.name}
                     </p>
                     <p className="text-sm text-gray-500 dark:text-zinc-400">
-                      {theme.description}
+                      {i18nKeys ? t(i18nKeys.description) : theme.description}
                     </p>
                   </div>
                 </div>

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -92,7 +92,20 @@
     "copy": "Copy",
     "subcategories": "Subcategories",
     "topics": "Topics",
-    "subreddits": "Subreddits"
+    "subreddits": "Subreddits",
+    "weekDescription": "Popular discussions this week",
+    "monthDescription": "Best-performing content of past month",
+    "generate": "Generate Analysis",
+    "processing": "Analyzing...",
+    "themesFound": "{{count}} themes found",
+    "failed": "Analysis failed. Click to retry.",
+    "hotDiscussions": "Hot Discussions",
+    "topContent": "Top Content",
+    "posts": "posts",
+    "avgScore": "Avg score",
+    "avgComments": "Avg comments",
+    "keywords": "Keywords",
+    "representativePosts": "Representative Posts"
   },
   "topics": {
     "title": "Topics",

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -92,7 +92,20 @@
     "copy": "Copiar",
     "subcategories": "Subcategorias",
     "topics": "Tópicos",
-    "subreddits": "Subreddits"
+    "subreddits": "Subreddits",
+    "weekDescription": "Discussões populares desta semana",
+    "monthDescription": "Melhor conteúdo do mês passado",
+    "generate": "Gerar Análise",
+    "processing": "Analisando...",
+    "themesFound": "{{count}} temas encontrados",
+    "failed": "Análise falhou. Clique para tentar novamente.",
+    "hotDiscussions": "Discussões em Alta",
+    "topContent": "Top Conteúdo",
+    "posts": "posts",
+    "avgScore": "Score médio",
+    "avgComments": "Média de comentários",
+    "keywords": "Palavras-chave",
+    "representativePosts": "Posts Representativos"
   },
   "topics": {
     "title": "Tópicos",

--- a/src/modules/audience/application/hooks/index.ts
+++ b/src/modules/audience/application/hooks/index.ts
@@ -24,3 +24,5 @@ export { useListTopicChatConversations, TOPIC_CHAT_CONVERSATIONS_QUERY_KEY } fro
 export { useGetTopicChatMessages, TOPIC_CHAT_MESSAGES_QUERY_KEY } from './useGetTopicChatMessages'
 export { useArchiveTopicChat } from './useArchiveTopicChat'
 export { useGetTopicGrowthHistory, TOPIC_GROWTH_HISTORY_QUERY_KEY } from './useGetTopicGrowthHistory'
+export { useGetAudienceThemes, AUDIENCE_THEMES_QUERY_KEY } from './useGetAudienceThemes'
+export { useRefreshAudienceThemes } from './useRefreshAudienceThemes'

--- a/src/modules/audience/application/hooks/useGetAudienceThemes.ts
+++ b/src/modules/audience/application/hooks/useGetAudienceThemes.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IGetAudienceThemesUseCase, GetAudienceThemesResult, ThemeAnalysisWindow } from '@/modules/audience/domain/use-cases'
+
+const getAudienceThemesUseCase = container.get<IGetAudienceThemesUseCase>(
+  TYPES.GetAudienceThemesUseCase
+)
+
+export const AUDIENCE_THEMES_QUERY_KEY = (audienceId: string, window: ThemeAnalysisWindow) =>
+  ['audience-themes', audienceId, window] as const
+
+export function useGetAudienceThemes(audienceId: string, window: ThemeAnalysisWindow, enabled: boolean) {
+  return useQuery<GetAudienceThemesResult, Error>({
+    queryKey: AUDIENCE_THEMES_QUERY_KEY(audienceId, window),
+    queryFn: () => getAudienceThemesUseCase.execute({ audienceId, window }),
+    enabled: !!audienceId && enabled,
+  })
+}

--- a/src/modules/audience/application/hooks/useRefreshAudienceThemes.ts
+++ b/src/modules/audience/application/hooks/useRefreshAudienceThemes.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IRefreshAudienceThemesUseCase, RefreshAudienceThemesParams } from '@/modules/audience/domain/use-cases'
+import { AUDIENCE_THEMES_QUERY_KEY } from './useGetAudienceThemes'
+
+const refreshAudienceThemesUseCase = container.get<IRefreshAudienceThemesUseCase>(
+  TYPES.RefreshAudienceThemesUseCase
+)
+
+export function useRefreshAudienceThemes() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (params: RefreshAudienceThemesParams) =>
+      refreshAudienceThemesUseCase.execute(params),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: AUDIENCE_THEMES_QUERY_KEY(variables.audienceId, variables.window),
+      })
+    },
+  })
+}

--- a/src/modules/audience/application/use-cases/get-audience-themes-use-case/index.ts
+++ b/src/modules/audience/application/use-cases/get-audience-themes-use-case/index.ts
@@ -1,0 +1,10 @@
+import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
+import type { IGetAudienceThemesUseCase, GetAudienceThemesParams, GetAudienceThemesResult } from '@/modules/audience/domain/use-cases'
+
+export class GetAudienceThemesUseCase implements IGetAudienceThemesUseCase {
+  constructor(private readonly audienceRepository: IAudienceRepository) {}
+
+  async execute(params: GetAudienceThemesParams): Promise<GetAudienceThemesResult> {
+    return this.audienceRepository.getAudienceThemes(params)
+  }
+}

--- a/src/modules/audience/application/use-cases/index.ts
+++ b/src/modules/audience/application/use-cases/index.ts
@@ -24,3 +24,5 @@ export { ListTopicChatConversationsUseCase } from './list-topic-chat-conversatio
 export { GetTopicChatMessagesUseCase } from './get-topic-chat-messages-use-case'
 export { ArchiveTopicChatUseCase } from './archive-topic-chat-use-case'
 export { GetTopicGrowthHistoryUseCase } from './get-topic-growth-history-use-case'
+export { GetAudienceThemesUseCase } from './get-audience-themes-use-case'
+export { RefreshAudienceThemesUseCase } from './refresh-audience-themes-use-case'

--- a/src/modules/audience/application/use-cases/refresh-audience-themes-use-case/index.ts
+++ b/src/modules/audience/application/use-cases/refresh-audience-themes-use-case/index.ts
@@ -1,0 +1,10 @@
+import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
+import type { IRefreshAudienceThemesUseCase, RefreshAudienceThemesParams, RefreshAudienceThemesResult } from '@/modules/audience/domain/use-cases'
+
+export class RefreshAudienceThemesUseCase implements IRefreshAudienceThemesUseCase {
+  constructor(private readonly audienceRepository: IAudienceRepository) {}
+
+  async execute(params: RefreshAudienceThemesParams): Promise<RefreshAudienceThemesResult> {
+    return this.audienceRepository.refreshAudienceThemes(params)
+  }
+}

--- a/src/modules/audience/domain/entities/Theme.entity.ts
+++ b/src/modules/audience/domain/entities/Theme.entity.ts
@@ -1,0 +1,96 @@
+export interface ThemeSubreddit {
+  name: string
+  postCount: number
+  avgScore: number
+}
+
+export interface ThemeKeyword {
+  keyword: string
+  frequency: number
+}
+
+export interface ThemeRepresentativePost {
+  title: string
+  subreddit: string
+  score: number
+  permalink: string
+}
+
+interface ThemeProps {
+  name: string
+  summary: string
+  postCount: number
+  avgScore: number
+  avgComments: number
+  engagementScore: number
+  rank: number
+  topSubreddits: ThemeSubreddit[]
+  topKeywords: ThemeKeyword[]
+  representativePosts: ThemeRepresentativePost[]
+}
+
+export class Theme {
+  private readonly name: string
+  private readonly summary: string
+  private readonly postCount: number
+  private readonly avgScore: number
+  private readonly avgComments: number
+  private readonly engagementScore: number
+  private readonly rank: number
+  private readonly topSubreddits: ThemeSubreddit[]
+  private readonly topKeywords: ThemeKeyword[]
+  private readonly representativePosts: ThemeRepresentativePost[]
+
+  constructor({ name, summary, postCount, avgScore, avgComments, engagementScore, rank, topSubreddits, topKeywords, representativePosts }: ThemeProps) {
+    this.name = name
+    this.summary = summary
+    this.postCount = postCount
+    this.avgScore = avgScore
+    this.avgComments = avgComments
+    this.engagementScore = engagementScore
+    this.rank = rank
+    this.topSubreddits = topSubreddits
+    this.topKeywords = topKeywords
+    this.representativePosts = representativePosts
+  }
+
+  getName(): string {
+    return this.name
+  }
+
+  getSummary(): string {
+    return this.summary
+  }
+
+  getPostCount(): number {
+    return this.postCount
+  }
+
+  getAvgScore(): number {
+    return this.avgScore
+  }
+
+  getAvgComments(): number {
+    return this.avgComments
+  }
+
+  getEngagementScore(): number {
+    return this.engagementScore
+  }
+
+  getRank(): number {
+    return this.rank
+  }
+
+  getTopSubreddits(): ThemeSubreddit[] {
+    return this.topSubreddits
+  }
+
+  getTopKeywords(): ThemeKeyword[] {
+    return this.topKeywords
+  }
+
+  getRepresentativePosts(): ThemeRepresentativePost[] {
+    return this.representativePosts
+  }
+}

--- a/src/modules/audience/domain/repositories/audience.repository.ts
+++ b/src/modules/audience/domain/repositories/audience.repository.ts
@@ -22,6 +22,8 @@ import type { ListTopicChatConversationsParams, ListTopicChatConversationsResult
 import type { GetTopicChatMessagesParams, GetTopicChatMessagesResult } from "../use-cases/get-topic-chat-messages.use-case";
 import type { ArchiveTopicChatParams, ArchiveTopicChatResult } from "../use-cases/archive-topic-chat.use-case";
 import type { GetTopicGrowthHistoryParams, GetTopicGrowthHistoryResult } from "../use-cases/get-topic-growth-history.use-case";
+import type { GetAudienceThemesParams, GetAudienceThemesResult } from "../use-cases/get-audience-themes.use-case";
+import type { RefreshAudienceThemesParams, RefreshAudienceThemesResult } from "../use-cases/refresh-audience-themes.use-case";
 
 export interface IAudienceRepository {
   listUserAudiences(): Promise<Audience[]>
@@ -50,4 +52,6 @@ export interface IAudienceRepository {
   getTopicChatMessages(params: GetTopicChatMessagesParams): Promise<GetTopicChatMessagesResult>
   archiveTopicChat(params: ArchiveTopicChatParams): Promise<ArchiveTopicChatResult>
   getTopicGrowthHistory(params: GetTopicGrowthHistoryParams): Promise<GetTopicGrowthHistoryResult>
+  getAudienceThemes(params: GetAudienceThemesParams): Promise<GetAudienceThemesResult>
+  refreshAudienceThemes(params: RefreshAudienceThemesParams): Promise<RefreshAudienceThemesResult>
 }

--- a/src/modules/audience/domain/use-cases/get-audience-themes.use-case.ts
+++ b/src/modules/audience/domain/use-cases/get-audience-themes.use-case.ts
@@ -1,0 +1,19 @@
+import type { Theme } from '../entities/Theme.entity'
+
+export type ThemeAnalysisWindow = 'week' | 'month'
+
+export type ThemeAnalysisStatus = 'no_analysis' | 'processing' | 'ready' | 'failed'
+
+export interface GetAudienceThemesParams {
+  audienceId: string
+  window: ThemeAnalysisWindow
+}
+
+export interface GetAudienceThemesResult {
+  status: ThemeAnalysisStatus
+  data: Theme[] | null
+}
+
+export interface IGetAudienceThemesUseCase {
+  execute(params: GetAudienceThemesParams): Promise<GetAudienceThemesResult>
+}

--- a/src/modules/audience/domain/use-cases/index.ts
+++ b/src/modules/audience/domain/use-cases/index.ts
@@ -24,3 +24,5 @@ export type { IListTopicChatConversationsUseCase, ListTopicChatConversationsPara
 export type { IGetTopicChatMessagesUseCase, GetTopicChatMessagesParams, GetTopicChatMessagesResult } from './get-topic-chat-messages.use-case'
 export type { IArchiveTopicChatUseCase, ArchiveTopicChatParams, ArchiveTopicChatResult } from './archive-topic-chat.use-case'
 export type { IGetTopicGrowthHistoryUseCase, GetTopicGrowthHistoryParams, GetTopicGrowthHistoryResult } from './get-topic-growth-history.use-case'
+export type { IGetAudienceThemesUseCase, GetAudienceThemesParams, GetAudienceThemesResult, ThemeAnalysisStatus, ThemeAnalysisWindow } from './get-audience-themes.use-case'
+export type { IRefreshAudienceThemesUseCase, RefreshAudienceThemesParams, RefreshAudienceThemesResult } from './refresh-audience-themes.use-case'

--- a/src/modules/audience/domain/use-cases/refresh-audience-themes.use-case.ts
+++ b/src/modules/audience/domain/use-cases/refresh-audience-themes.use-case.ts
@@ -1,0 +1,15 @@
+import type { ThemeAnalysisWindow } from './get-audience-themes.use-case'
+
+export interface RefreshAudienceThemesParams {
+  audienceId: string
+  window: ThemeAnalysisWindow
+}
+
+export interface RefreshAudienceThemesResult {
+  status: string
+  analysisId: string
+}
+
+export interface IRefreshAudienceThemesUseCase {
+  execute(params: RefreshAudienceThemesParams): Promise<RefreshAudienceThemesResult>
+}

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -24,6 +24,8 @@ import type { ListTopicChatConversationsParams, ListTopicChatConversationsResult
 import type { GetTopicChatMessagesParams, GetTopicChatMessagesResult } from '../../domain/use-cases/get-topic-chat-messages.use-case'
 import type { ArchiveTopicChatParams, ArchiveTopicChatResult } from '../../domain/use-cases/archive-topic-chat.use-case'
 import type { GetTopicGrowthHistoryParams, GetTopicGrowthHistoryResult } from '../../domain/use-cases/get-topic-growth-history.use-case'
+import type { GetAudienceThemesParams, GetAudienceThemesResult, ThemeAnalysisStatus } from '../../domain/use-cases/get-audience-themes.use-case'
+import type { RefreshAudienceThemesParams, RefreshAudienceThemesResult } from '../../domain/use-cases/refresh-audience-themes.use-case'
 import { Keyword } from '../../domain/entities/Keyword.entity'
 import { Topic } from '../../domain/entities/Topic.entity'
 import { TopicDeepDive } from '../../domain/entities/TopicDeepDive.entity'
@@ -33,6 +35,7 @@ import { TopicAskResponse } from '../../domain/entities/TopicAskResponse.entity'
 import { TopicConversation } from '../../domain/entities/TopicConversation.entity'
 import { TopicConversationMessage } from '../../domain/entities/TopicConversationMessage.entity'
 import { TopicGrowthHistory } from '../../domain/entities/TopicGrowthHistory.entity'
+import { Theme } from '../../domain/entities/Theme.entity'
 
 interface AudienceTemplateResponse {
   id: string
@@ -352,6 +355,31 @@ interface GetTopicChatMessagesApiResponse {
 interface ArchiveTopicChatApiResponse {
   status: string
   conversation_id: string
+}
+
+interface ThemeAnalysisApiResponse {
+  status: string
+  analysis_id?: string
+  completed_at?: string
+  error_message?: string
+  themes?: Array<{
+    name: string
+    summary: string
+    post_count: number
+    avg_score: number
+    avg_comments: number
+    engagement_score: number
+    rank: number
+    top_subreddits: Array<{ name: string; post_count: number; avg_score: number }>
+    top_keywords: Array<{ keyword: string; frequency: number }>
+    representative_posts: Array<{ title: string; subreddit: string; score: number; permalink: string }>
+  }>
+}
+
+interface RefreshThemeApiResponse {
+  status: string
+  analysis_id: string
+  message?: string
 }
 
 export class AudienceRepository implements IAudienceRepository {
@@ -879,6 +907,56 @@ export class AudienceRepository implements IAudienceRepository {
         trend: response.trend,
         totalSnapshots: response.total_snapshots,
       }),
+    }
+  }
+
+  async getAudienceThemes(params: GetAudienceThemesParams): Promise<GetAudienceThemesResult> {
+    const response = await this.httpClient.get<ThemeAnalysisApiResponse>(
+      `audiences/${params.audienceId}/themes?window=${params.window}`
+    )
+
+    const status = response.status as ThemeAnalysisStatus
+
+    if (status !== 'ready' || !response.themes) {
+      return { status, data: null }
+    }
+
+    return {
+      status,
+      data: response.themes.map((t) => new Theme({
+        name: t.name,
+        summary: t.summary,
+        postCount: t.post_count,
+        avgScore: t.avg_score,
+        avgComments: t.avg_comments,
+        engagementScore: t.engagement_score,
+        rank: t.rank,
+        topSubreddits: (t.top_subreddits ?? []).map((s) => ({
+          name: s.name,
+          postCount: s.post_count,
+          avgScore: s.avg_score,
+        })),
+        topKeywords: (t.top_keywords ?? []).map((k) => ({
+          keyword: k.keyword,
+          frequency: k.frequency,
+        })),
+        representativePosts: (t.representative_posts ?? []).map((p) => ({
+          title: p.title,
+          subreddit: p.subreddit,
+          score: p.score,
+          permalink: p.permalink,
+        })),
+      })),
+    }
+  }
+
+  async refreshAudienceThemes(params: RefreshAudienceThemesParams): Promise<RefreshAudienceThemesResult> {
+    const response = await this.httpClient.post<RefreshThemeApiResponse>(
+      `audiences/${params.audienceId}/themes/refresh?window=${params.window}`
+    )
+    return {
+      status: response.status,
+      analysisId: response.analysis_id,
     }
   }
 }

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -3,8 +3,8 @@ import { TYPES } from './types'
 import { KyHttpClient, type HttpClient } from '../http'
 import { AudienceRepository } from '@/modules/audience/infra/repositories'
 import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
-import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase, MarkCommunityNotRelevantUseCase, GetAudienceTopicsUseCase, GetTopicDeepDiveUseCase, TriggerTopicDeepDiveUseCase, GetTopicBehavioralPatternsUseCase, TriggerTopicBehavioralPatternsUseCase, GetTopicSentimentUseCase, TriggerTopicSentimentUseCase, AskTopicUseCase, StartTopicChatUseCase, SendTopicChatMessageUseCase, ListTopicChatConversationsUseCase, GetTopicChatMessagesUseCase, ArchiveTopicChatUseCase, GetTopicGrowthHistoryUseCase } from '@/modules/audience/application/use-cases'
-import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase, IMarkCommunityNotRelevantUseCase, IGetAudienceTopicsUseCase, IGetTopicDeepDiveUseCase, ITriggerTopicDeepDiveUseCase, IGetTopicBehavioralPatternsUseCase, ITriggerTopicBehavioralPatternsUseCase, IGetTopicSentimentUseCase, ITriggerTopicSentimentUseCase, IAskTopicUseCase, IStartTopicChatUseCase, ISendTopicChatMessageUseCase, IListTopicChatConversationsUseCase, IGetTopicChatMessagesUseCase, IArchiveTopicChatUseCase, IGetTopicGrowthHistoryUseCase } from '@/modules/audience/domain/use-cases'
+import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase, MarkCommunityNotRelevantUseCase, GetAudienceTopicsUseCase, GetTopicDeepDiveUseCase, TriggerTopicDeepDiveUseCase, GetTopicBehavioralPatternsUseCase, TriggerTopicBehavioralPatternsUseCase, GetTopicSentimentUseCase, TriggerTopicSentimentUseCase, AskTopicUseCase, StartTopicChatUseCase, SendTopicChatMessageUseCase, ListTopicChatConversationsUseCase, GetTopicChatMessagesUseCase, ArchiveTopicChatUseCase, GetTopicGrowthHistoryUseCase, GetAudienceThemesUseCase, RefreshAudienceThemesUseCase } from '@/modules/audience/application/use-cases'
+import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase, IMarkCommunityNotRelevantUseCase, IGetAudienceTopicsUseCase, IGetTopicDeepDiveUseCase, ITriggerTopicDeepDiveUseCase, IGetTopicBehavioralPatternsUseCase, ITriggerTopicBehavioralPatternsUseCase, IGetTopicSentimentUseCase, ITriggerTopicSentimentUseCase, IAskTopicUseCase, IStartTopicChatUseCase, ISendTopicChatMessageUseCase, IListTopicChatConversationsUseCase, IGetTopicChatMessagesUseCase, IArchiveTopicChatUseCase, IGetTopicGrowthHistoryUseCase, IGetAudienceThemesUseCase, IRefreshAudienceThemesUseCase } from '@/modules/audience/domain/use-cases'
 import { CommunityRepository } from '@/modules/community/infra/repositories'
 import type { ICommunityRepository } from '@/modules/community/domain/repositories'
 import { BrowseCommunitiesUseCase } from '@/modules/community/application/use-cases'
@@ -155,6 +155,16 @@ container.bind<IArchiveTopicChatUseCase>(TYPES.ArchiveTopicChatUseCase).toDynami
 container.bind<IGetTopicGrowthHistoryUseCase>(TYPES.GetTopicGrowthHistoryUseCase).toDynamicValue(() => {
   const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
   return new GetTopicGrowthHistoryUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<IGetAudienceThemesUseCase>(TYPES.GetAudienceThemesUseCase).toDynamicValue(() => {
+  const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
+  return new GetAudienceThemesUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<IRefreshAudienceThemesUseCase>(TYPES.RefreshAudienceThemesUseCase).toDynamicValue(() => {
+  const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
+  return new RefreshAudienceThemesUseCase(audienceRepository)
 }).inSingletonScope()
 
 container.bind<ICommunityRepository>(TYPES.CommunityRepository).toDynamicValue(() => {

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -27,6 +27,8 @@ export const TYPES = {
   GetTopicChatMessagesUseCase: Symbol.for('GetTopicChatMessagesUseCase'),
   ArchiveTopicChatUseCase: Symbol.for('ArchiveTopicChatUseCase'),
   GetTopicGrowthHistoryUseCase: Symbol.for('GetTopicGrowthHistoryUseCase'),
+  GetAudienceThemesUseCase: Symbol.for('GetAudienceThemesUseCase'),
+  RefreshAudienceThemesUseCase: Symbol.for('RefreshAudienceThemesUseCase'),
   CommunityRepository: Symbol.for('CommunityRepository'),
   BrowseCommunitiesUseCase: Symbol.for('BrowseCommunitiesUseCase'),
   AuthRepository: Symbol.for('AuthRepository'),


### PR DESCRIPTION
## Summary
- Add full DDD stack for scoring themes: Theme entity, use case interfaces/implementations, repository methods, React Query hooks, and DI container bindings
- Connect Themes tab scoring cards (Hot Discussions / Top Content) to API endpoints (`GET /audiences/{id}/themes?window=week|month` and `POST /audiences/{id}/themes/refresh`)
- Map API response (themes with summary, keywords, subreddits) to the existing ThemeDetail layout (subcategories, topics, subreddits columns)
- Add i18n translations for scoring theme card labels (EN + PT-BR)
- AI-tagged themes remain using mock data (to be migrated separately)

Closes #79

## Test plan
- [ ] Open audience detail → Themes tab
- [ ] Verify scoring cards show translated text (PT-BR: "Discussões em Alta", "Top Conteúdo")
- [ ] Click "Hot Discussions" → triggers week analysis if no data, shows detail panel when ready
- [ ] Click "Top Content" → triggers month analysis if no data, shows detail panel when ready
- [ ] Verify detail panel shows subcategories (theme names), topics (keywords), subreddits correctly
- [ ] Verify AI-tagged themes still work with mock data
- [ ] Verify no excessive polling in the network tab