### PR TITLE
feat: integrate theme narrative summaries with dynamic API data

### DIFF
--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -53,6 +53,7 @@ function mapScoringThemesToDetail(
   id: string,
   name: string,
   themes: Theme[],
+  window: 'week' | 'month',
 ): ThemeDetail {
   const topTheme = themes[0]
 
@@ -81,6 +82,11 @@ function mapScoringThemesToDetail(
     .sort((a, b) => b[1] - a[1])
     .map(([subredditName, count]) => ({ name: subredditName, count }))
 
+  const summaryThemes = themes.map((theme) => ({
+    id: theme.getId(),
+    name: theme.getName(),
+  }))
+
   return {
     id,
     name,
@@ -88,6 +94,8 @@ function mapScoringThemesToDetail(
     subcategories,
     topics,
     subreddits,
+    summaryThemes,
+    window,
   }
 }
 
@@ -203,7 +211,7 @@ export function AudienceDetailTabs({
       const translatedName = scoringNameKeys[theme.id] ? t(scoringNameKeys[theme.id]) : theme.name
 
       if (query.data?.status === 'ready' && query.data.data) {
-        setSelectedTheme(mapScoringThemesToDetail(theme.id, translatedName, query.data.data))
+        setSelectedTheme(mapScoringThemesToDetail(theme.id, translatedName, query.data.data, window))
         setSelectedIntentCategory(null)
       } else if (query.data?.status === 'no_analysis' || query.data?.status === 'failed') {
         refreshMutation.mutate({ audienceId, window })

--- a/src/components/audiences/detail/ThemeDetailPanel.tsx
+++ b/src/components/audiences/detail/ThemeDetailPanel.tsx
@@ -5,6 +5,8 @@ import { gsap } from '@/lib/gsap'
 import { useReducedMotion } from '@/hooks'
 import { Button } from '@/components/ui/button'
 import { useGetIntentPosts } from '@/modules/audience/application/hooks'
+import { ThemeSummaryCard } from './ThemeSummaryCard'
+import type { ThemeAnalysisWindow } from '@/modules/audience/domain/use-cases'
 
 export interface ThemeSubcategory {
   name: string
@@ -22,6 +24,11 @@ export interface ThemeSubreddit {
   count: number
 }
 
+export interface ThemeSummaryTheme {
+  id: string
+  name: string
+}
+
 export interface ThemeDetail {
   id: string
   name: string
@@ -29,6 +36,8 @@ export interface ThemeDetail {
   subcategories: ThemeSubcategory[]
   topics: ThemeTopic[]
   subreddits: ThemeSubreddit[]
+  summaryThemes?: ThemeSummaryTheme[]
+  window?: ThemeAnalysisWindow
 }
 
 export interface ThemeDetailPanelProps {
@@ -147,6 +156,27 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory }: Readonly
                 {t('themes.copy')}
               </Button>
             </div>
+
+            {/* Narrative Summaries */}
+            {theme.summaryThemes && theme.summaryThemes.length > 0 && audienceId && (
+              <div className="mb-6">
+                <h4 className="font-medium text-gray-900 dark:text-white text-sm mb-3">
+                  {t('themes.summary.title')}
+                </h4>
+                <div className="space-y-3">
+                  {theme.summaryThemes.map((st) => (
+                    <ThemeSummaryCard
+                      key={st.id}
+                      audienceId={audienceId}
+                      themeId={st.id}
+                      themeName={st.name}
+                      window={theme.window ?? 'week'}
+                      enabled={!!audienceId}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
 
             <div className="grid grid-cols-3 gap-4">
               {/* Subcategories */}
@@ -267,7 +297,7 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory }: Readonly
                             r/{post.getPostSubreddit()}
                           </span>
                           <span className="text-xs text-gray-400 dark:text-zinc-500">
-                            {Math.round(post.getConfidence() * 100)}%
+                            {post.getConfidence()}
                           </span>
                         </div>
                       </li>

--- a/src/components/audiences/detail/ThemeSummaryCard.tsx
+++ b/src/components/audiences/detail/ThemeSummaryCard.tsx
@@ -1,0 +1,257 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronDown, ChevronRight, Loader2, Sparkles, Star, Tag, TrendingUp, BarChart3 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useGetThemeSummary } from '@/modules/audience/application/hooks/useGetThemeSummary'
+import { useRefreshThemeSummary } from '@/modules/audience/application/hooks/useRefreshThemeSummary'
+import type { ThemeAnalysisWindow } from '@/modules/audience/domain/use-cases'
+import type { EmotionalTone } from '@/modules/audience/domain/entities/ThemeSummary.entity'
+
+const TONE_COLORS: Record<EmotionalTone, string> = {
+  positive: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+  mixed: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  tense: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  neutral: 'bg-gray-100 text-gray-700 dark:bg-zinc-700 dark:text-zinc-300',
+  celebratory: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400',
+  concerned: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+  supportive: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+}
+
+export interface ThemeSummaryCardProps {
+  audienceId: string
+  themeId: string
+  themeName: string
+  window: ThemeAnalysisWindow
+  enabled: boolean
+}
+
+export function ThemeSummaryCard({ audienceId, themeId, themeName, window, enabled }: Readonly<ThemeSummaryCardProps>) {
+  const { t } = useTranslation('audiences')
+  const [isExpanded, setIsExpanded] = useState(true)
+  const [narrativeExpanded, setNarrativeExpanded] = useState(true)
+  const [highlightsExpanded, setHighlightsExpanded] = useState(false)
+  const [keyThemesExpanded, setKeyThemesExpanded] = useState(false)
+
+  const summaryQuery = useGetThemeSummary(audienceId, themeId, enabled)
+  const refreshMutation = useRefreshThemeSummary()
+
+  const summary = summaryQuery.data?.data
+  const status = summaryQuery.data?.status
+  const isLoading = summaryQuery.isLoading
+  const isGenerating = refreshMutation.isPending
+
+  const handleGenerate = () => {
+    refreshMutation.mutate({ audienceId, themeId, window })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="border border-gray-200 dark:border-zinc-700 rounded-xl p-4">
+        <div className="flex items-center gap-2">
+          <Loader2 className="w-4 h-4 animate-spin text-gray-400" />
+          <span className="text-sm text-gray-500 dark:text-zinc-400">{themeName}</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (!summary || status === 'no_summary') {
+    return (
+      <div className="border border-gray-200 dark:border-zinc-700 rounded-xl p-4">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-700 dark:text-zinc-300">{themeName}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={handleGenerate}
+            disabled={isGenerating}
+          >
+            {isGenerating ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="w-3.5 h-3.5" />
+            )}
+            {isGenerating ? t('themes.summary.generating') : t('themes.summary.generate')}
+          </Button>
+        </div>
+        <p className="text-xs text-gray-400 dark:text-zinc-500 mt-2">
+          {t('themes.summary.noSummary')}
+        </p>
+      </div>
+    )
+  }
+
+  const emotionalTone = summary.getEmotionalTone()
+  const toneColorClass = TONE_COLORS[emotionalTone] ?? TONE_COLORS.neutral
+
+  return (
+    <div className="border border-gray-200 dark:border-zinc-700 rounded-xl overflow-hidden">
+      {/* Header */}
+      <button
+        type="button"
+        className="w-full flex items-center justify-between p-4 hover:bg-gray-50 dark:hover:bg-zinc-800/50 transition-colors cursor-pointer"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <div className="flex items-center gap-3">
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4 text-gray-400" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-gray-400" />
+          )}
+          <span className="text-sm font-medium text-gray-900 dark:text-white">{themeName}</span>
+          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${toneColorClass}`}>
+            {t(`themes.summary.emotionalTone.${emotionalTone}`)}
+          </span>
+        </div>
+        <span className="text-xs text-gray-400 dark:text-zinc-500">
+          {summary.getToneDescription()}
+        </span>
+      </button>
+
+      {/* Content */}
+      {isExpanded && (
+        <div className="px-4 pb-4 space-y-3">
+          {/* Narrative */}
+          <CollapsibleSection
+            title={t('themes.summary.narrative')}
+            icon={<Sparkles className="w-3.5 h-3.5" />}
+            isExpanded={narrativeExpanded}
+            onToggle={() => setNarrativeExpanded(!narrativeExpanded)}
+          >
+            <div className="text-sm text-gray-600 dark:text-zinc-300 leading-relaxed whitespace-pre-line">
+              {summary.getNarrative()}
+            </div>
+          </CollapsibleSection>
+
+          {/* Key Themes */}
+          {summary.getKeyThemes().length > 0 && (
+            <CollapsibleSection
+              title={t('themes.summary.keyThemes')}
+              icon={<Tag className="w-3.5 h-3.5" />}
+              count={summary.getKeyThemes().length}
+              isExpanded={keyThemesExpanded}
+              onToggle={() => setKeyThemesExpanded(!keyThemesExpanded)}
+            >
+              <div className="flex flex-wrap gap-2">
+                {summary.getKeyThemes().map((kt) => (
+                  <div
+                    key={kt.theme}
+                    className="group relative inline-flex items-center px-2.5 py-1 rounded-lg bg-gray-100 dark:bg-zinc-800 text-xs font-medium text-gray-700 dark:text-zinc-300"
+                  >
+                    {kt.theme}
+                    <div className="hidden group-hover:block absolute bottom-full left-0 mb-1 px-2 py-1 rounded bg-gray-900 dark:bg-zinc-700 text-white text-xs whitespace-nowrap z-10">
+                      {kt.description}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CollapsibleSection>
+          )}
+
+          {/* Highlights */}
+          {summary.getHighlights().length > 0 && (
+            <CollapsibleSection
+              title={t('themes.summary.highlights')}
+              icon={<Star className="w-3.5 h-3.5" />}
+              count={summary.getHighlights().length}
+              isExpanded={highlightsExpanded}
+              onToggle={() => setHighlightsExpanded(!highlightsExpanded)}
+            >
+              <ul className="space-y-2">
+                {summary.getHighlights().map((h) => (
+                  <li key={h.title} className="py-2 px-3 rounded-lg bg-gray-50 dark:bg-zinc-800">
+                    <p className="text-sm font-medium text-gray-900 dark:text-white">{h.title}</p>
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className="text-xs text-gray-500 dark:text-zinc-400">r/{h.subreddit}</span>
+                      <span className="text-xs text-gray-400 dark:text-zinc-500">{h.score} pts</span>
+                    </div>
+                    <p className="text-xs text-gray-500 dark:text-zinc-400 mt-1 italic">
+                      {t('themes.summary.whyNotable')}: {h.whyNotable}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            </CollapsibleSection>
+          )}
+
+          {/* Week Differentiator */}
+          {summary.getWeekDifferentiator() && (
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-blue-50 dark:bg-blue-900/20">
+              <TrendingUp className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
+              <div>
+                <p className="text-xs font-medium text-blue-700 dark:text-blue-400 mb-1">
+                  {t('themes.summary.weekDifferentiator')}
+                </p>
+                <p className="text-sm text-blue-600 dark:text-blue-300">
+                  {summary.getWeekDifferentiator()}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Intent Breakdown */}
+          {summary.getIntentBreakdown() && Object.keys(summary.getIntentBreakdown()!).length > 0 && (
+            <div className="p-3 rounded-lg bg-gray-50 dark:bg-zinc-800">
+              <div className="flex items-center gap-2 mb-2">
+                <BarChart3 className="w-3.5 h-3.5 text-gray-400" />
+                <span className="text-xs font-medium text-gray-700 dark:text-zinc-300">
+                  {t('themes.summary.intentBreakdown')}
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {Object.entries(summary.getIntentBreakdown()!).map(([intent, count]) => (
+                  <span
+                    key={intent}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-200 dark:bg-zinc-700 text-xs text-gray-600 dark:text-zinc-300"
+                  >
+                    {t(`themes.intents.${intent}`, intent)}
+                    <span className="font-medium">{count}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CollapsibleSection({
+  title,
+  icon,
+  count,
+  isExpanded,
+  onToggle,
+  children,
+}: Readonly<{
+  title: string
+  icon: React.ReactNode
+  count?: number
+  isExpanded: boolean
+  onToggle: () => void
+  children: React.ReactNode
+}>) {
+  return (
+    <div>
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 py-1.5 text-left hover:text-gray-900 dark:hover:text-white transition-colors cursor-pointer"
+        onClick={onToggle}
+      >
+        {isExpanded ? (
+          <ChevronDown className="w-3 h-3 text-gray-400" />
+        ) : (
+          <ChevronRight className="w-3 h-3 text-gray-400" />
+        )}
+        <span className="text-gray-500 dark:text-zinc-400">{icon}</span>
+        <span className="text-xs font-medium text-gray-700 dark:text-zinc-300">{title}</span>
+        {count !== undefined && (
+          <span className="text-xs text-gray-400 dark:text-zinc-500">{count}</span>
+        )}
+      </button>
+      {isExpanded && <div className="pl-5 mt-1">{children}</div>}
+    </div>
+  )
+}

--- a/src/components/audiences/detail/index.ts
+++ b/src/components/audiences/detail/index.ts
@@ -23,7 +23,10 @@ export { TopicDetailPanel } from './TopicDetailPanel'
 export type { TopicDetailPanelProps, TopicDetail, TopicSubreddit } from './TopicDetailPanel'
 
 export { ThemeDetailPanel } from './ThemeDetailPanel'
-export type { ThemeDetailPanelProps, ThemeDetail, ThemeSubcategory, ThemeTopic, ThemeSubreddit } from './ThemeDetailPanel'
+export type { ThemeDetailPanelProps, ThemeDetail, ThemeSubcategory, ThemeTopic, ThemeSubreddit, ThemeSummaryTheme } from './ThemeDetailPanel'
+
+export { ThemeSummaryCard } from './ThemeSummaryCard'
+export type { ThemeSummaryCardProps } from './ThemeSummaryCard'
 
 export { ThemesGrid } from './ThemesGrid'
 export type { ThemesGridProps, ThemeGridItem } from './ThemesGrid'

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -106,6 +106,28 @@
     "avgComments": "Avg comments",
     "keywords": "Keywords",
     "representativePosts": "Representative Posts",
+    "summary": {
+      "title": "Narrative Summary",
+      "generate": "Generate Summary",
+      "generating": "Generating summary...",
+      "noSummary": "No summary available yet. Generate one to get AI-powered insights.",
+      "narrative": "Narrative",
+      "highlights": "Highlights",
+      "keyThemes": "Key Themes",
+      "weekDifferentiator": "What made this period different",
+      "intentBreakdown": "Intent Breakdown",
+      "whyNotable": "Why notable",
+      "emotionalTone": {
+        "label": "Emotional Tone",
+        "positive": "Positive",
+        "mixed": "Mixed",
+        "tense": "Tense",
+        "neutral": "Neutral",
+        "celebratory": "Celebratory",
+        "concerned": "Concerned",
+        "supportive": "Supportive"
+      }
+    },
     "intents": {
       "advice_request": "Advice Requests",
       "advice_request_desc": "People asking for advice & resources",

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -106,6 +106,28 @@
     "avgComments": "Média de comentários",
     "keywords": "Palavras-chave",
     "representativePosts": "Posts Representativos",
+    "summary": {
+      "title": "Sumário Narrativo",
+      "generate": "Gerar Sumário",
+      "generating": "Gerando sumário...",
+      "noSummary": "Nenhum sumário disponível ainda. Gere um para obter insights com IA.",
+      "narrative": "Narrativa",
+      "highlights": "Destaques",
+      "keyThemes": "Temas-chave",
+      "weekDifferentiator": "O que tornou este período diferente",
+      "intentBreakdown": "Distribuição de Intenções",
+      "whyNotable": "Por que é notável",
+      "emotionalTone": {
+        "label": "Tom Emocional",
+        "positive": "Positivo",
+        "mixed": "Misto",
+        "tense": "Tenso",
+        "neutral": "Neutro",
+        "celebratory": "Celebratório",
+        "concerned": "Preocupado",
+        "supportive": "Solidário"
+      }
+    },
     "intents": {
       "advice_request": "Pedidos de Conselho",
       "advice_request_desc": "Pessoas pedindo conselhos e recursos",

--- a/src/modules/audience/application/hooks/useGetThemeSummary.ts
+++ b/src/modules/audience/application/hooks/useGetThemeSummary.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IGetThemeSummaryUseCase, GetThemeSummaryResult } from '@/modules/audience/domain/use-cases'
+
+const getThemeSummaryUseCase = container.get<IGetThemeSummaryUseCase>(
+  TYPES.GetThemeSummaryUseCase
+)
+
+export const THEME_SUMMARY_QUERY_KEY = (audienceId: string, themeId: string) =>
+  ['theme-summary', audienceId, themeId] as const
+
+export function useGetThemeSummary(audienceId: string, themeId: string, enabled: boolean) {
+  return useQuery<GetThemeSummaryResult, Error>({
+    queryKey: THEME_SUMMARY_QUERY_KEY(audienceId, themeId),
+    queryFn: () => getThemeSummaryUseCase.execute({ audienceId, themeId }),
+    enabled: !!audienceId && !!themeId && enabled,
+  })
+}

--- a/src/modules/audience/application/hooks/useRefreshThemeSummary.ts
+++ b/src/modules/audience/application/hooks/useRefreshThemeSummary.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IRefreshThemeSummaryUseCase, RefreshThemeSummaryParams } from '@/modules/audience/domain/use-cases'
+import { THEME_SUMMARY_QUERY_KEY } from './useGetThemeSummary'
+
+const refreshThemeSummaryUseCase = container.get<IRefreshThemeSummaryUseCase>(
+  TYPES.RefreshThemeSummaryUseCase
+)
+
+export function useRefreshThemeSummary() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (params: RefreshThemeSummaryParams) =>
+      refreshThemeSummaryUseCase.execute(params),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: THEME_SUMMARY_QUERY_KEY(variables.audienceId, variables.themeId),
+      })
+    },
+  })
+}

--- a/src/modules/audience/application/use-cases/get-theme-summary-use-case/index.ts
+++ b/src/modules/audience/application/use-cases/get-theme-summary-use-case/index.ts
@@ -1,0 +1,10 @@
+import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
+import type { IGetThemeSummaryUseCase, GetThemeSummaryParams, GetThemeSummaryResult } from '@/modules/audience/domain/use-cases'
+
+export class GetThemeSummaryUseCase implements IGetThemeSummaryUseCase {
+  constructor(private readonly audienceRepository: IAudienceRepository) {}
+
+  async execute(params: GetThemeSummaryParams): Promise<GetThemeSummaryResult> {
+    return this.audienceRepository.getThemeSummary(params)
+  }
+}

--- a/src/modules/audience/application/use-cases/index.ts
+++ b/src/modules/audience/application/use-cases/index.ts
@@ -29,3 +29,5 @@ export { RefreshAudienceThemesUseCase } from './refresh-audience-themes-use-case
 export { GetAudienceIntentsUseCase } from './get-audience-intents-use-case'
 export { RefreshAudienceIntentsUseCase } from './refresh-audience-intents-use-case'
 export { GetIntentPostsUseCase } from './get-intent-posts-use-case'
+export { GetThemeSummaryUseCase } from './get-theme-summary-use-case'
+export { RefreshThemeSummaryUseCase } from './refresh-theme-summary-use-case'

--- a/src/modules/audience/application/use-cases/refresh-theme-summary-use-case/index.ts
+++ b/src/modules/audience/application/use-cases/refresh-theme-summary-use-case/index.ts
@@ -1,0 +1,10 @@
+import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
+import type { IRefreshThemeSummaryUseCase, RefreshThemeSummaryParams, RefreshThemeSummaryResult } from '@/modules/audience/domain/use-cases'
+
+export class RefreshThemeSummaryUseCase implements IRefreshThemeSummaryUseCase {
+  constructor(private readonly audienceRepository: IAudienceRepository) {}
+
+  async execute(params: RefreshThemeSummaryParams): Promise<RefreshThemeSummaryResult> {
+    return this.audienceRepository.refreshThemeSummary(params)
+  }
+}

--- a/src/modules/audience/domain/entities/Theme.entity.ts
+++ b/src/modules/audience/domain/entities/Theme.entity.ts
@@ -17,6 +17,7 @@ export interface ThemeRepresentativePost {
 }
 
 interface ThemeProps {
+  id: string
   name: string
   summary: string
   postCount: number
@@ -30,6 +31,7 @@ interface ThemeProps {
 }
 
 export class Theme {
+  private readonly id: string
   private readonly name: string
   private readonly summary: string
   private readonly postCount: number
@@ -41,7 +43,8 @@ export class Theme {
   private readonly topKeywords: ThemeKeyword[]
   private readonly representativePosts: ThemeRepresentativePost[]
 
-  constructor({ name, summary, postCount, avgScore, avgComments, engagementScore, rank, topSubreddits, topKeywords, representativePosts }: ThemeProps) {
+  constructor({ id, name, summary, postCount, avgScore, avgComments, engagementScore, rank, topSubreddits, topKeywords, representativePosts }: ThemeProps) {
+    this.id = id
     this.name = name
     this.summary = summary
     this.postCount = postCount
@@ -52,6 +55,10 @@ export class Theme {
     this.topSubreddits = topSubreddits
     this.topKeywords = topKeywords
     this.representativePosts = representativePosts
+  }
+
+  getId(): string {
+    return this.id
   }
 
   getName(): string {

--- a/src/modules/audience/domain/entities/ThemeSummary.entity.ts
+++ b/src/modules/audience/domain/entities/ThemeSummary.entity.ts
@@ -1,0 +1,85 @@
+export type EmotionalTone = 'positive' | 'mixed' | 'tense' | 'neutral' | 'celebratory' | 'concerned' | 'supportive'
+
+export interface ThemeSummaryHighlight {
+  title: string
+  subreddit: string
+  score: number
+  whyNotable: string
+}
+
+export interface ThemeSummaryKeyTheme {
+  theme: string
+  description: string
+}
+
+interface ThemeSummaryProps {
+  themeId: string
+  narrative: string
+  highlights: ThemeSummaryHighlight[]
+  emotionalTone: EmotionalTone
+  toneDescription: string
+  keyThemes: ThemeSummaryKeyTheme[]
+  intentBreakdown: Record<string, number> | null
+  weekDifferentiator: string | null
+  createdAt: string
+}
+
+export class ThemeSummary {
+  private readonly themeId: string
+  private readonly narrative: string
+  private readonly highlights: ThemeSummaryHighlight[]
+  private readonly emotionalTone: EmotionalTone
+  private readonly toneDescription: string
+  private readonly keyThemes: ThemeSummaryKeyTheme[]
+  private readonly intentBreakdown: Record<string, number> | null
+  private readonly weekDifferentiator: string | null
+  private readonly createdAt: string
+
+  constructor({ themeId, narrative, highlights, emotionalTone, toneDescription, keyThemes, intentBreakdown, weekDifferentiator, createdAt }: ThemeSummaryProps) {
+    this.themeId = themeId
+    this.narrative = narrative
+    this.highlights = highlights
+    this.emotionalTone = emotionalTone
+    this.toneDescription = toneDescription
+    this.keyThemes = keyThemes
+    this.intentBreakdown = intentBreakdown
+    this.weekDifferentiator = weekDifferentiator
+    this.createdAt = createdAt
+  }
+
+  getThemeId(): string {
+    return this.themeId
+  }
+
+  getNarrative(): string {
+    return this.narrative
+  }
+
+  getHighlights(): ThemeSummaryHighlight[] {
+    return this.highlights
+  }
+
+  getEmotionalTone(): EmotionalTone {
+    return this.emotionalTone
+  }
+
+  getToneDescription(): string {
+    return this.toneDescription
+  }
+
+  getKeyThemes(): ThemeSummaryKeyTheme[] {
+    return this.keyThemes
+  }
+
+  getIntentBreakdown(): Record<string, number> | null {
+    return this.intentBreakdown
+  }
+
+  getWeekDifferentiator(): string | null {
+    return this.weekDifferentiator
+  }
+
+  getCreatedAt(): string {
+    return this.createdAt
+  }
+}

--- a/src/modules/audience/domain/repositories/audience.repository.ts
+++ b/src/modules/audience/domain/repositories/audience.repository.ts
@@ -27,6 +27,8 @@ import type { RefreshAudienceThemesParams, RefreshAudienceThemesResult } from ".
 import type { GetAudienceIntentsParams, GetAudienceIntentsResult } from "../use-cases/get-audience-intents.use-case";
 import type { RefreshAudienceIntentsParams, RefreshAudienceIntentsResult } from "../use-cases/refresh-audience-intents.use-case";
 import type { GetIntentPostsParams, GetIntentPostsResult } from "../use-cases/get-intent-posts.use-case";
+import type { GetThemeSummaryParams, GetThemeSummaryResult } from "../use-cases/get-theme-summary.use-case";
+import type { RefreshThemeSummaryParams, RefreshThemeSummaryResult } from "../use-cases/refresh-theme-summary.use-case";
 
 export interface IAudienceRepository {
   listUserAudiences(): Promise<Audience[]>
@@ -60,4 +62,6 @@ export interface IAudienceRepository {
   getAudienceIntents(params: GetAudienceIntentsParams): Promise<GetAudienceIntentsResult>
   refreshAudienceIntents(params: RefreshAudienceIntentsParams): Promise<RefreshAudienceIntentsResult>
   getIntentPosts(params: GetIntentPostsParams): Promise<GetIntentPostsResult>
+  getThemeSummary(params: GetThemeSummaryParams): Promise<GetThemeSummaryResult>
+  refreshThemeSummary(params: RefreshThemeSummaryParams): Promise<RefreshThemeSummaryResult>
 }

--- a/src/modules/audience/domain/use-cases/get-theme-summary.use-case.ts
+++ b/src/modules/audience/domain/use-cases/get-theme-summary.use-case.ts
@@ -1,0 +1,17 @@
+import type { ThemeSummary } from '../entities/ThemeSummary.entity'
+
+export type ThemeSummaryStatus = 'no_summary' | 'ready'
+
+export interface GetThemeSummaryParams {
+  audienceId: string
+  themeId: string
+}
+
+export interface GetThemeSummaryResult {
+  status: ThemeSummaryStatus
+  data: ThemeSummary | null
+}
+
+export interface IGetThemeSummaryUseCase {
+  execute(params: GetThemeSummaryParams): Promise<GetThemeSummaryResult>
+}

--- a/src/modules/audience/domain/use-cases/index.ts
+++ b/src/modules/audience/domain/use-cases/index.ts
@@ -29,3 +29,5 @@ export type { IRefreshAudienceThemesUseCase, RefreshAudienceThemesParams, Refres
 export type { IGetAudienceIntentsUseCase, GetAudienceIntentsParams, GetAudienceIntentsResult, IntentAnalysisStatus } from './get-audience-intents.use-case'
 export type { IRefreshAudienceIntentsUseCase, RefreshAudienceIntentsParams, RefreshAudienceIntentsResult } from './refresh-audience-intents.use-case'
 export type { IGetIntentPostsUseCase, GetIntentPostsParams, GetIntentPostsResult } from './get-intent-posts.use-case'
+export type { IGetThemeSummaryUseCase, GetThemeSummaryParams, GetThemeSummaryResult, ThemeSummaryStatus } from './get-theme-summary.use-case'
+export type { IRefreshThemeSummaryUseCase, RefreshThemeSummaryParams, RefreshThemeSummaryResult } from './refresh-theme-summary.use-case'

--- a/src/modules/audience/domain/use-cases/refresh-theme-summary.use-case.ts
+++ b/src/modules/audience/domain/use-cases/refresh-theme-summary.use-case.ts
@@ -1,0 +1,17 @@
+import type { ThemeAnalysisWindow } from './get-audience-themes.use-case'
+
+export interface RefreshThemeSummaryParams {
+  audienceId: string
+  themeId: string
+  window: ThemeAnalysisWindow
+}
+
+export interface RefreshThemeSummaryResult {
+  status: string
+  themeId: string
+  summaryId?: string
+}
+
+export interface IRefreshThemeSummaryUseCase {
+  execute(params: RefreshThemeSummaryParams): Promise<RefreshThemeSummaryResult>
+}

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -29,6 +29,8 @@ import type { RefreshAudienceThemesParams, RefreshAudienceThemesResult } from '.
 import type { GetAudienceIntentsParams, GetAudienceIntentsResult, IntentAnalysisStatus } from '../../domain/use-cases/get-audience-intents.use-case'
 import type { RefreshAudienceIntentsParams, RefreshAudienceIntentsResult } from '../../domain/use-cases/refresh-audience-intents.use-case'
 import type { GetIntentPostsParams, GetIntentPostsResult } from '../../domain/use-cases/get-intent-posts.use-case'
+import type { GetThemeSummaryParams, GetThemeSummaryResult, ThemeSummaryStatus } from '../../domain/use-cases/get-theme-summary.use-case'
+import type { RefreshThemeSummaryParams, RefreshThemeSummaryResult } from '../../domain/use-cases/refresh-theme-summary.use-case'
 import { Keyword } from '../../domain/entities/Keyword.entity'
 import { Topic } from '../../domain/entities/Topic.entity'
 import { TopicDeepDive } from '../../domain/entities/TopicDeepDive.entity'
@@ -41,6 +43,8 @@ import { TopicGrowthHistory } from '../../domain/entities/TopicGrowthHistory.ent
 import { Theme } from '../../domain/entities/Theme.entity'
 import { IntentCategory } from '../../domain/entities/IntentCategory.entity'
 import { IntentPost } from '../../domain/entities/IntentPost.entity'
+import { ThemeSummary } from '../../domain/entities/ThemeSummary.entity'
+import type { EmotionalTone } from '../../domain/entities/ThemeSummary.entity'
 
 interface AudienceTemplateResponse {
   id: string
@@ -368,6 +372,7 @@ interface ThemeAnalysisApiResponse {
   completed_at?: string
   error_message?: string
   themes?: Array<{
+    id: string
     name: string
     summary: string
     post_count: number
@@ -431,6 +436,26 @@ interface IntentPostsApiResponse {
   total: number
   limit: number
   offset: number
+}
+
+interface ThemeSummaryApiResponse {
+  status: string
+  theme_id?: string
+  narrative?: string
+  highlights?: Array<{ title: string; subreddit: string; score: number; why_notable: string }>
+  emotional_tone?: string
+  tone_description?: string
+  key_themes?: Array<{ theme: string; description: string }>
+  intent_breakdown?: Record<string, number> | null
+  week_differentiator?: string | null
+  created_at?: string
+}
+
+interface RefreshThemeSummaryApiResponse {
+  status: string
+  theme_id: string
+  summary_id?: string
+  message?: string
 }
 
 export class AudienceRepository implements IAudienceRepository {
@@ -975,6 +1000,7 @@ export class AudienceRepository implements IAudienceRepository {
     return {
       status,
       data: response.themes.map((t) => new Theme({
+        id: t.id,
         name: t.name,
         summary: t.summary,
         postCount: t.post_count,
@@ -1079,6 +1105,54 @@ export class AudienceRepository implements IAudienceRepository {
       limit: response.limit,
       offset: response.offset,
       hasMore: offset + posts.length < response.total,
+    }
+  }
+
+  async getThemeSummary(params: GetThemeSummaryParams): Promise<GetThemeSummaryResult> {
+    const response = await this.httpClient.get<ThemeSummaryApiResponse>(
+      `audiences/${params.audienceId}/themes/${params.themeId}/summary`
+    )
+
+    const status = response.status as ThemeSummaryStatus
+
+    if (status !== 'ready' || !response.narrative) {
+      return { status, data: null }
+    }
+
+    return {
+      status,
+      data: new ThemeSummary({
+        themeId: response.theme_id ?? params.themeId,
+        narrative: response.narrative,
+        highlights: (response.highlights ?? []).map((h) => ({
+          title: h.title,
+          subreddit: h.subreddit,
+          score: h.score,
+          whyNotable: h.why_notable,
+        })),
+        emotionalTone: (response.emotional_tone ?? 'neutral') as EmotionalTone,
+        toneDescription: response.tone_description ?? '',
+        keyThemes: (response.key_themes ?? []).map((k) => ({
+          theme: k.theme,
+          description: k.description,
+        })),
+        intentBreakdown: response.intent_breakdown ?? null,
+        weekDifferentiator: response.week_differentiator ?? null,
+        createdAt: response.created_at ?? '',
+      }),
+    }
+  }
+
+  async refreshThemeSummary(params: RefreshThemeSummaryParams): Promise<RefreshThemeSummaryResult> {
+    const response = await this.httpClient.post<RefreshThemeSummaryApiResponse>(
+      `audiences/${params.audienceId}/themes/${params.themeId}/summary/refresh?window=${params.window}`,
+      {}
+    )
+
+    return {
+      status: response.status,
+      themeId: response.theme_id,
+      summaryId: response.summary_id,
     }
   }
 }

--- a/src/modules/notifications/application/hooks/useNotificationSSE.ts
+++ b/src/modules/notifications/application/hooks/useNotificationSSE.ts
@@ -6,6 +6,7 @@ import { TOPIC_DEEP_DIVE_QUERY_KEY } from '@/modules/audience/application/hooks/
 import { TOPIC_BEHAVIORAL_PATTERNS_QUERY_KEY } from '@/modules/audience/application/hooks/useGetTopicBehavioralPatterns'
 import { TOPIC_SENTIMENT_QUERY_KEY } from '@/modules/audience/application/hooks/useGetTopicSentiment'
 import { AUDIENCE_INTENTS_QUERY_KEY } from '@/modules/audience/application/hooks/useGetAudienceIntents'
+import { THEME_SUMMARY_QUERY_KEY } from '@/modules/audience/application/hooks/useGetThemeSummary'
 import { NotificationSSEService } from '../../infra/services/sse.service'
 import type { Notification } from '../../domain/entities'
 import { useNotificationStore } from '../store/notification.store'
@@ -25,6 +26,14 @@ function invalidateAnalysisQueries(
   if (type === 'intent_classification_complete' || type === 'intent_classification_failed') {
     queryClient.invalidateQueries({ queryKey: AUDIENCE_INTENTS_QUERY_KEY(audienceId, 'week') })
     queryClient.invalidateQueries({ queryKey: AUDIENCE_INTENTS_QUERY_KEY(audienceId, 'month') })
+    return
+  }
+
+  const themeId = metadata.theme_id
+  if (type === 'theme_summary_complete' || type === 'theme_summary_failed') {
+    if (themeId) {
+      queryClient.invalidateQueries({ queryKey: THEME_SUMMARY_QUERY_KEY(audienceId, themeId) })
+    }
     return
   }
 

--- a/src/modules/notifications/domain/entities/notification.entity.ts
+++ b/src/modules/notifications/domain/entities/notification.entity.ts
@@ -11,11 +11,16 @@ export type NotificationType =
   | 'topic_analysis_failed'
   | 'sentiment_complete'
   | 'sentiment_failed'
+  | 'intent_classification_complete'
+  | 'intent_classification_failed'
+  | 'theme_summary_complete'
+  | 'theme_summary_failed'
 
 export interface NotificationMetadata {
   audience_id?: string
   topic_id?: string
   topic_name?: string
+  theme_id?: string
   analysis_id?: string
   [key: string]: unknown
 }

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -3,8 +3,8 @@ import { TYPES } from './types'
 import { KyHttpClient, type HttpClient } from '../http'
 import { AudienceRepository } from '@/modules/audience/infra/repositories'
 import type { IAudienceRepository } from '@/modules/audience/domain/repositories'
-import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase, MarkCommunityNotRelevantUseCase, GetAudienceTopicsUseCase, GetTopicDeepDiveUseCase, TriggerTopicDeepDiveUseCase, GetTopicBehavioralPatternsUseCase, TriggerTopicBehavioralPatternsUseCase, GetTopicSentimentUseCase, TriggerTopicSentimentUseCase, AskTopicUseCase, StartTopicChatUseCase, SendTopicChatMessageUseCase, ListTopicChatConversationsUseCase, GetTopicChatMessagesUseCase, ArchiveTopicChatUseCase, GetTopicGrowthHistoryUseCase, GetAudienceThemesUseCase, RefreshAudienceThemesUseCase, GetAudienceIntentsUseCase, RefreshAudienceIntentsUseCase, GetIntentPostsUseCase } from '@/modules/audience/application/use-cases'
-import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase, IMarkCommunityNotRelevantUseCase, IGetAudienceTopicsUseCase, IGetTopicDeepDiveUseCase, ITriggerTopicDeepDiveUseCase, IGetTopicBehavioralPatternsUseCase, ITriggerTopicBehavioralPatternsUseCase, IGetTopicSentimentUseCase, ITriggerTopicSentimentUseCase, IAskTopicUseCase, IStartTopicChatUseCase, ISendTopicChatMessageUseCase, IListTopicChatConversationsUseCase, IGetTopicChatMessagesUseCase, IArchiveTopicChatUseCase, IGetTopicGrowthHistoryUseCase, IGetAudienceThemesUseCase, IRefreshAudienceThemesUseCase, IGetAudienceIntentsUseCase, IRefreshAudienceIntentsUseCase, IGetIntentPostsUseCase } from '@/modules/audience/domain/use-cases'
+import { ListUserAudiencesUseCase, FetchDefaultAudiencesUseCase, GetAudienceTemplateByIdUseCase, CreateAudienceUseCase, GetAudienceByIdUseCase, UpdateAudienceUseCase, AddCommunityToAudienceUseCase, RemoveCommunityFromAudienceUseCase, GetAudienceSuggestionsUseCase, DeleteAudienceUseCase, GetAudienceKeywordsUseCase, MarkCommunityNotRelevantUseCase, GetAudienceTopicsUseCase, GetTopicDeepDiveUseCase, TriggerTopicDeepDiveUseCase, GetTopicBehavioralPatternsUseCase, TriggerTopicBehavioralPatternsUseCase, GetTopicSentimentUseCase, TriggerTopicSentimentUseCase, AskTopicUseCase, StartTopicChatUseCase, SendTopicChatMessageUseCase, ListTopicChatConversationsUseCase, GetTopicChatMessagesUseCase, ArchiveTopicChatUseCase, GetTopicGrowthHistoryUseCase, GetAudienceThemesUseCase, RefreshAudienceThemesUseCase, GetAudienceIntentsUseCase, RefreshAudienceIntentsUseCase, GetIntentPostsUseCase, GetThemeSummaryUseCase, RefreshThemeSummaryUseCase } from '@/modules/audience/application/use-cases'
+import type { IListUserAudiencesUseCase, IFetchDefaultAudiencesUseCase, IGetAudienceTemplateByIdUseCase, ICreateAudienceUseCase, IGetAudienceByIdUseCase, IUpdateAudienceUseCase, IAddCommunityToAudienceUseCase, IRemoveCommunityFromAudienceUseCase, IGetAudienceSuggestionsUseCase, IDeleteAudienceUseCase, IGetAudienceKeywordsUseCase, IMarkCommunityNotRelevantUseCase, IGetAudienceTopicsUseCase, IGetTopicDeepDiveUseCase, ITriggerTopicDeepDiveUseCase, IGetTopicBehavioralPatternsUseCase, ITriggerTopicBehavioralPatternsUseCase, IGetTopicSentimentUseCase, ITriggerTopicSentimentUseCase, IAskTopicUseCase, IStartTopicChatUseCase, ISendTopicChatMessageUseCase, IListTopicChatConversationsUseCase, IGetTopicChatMessagesUseCase, IArchiveTopicChatUseCase, IGetTopicGrowthHistoryUseCase, IGetAudienceThemesUseCase, IRefreshAudienceThemesUseCase, IGetAudienceIntentsUseCase, IRefreshAudienceIntentsUseCase, IGetIntentPostsUseCase, IGetThemeSummaryUseCase, IRefreshThemeSummaryUseCase } from '@/modules/audience/domain/use-cases'
 import { CommunityRepository } from '@/modules/community/infra/repositories'
 import type { ICommunityRepository } from '@/modules/community/domain/repositories'
 import { BrowseCommunitiesUseCase } from '@/modules/community/application/use-cases'
@@ -180,6 +180,16 @@ container.bind<IRefreshAudienceIntentsUseCase>(TYPES.RefreshAudienceIntentsUseCa
 container.bind<IGetIntentPostsUseCase>(TYPES.GetIntentPostsUseCase).toDynamicValue(() => {
   const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
   return new GetIntentPostsUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<IGetThemeSummaryUseCase>(TYPES.GetThemeSummaryUseCase).toDynamicValue(() => {
+  const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
+  return new GetThemeSummaryUseCase(audienceRepository)
+}).inSingletonScope()
+
+container.bind<IRefreshThemeSummaryUseCase>(TYPES.RefreshThemeSummaryUseCase).toDynamicValue(() => {
+  const audienceRepository = container.get<IAudienceRepository>(TYPES.AudienceRepository)
+  return new RefreshThemeSummaryUseCase(audienceRepository)
 }).inSingletonScope()
 
 container.bind<ICommunityRepository>(TYPES.CommunityRepository).toDynamicValue(() => {

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -32,6 +32,8 @@ export const TYPES = {
   GetAudienceIntentsUseCase: Symbol.for('GetAudienceIntentsUseCase'),
   RefreshAudienceIntentsUseCase: Symbol.for('RefreshAudienceIntentsUseCase'),
   GetIntentPostsUseCase: Symbol.for('GetIntentPostsUseCase'),
+  GetThemeSummaryUseCase: Symbol.for('GetThemeSummaryUseCase'),
+  RefreshThemeSummaryUseCase: Symbol.for('RefreshThemeSummaryUseCase'),
   CommunityRepository: Symbol.for('CommunityRepository'),
   BrowseCommunitiesUseCase: Symbol.for('BrowseCommunitiesUseCase'),
   AuthRepository: Symbol.for('AuthRepository'),


### PR DESCRIPTION
## Summary
- Add `ThemeSummaryCard` component with collapsible sections displaying narrative, emotional tone, key themes, highlights, intent breakdown, and week differentiator
- Wire up `getThemeSummary` / `refreshThemeSummary` use cases through all clean architecture layers (entity, domain use case, repository, application use case, hooks, DI container)
- Handle `theme_summary_complete` / `theme_summary_failed` SSE notifications with automatic React Query invalidation
- Add i18n translations for en and pt-BR

## Test plan
- [ ] Navigate to Audience Detail → Themes tab → click a theme
- [ ] Verify "Narrative Summaries" section appears with "Generate Summary" button
- [ ] Click "Generate Summary" and confirm loading state
- [ ] Verify SSE notification triggers auto-refresh of summary data
- [ ] Verify collapsible sections (Narrative, Key Themes, Highlights) work correctly
- [ ] Verify emotional tone badge displays with correct color
- [ ] Verify Week Differentiator and Intent Breakdown render when data is present
- [ ] Verify dark mode rendering
- [ ] Verify pt-BR and en translations