### PR TITLE
feat: integrate smart topic alerts system

### DIFF
--- a/src/components/audiences/detail/AlertCard.tsx
+++ b/src/components/audiences/detail/AlertCard.tsx
@@ -1,0 +1,140 @@
+import { useTranslation } from 'react-i18next'
+import { Clock, X, Zap, Flame, Sparkles, AlertTriangle, Info, AlertOctagon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { TopicAlert } from '@/modules/topic-alerts'
+
+export interface AlertCardProps {
+  alert: TopicAlert
+  onDismiss?: (id: string) => void
+  isDismissing?: boolean
+}
+
+const typeIcons: Record<string, React.ElementType> = {
+  new_topic: Zap,
+  growth_spike: Flame,
+  new_theme: Sparkles,
+}
+
+const severityConfig: Record<string, { icon: React.ElementType; bgClass: string; textClass: string; badgeBg: string; badgeText: string }> = {
+  info: {
+    icon: Info,
+    bgClass: 'bg-blue-50 dark:bg-blue-900/20',
+    textClass: 'text-blue-600 dark:text-blue-400',
+    badgeBg: 'bg-blue-100 dark:bg-blue-900/40',
+    badgeText: 'text-blue-700 dark:text-blue-300',
+  },
+  warning: {
+    icon: AlertTriangle,
+    bgClass: 'bg-orange-50 dark:bg-orange-900/20',
+    textClass: 'text-orange-600 dark:text-orange-400',
+    badgeBg: 'bg-orange-100 dark:bg-orange-900/40',
+    badgeText: 'text-orange-700 dark:text-orange-300',
+  },
+  critical: {
+    icon: AlertOctagon,
+    bgClass: 'bg-red-50 dark:bg-red-900/20',
+    textClass: 'text-red-600 dark:text-red-400',
+    badgeBg: 'bg-red-100 dark:bg-red-900/40',
+    badgeText: 'text-red-700 dark:text-red-300',
+  },
+}
+
+function useTimeAgo(dateString: string) {
+  const { t } = useTranslation('notifications')
+
+  const now = new Date()
+  const date = new Date(dateString)
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMs / 3600000)
+  const diffDays = Math.floor(diffMs / 86400000)
+
+  if (diffMins < 1) return t('time.justNow')
+  if (diffMins < 60) return t('time.minutesAgo', { count: diffMins })
+  if (diffHours < 24) return t('time.hoursAgo', { count: diffHours })
+  return t('time.daysAgo', { count: diffDays })
+}
+
+export function AlertCard({ alert, onDismiss, isDismissing }: Readonly<AlertCardProps>) {
+  const { t } = useTranslation('audiences')
+  const timeAgo = useTimeAgo(alert.getCreatedAt())
+  const isDismissed = alert.getIsDismissed()
+
+  const severity = severityConfig[alert.getSeverity()] ?? severityConfig.info
+  const TypeIcon = typeIcons[alert.getAlertType()] ?? Zap
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-4 p-4 rounded-2xl border transition-colors',
+        isDismissed
+          ? 'bg-gray-50/50 dark:bg-zinc-900/50 border-gray-100 dark:border-zinc-800 opacity-60'
+          : 'bg-white dark:bg-zinc-900 border-gray-200 dark:border-zinc-700'
+      )}
+    >
+      <div
+        className={cn(
+          'w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0',
+          severity.bgClass
+        )}
+      >
+        <TypeIcon className={cn('w-5 h-5', severity.textClass)} />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <h4
+            className={cn(
+              'text-sm font-semibold truncate',
+              isDismissed
+                ? 'text-gray-600 dark:text-zinc-400'
+                : 'text-gray-900 dark:text-white'
+            )}
+          >
+            {alert.getTitle()}
+          </h4>
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium flex-shrink-0',
+              severity.badgeBg,
+              severity.badgeText
+            )}
+          >
+            {t(`alerts.severity.${alert.getSeverity()}`)}
+          </span>
+        </div>
+
+        <p className="text-sm text-gray-500 dark:text-zinc-400 mt-0.5 line-clamp-2">
+          {alert.getMessage()}
+        </p>
+
+        <div className="flex items-center gap-3 mt-2">
+          <span
+            className={cn(
+              'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium',
+              'bg-gray-100 dark:bg-zinc-800 text-gray-600 dark:text-zinc-400'
+            )}
+          >
+            {t(`alerts.type.${alert.getAlertType()}`)}
+          </span>
+
+          {!isDismissed && onDismiss && (
+            <button
+              onClick={() => onDismiss(alert.getId())}
+              disabled={isDismissing}
+              className="flex items-center gap-1.5 text-xs font-medium text-gray-400 dark:text-zinc-500 hover:text-gray-600 dark:hover:text-zinc-300 transition-colors cursor-pointer disabled:opacity-50"
+            >
+              <X className="w-3.5 h-3.5" />
+              {t('alerts.dismiss')}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1.5 text-xs text-gray-400 dark:text-zinc-500 flex-shrink-0 mt-0.5">
+        <Clock className="w-3.5 h-3.5" />
+        {timeAgo}
+      </div>
+    </div>
+  )
+}

--- a/src/components/audiences/detail/AlertsTabContent.tsx
+++ b/src/components/audiences/detail/AlertsTabContent.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Bell } from 'lucide-react'
+import { useListAlerts, useAlertsSummary, useDismissAlert } from '@/modules/topic-alerts'
+import type { AlertType, AlertSeverity } from '@/modules/topic-alerts'
+import { toast } from '@/hooks/useToast'
+import { AlertCard } from './AlertCard'
+
+export interface AlertsTabContentProps {
+  audienceId: string
+}
+
+const ALERT_TYPES: AlertType[] = ['new_topic', 'growth_spike', 'new_theme']
+const SEVERITIES: AlertSeverity[] = ['info', 'warning', 'critical']
+
+export function AlertsTabContent({ audienceId }: Readonly<AlertsTabContentProps>) {
+  const { t } = useTranslation('audiences')
+
+  const [selectedType, setSelectedType] = useState<AlertType | undefined>(undefined)
+  const [selectedSeverity, setSelectedSeverity] = useState<AlertSeverity | undefined>(undefined)
+  const [showDismissed, setShowDismissed] = useState(false)
+
+  const { data: alertsData, isLoading } = useListAlerts({
+    audienceId,
+    alert_type: selectedType,
+    severity: selectedSeverity,
+    dismissed: showDismissed ? undefined : false,
+    limit: 50,
+    offset: 0,
+  })
+
+  const { data: summary } = useAlertsSummary(audienceId)
+  const dismissMutation = useDismissAlert(audienceId)
+
+  const handleDismiss = (alertId: string) => {
+    dismissMutation.mutate(alertId, {
+      onSuccess: () => {
+        toast({
+          title: t('alerts.dismissed'),
+          variant: 'success',
+        })
+      },
+      onError: () => {
+        toast({
+          title: t('alerts.dismissError'),
+          variant: 'destructive',
+        })
+      },
+    })
+  }
+
+  const alerts = alertsData?.alerts ?? []
+  const totalActive = summary?.total ?? 0
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          value={selectedType ?? ''}
+          onChange={(e) => setSelectedType(e.target.value ? e.target.value as AlertType : undefined)}
+          className="px-3 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-gray-700 dark:text-zinc-300 focus:outline-none focus:ring-2 focus:ring-lime/50"
+        >
+          <option value="">{t('alerts.filters.allTypes')}</option>
+          {ALERT_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {t(`alerts.type.${type}`)}
+              {summary?.by_type[type] ? ` (${summary.by_type[type]})` : ''}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={selectedSeverity ?? ''}
+          onChange={(e) => setSelectedSeverity(e.target.value ? e.target.value as AlertSeverity : undefined)}
+          className="px-3 py-1.5 text-sm rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-gray-700 dark:text-zinc-300 focus:outline-none focus:ring-2 focus:ring-lime/50"
+        >
+          <option value="">{t('alerts.filters.allSeverities')}</option>
+          {SEVERITIES.map((sev) => (
+            <option key={sev} value={sev}>
+              {t(`alerts.severity.${sev}`)}
+              {summary?.by_severity[sev] ? ` (${summary.by_severity[sev]})` : ''}
+            </option>
+          ))}
+        </select>
+
+        <button
+          onClick={() => setShowDismissed(!showDismissed)}
+          className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+            showDismissed
+              ? 'border-lime bg-lime/10 text-lime-700 dark:text-lime-300'
+              : 'border-gray-200 dark:border-zinc-700 text-gray-600 dark:text-zinc-400 hover:border-gray-300 dark:hover:border-zinc-600'
+          }`}
+        >
+          {showDismissed ? t('alerts.filters.showDismissed') : t('alerts.filters.hideDismissed')}
+        </button>
+
+        {totalActive > 0 && (
+          <span className="ml-auto text-sm text-gray-500 dark:text-zinc-400">
+            {totalActive} {t('alerts.title').toLowerCase()}
+          </span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="w-8 h-8 border-4 border-lime border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : alerts.length === 0 ? (
+        <div className="bg-white dark:bg-zinc-900 rounded-2xl p-8 text-center border border-gray-100 dark:border-zinc-800">
+          <Bell className="w-8 h-8 text-gray-300 dark:text-zinc-600 mx-auto mb-3" />
+          <p className="text-sm text-gray-500 dark:text-zinc-400">
+            {selectedType || selectedSeverity ? t('alerts.emptyFiltered') : t('alerts.empty')}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {alerts.map((alert) => (
+            <AlertCard
+              key={alert.getId()}
+              alert={alert}
+              onDismiss={handleDismiss}
+              isDismissing={dismissMutation.isPending}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -1,6 +1,6 @@
 import { useState, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Sparkles } from 'lucide-react'
+import { Sparkles, Bell } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import {
   TopicsTable,
@@ -9,6 +9,7 @@ import {
   ThemeDetailPanel,
   SearchTabContent,
   SubredditsTabContent,
+  AlertsTabContent,
 } from '@/components/audiences/detail'
 import type { TopicDetail, ThemeDetail, ThemeGridItem } from '@/components/audiences/detail'
 import type { SimilarCommunity } from './SimilarCommunitiesGrid'
@@ -19,6 +20,7 @@ import type { Topic } from '@/modules/audience/domain/entities/Topic.entity'
 import type { Theme } from '@/modules/audience/domain/entities/Theme.entity'
 import { useGetAudienceThemes, useRefreshAudienceThemes, useGetAudienceIntents, useRefreshAudienceIntents } from '@/modules/audience/application/hooks'
 import type { IntentCategory } from '@/modules/audience/domain/entities/IntentCategory.entity'
+import { useAlertsSummary } from '@/modules/topic-alerts'
 
 export interface AudienceDetailTabsProps {
   contentRef: RefObject<HTMLDivElement | null>
@@ -157,6 +159,9 @@ export function AudienceDetailTabs({
   const [selectedTheme, setSelectedTheme] = useState<ThemeDetail | null>(null)
   const [selectedIntentCategory, setSelectedIntentCategory] = useState<string | null>(null)
 
+  const { data: alertsSummary } = useAlertsSummary(audienceId)
+  const alertsCount = alertsSummary?.total ?? 0
+
   const isThemesTab = activeTab === 'themes'
 
   const weekQuery = useGetAudienceThemes(audienceId, 'week', isThemesTab)
@@ -244,6 +249,10 @@ export function AudienceDetailTabs({
         <TabsTrigger value="themes">
           <Sparkles className="w-4 h-4" />
           {t('tabs.themes')}
+        </TabsTrigger>
+        <TabsTrigger value="alerts" count={alertsCount > 0 ? alertsCount : undefined}>
+          <Bell className="w-4 h-4" />
+          {t('tabs.alerts')}
         </TabsTrigger>
         <TabsTrigger value="ask">
           <Sparkles className="w-4 h-4" />
@@ -348,6 +357,10 @@ export function AudienceDetailTabs({
             />
           </div>
         </div>
+      </TabsContent>
+
+      <TabsContent value="alerts" className="mt-6">
+        <AlertsTabContent audienceId={audienceId} />
       </TabsContent>
 
       <TabsContent value="ask" className="mt-6">

--- a/src/components/audiences/detail/index.ts
+++ b/src/components/audiences/detail/index.ts
@@ -51,3 +51,9 @@ export type { SubredditsTabContentProps } from './SubredditsTabContent'
 
 export { AudienceDetailTabs } from './AudienceDetailTabs'
 export type { AudienceDetailTabsProps } from './AudienceDetailTabs'
+
+export { AlertCard } from './AlertCard'
+export type { AlertCardProps } from './AlertCard'
+
+export { AlertsTabContent } from './AlertsTabContent'
+export type { AlertsTabContentProps } from './AlertsTabContent'

--- a/src/components/notifications/NotificationIcon.tsx
+++ b/src/components/notifications/NotificationIcon.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, AlertTriangle, Bell, Brain, Search, TrendingUp, Tag, MessageSquare, Heart } from 'lucide-react'
+import { CheckCircle, AlertTriangle, Bell, Brain, Search, TrendingUp, Tag, MessageSquare, Heart, Zap, Flame, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { NotificationType } from '@/modules/notifications'
 
@@ -15,6 +15,9 @@ const iconConfig: Record<string, { icon: React.ElementType; bgClass: string; ico
   topic_analysis_failed: { icon: MessageSquare, bgClass: 'bg-red-100 dark:bg-red-900/30', iconClass: 'text-red-600 dark:text-red-400' },
   sentiment_complete: { icon: Heart, bgClass: 'bg-green-100 dark:bg-green-900/30', iconClass: 'text-green-600 dark:text-green-400' },
   sentiment_failed: { icon: Heart, bgClass: 'bg-red-100 dark:bg-red-900/30', iconClass: 'text-red-600 dark:text-red-400' },
+  topic_alert_new_topic: { icon: Zap, bgClass: 'bg-blue-100 dark:bg-blue-900/30', iconClass: 'text-blue-600 dark:text-blue-400' },
+  topic_alert_growth_spike: { icon: Flame, bgClass: 'bg-orange-100 dark:bg-orange-900/30', iconClass: 'text-orange-600 dark:text-orange-400' },
+  topic_alert_new_theme: { icon: Sparkles, bgClass: 'bg-purple-100 dark:bg-purple-900/30', iconClass: 'text-purple-600 dark:text-purple-400' },
 }
 
 const defaultConfig = { icon: Bell, bgClass: 'bg-gray-100 dark:bg-zinc-800', iconClass: 'text-gray-500 dark:text-zinc-400' }

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -286,11 +286,36 @@
     "subreddits": "Subreddits",
     "topics": "Topics",
     "themes": "Themes",
+    "alerts": "Alerts",
     "ask": "Ask",
     "products": "Products",
     "askAI": "Ask AI",
     "askComingSoon": "Coming soon - Ask questions about this audience",
     "productsComingSoon": "Coming soon - Discover products relevant to this audience"
+  },
+  "alerts": {
+    "title": "Alerts",
+    "empty": "No alerts for this audience yet.",
+    "emptyFiltered": "No alerts match the selected filters.",
+    "dismiss": "Dismiss",
+    "dismissed": "Alert dismissed",
+    "dismissError": "Failed to dismiss alert",
+    "filters": {
+      "allTypes": "All types",
+      "allSeverities": "All severities",
+      "showDismissed": "Show dismissed",
+      "hideDismissed": "Active only"
+    },
+    "type": {
+      "new_topic": "New Topic",
+      "growth_spike": "Growth Spike",
+      "new_theme": "New Theme"
+    },
+    "severity": {
+      "info": "Info",
+      "warning": "Warning",
+      "critical": "Critical"
+    }
   },
   "search": {
     "keywordSearch": "Keyword Search",

--- a/src/locales/en/notifications.json
+++ b/src/locales/en/notifications.json
@@ -33,7 +33,10 @@
     "keyword_analysis_complete": "Keywords Ready",
     "keyword_analysis_failed": "Keywords Failed",
     "topic_analysis_complete": "Topics Ready",
-    "topic_analysis_failed": "Topics Failed"
+    "topic_analysis_failed": "Topics Failed",
+    "topic_alert_new_topic": "New Topic Detected",
+    "topic_alert_growth_spike": "Growth Spike Detected",
+    "topic_alert_new_theme": "New Theme Detected"
   },
   "time": {
     "justNow": "Just now",

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -286,11 +286,36 @@
     "subreddits": "Subreddits",
     "topics": "Tópicos",
     "themes": "Temas",
+    "alerts": "Alertas",
     "ask": "Perguntar",
     "products": "Produtos",
     "askAI": "Perguntar à IA",
     "askComingSoon": "Em breve - Faça perguntas sobre esta audiência",
     "productsComingSoon": "Em breve - Descubra produtos relevantes para esta audiência"
+  },
+  "alerts": {
+    "title": "Alertas",
+    "empty": "Nenhum alerta para esta audiência ainda.",
+    "emptyFiltered": "Nenhum alerta corresponde aos filtros selecionados.",
+    "dismiss": "Descartar",
+    "dismissed": "Alerta descartado",
+    "dismissError": "Falha ao descartar alerta",
+    "filters": {
+      "allTypes": "Todos os tipos",
+      "allSeverities": "Todas as severidades",
+      "showDismissed": "Mostrar descartados",
+      "hideDismissed": "Apenas ativos"
+    },
+    "type": {
+      "new_topic": "Novo Tópico",
+      "growth_spike": "Pico de Crescimento",
+      "new_theme": "Novo Tema"
+    },
+    "severity": {
+      "info": "Info",
+      "warning": "Alerta",
+      "critical": "Crítico"
+    }
   },
   "search": {
     "keywordSearch": "Busca por Palavra-chave",

--- a/src/locales/pt-BR/notifications.json
+++ b/src/locales/pt-BR/notifications.json
@@ -33,7 +33,10 @@
     "keyword_analysis_complete": "Keywords Prontas",
     "keyword_analysis_failed": "Keywords Falharam",
     "topic_analysis_complete": "Topicos Prontos",
-    "topic_analysis_failed": "Topicos Falharam"
+    "topic_analysis_failed": "Topicos Falharam",
+    "topic_alert_new_topic": "Novo Topico Detectado",
+    "topic_alert_growth_spike": "Pico de Crescimento Detectado",
+    "topic_alert_new_theme": "Novo Tema Detectado"
   },
   "time": {
     "justNow": "Agora mesmo",

--- a/src/modules/notifications/application/hooks/useNotificationSSE.ts
+++ b/src/modules/notifications/application/hooks/useNotificationSSE.ts
@@ -8,6 +8,7 @@ import { TOPIC_SENTIMENT_QUERY_KEY } from '@/modules/audience/application/hooks/
 import { AUDIENCE_INTENTS_QUERY_KEY } from '@/modules/audience/application/hooks/useGetAudienceIntents'
 import { THEME_SUMMARY_QUERY_KEY } from '@/modules/audience/application/hooks/useGetThemeSummary'
 import { THEME_PANEL_QUERY_KEY } from '@/modules/audience/application/hooks/useGetThemePanel'
+import { ALERTS_QUERY_KEY, ALERTS_SUMMARY_QUERY_KEY } from '@/modules/topic-alerts'
 import { NotificationSSEService } from '../../infra/services/sse.service'
 import type { Notification } from '../../domain/entities'
 import { useNotificationStore } from '../store/notification.store'
@@ -23,6 +24,12 @@ function invalidateAnalysisQueries(
   const type = notification.getType()
 
   if (!audienceId) return
+
+  if (type === 'topic_alert_new_topic' || type === 'topic_alert_growth_spike' || type === 'topic_alert_new_theme') {
+    queryClient.invalidateQueries({ queryKey: ALERTS_QUERY_KEY(audienceId) })
+    queryClient.invalidateQueries({ queryKey: ALERTS_SUMMARY_QUERY_KEY(audienceId) })
+    return
+  }
 
   if (type === 'intent_classification_complete' || type === 'intent_classification_failed') {
     queryClient.invalidateQueries({ queryKey: AUDIENCE_INTENTS_QUERY_KEY(audienceId, 'week') })
@@ -89,10 +96,11 @@ export function useNotificationSSE() {
         queryClient.invalidateQueries({ queryKey: UNREAD_COUNT_QUERY_KEY })
         invalidateAnalysisQueries(queryClient, notification)
 
+        const isAlert = notification.getType().startsWith('topic_alert_')
         toast({
           title: notification.getTitle(),
           description: notification.getMessage(),
-          variant: notification.isSuccess() ? 'success' : 'destructive',
+          variant: isAlert || notification.isSuccess() ? 'success' : 'destructive',
         })
       },
       onOpen: () => {

--- a/src/modules/notifications/domain/entities/notification.entity.ts
+++ b/src/modules/notifications/domain/entities/notification.entity.ts
@@ -17,6 +17,9 @@ export type NotificationType =
   | 'theme_summary_failed'
   | 'theme_panel_complete'
   | 'theme_panel_failed'
+  | 'topic_alert_new_topic'
+  | 'topic_alert_growth_spike'
+  | 'topic_alert_new_theme'
 
 export interface NotificationMetadata {
   audience_id?: string
@@ -24,6 +27,9 @@ export interface NotificationMetadata {
   topic_name?: string
   theme_id?: string
   analysis_id?: string
+  alert_id?: string
+  severity?: string
+  alert_type?: string
   [key: string]: unknown
 }
 

--- a/src/modules/shared/infra/container/container.ts
+++ b/src/modules/shared/infra/container/container.ts
@@ -17,6 +17,10 @@ import { NotificationRepository } from '@/modules/notifications/infra/repositori
 import type { INotificationRepository } from '@/modules/notifications/domain/repositories'
 import { ListNotificationsUseCase, GetUnreadCountUseCase, MarkNotificationReadUseCase, MarkAllReadUseCase } from '@/modules/notifications/application/use-cases'
 import type { IListNotificationsUseCase, IGetUnreadCountUseCase, IMarkNotificationReadUseCase, IMarkAllReadUseCase } from '@/modules/notifications/domain/use-cases'
+import { TopicAlertRepository } from '@/modules/topic-alerts/infra/repositories'
+import type { ITopicAlertRepository } from '@/modules/topic-alerts/domain/repositories'
+import { ListAlertsUseCase, GetAlertsSummaryUseCase, DismissAlertUseCase } from '@/modules/topic-alerts/application/use-cases'
+import type { IListAlertsUseCase, IGetAlertsSummaryUseCase, IDismissAlertUseCase } from '@/modules/topic-alerts/domain/use-cases'
 
 const container = new Container()
 
@@ -270,6 +274,26 @@ container.bind<IMarkNotificationReadUseCase>(TYPES.MarkNotificationReadUseCase).
 container.bind<IMarkAllReadUseCase>(TYPES.MarkAllReadUseCase).toDynamicValue(() => {
   const notificationRepository = container.get<INotificationRepository>(TYPES.NotificationRepository)
   return new MarkAllReadUseCase(notificationRepository)
+}).inSingletonScope()
+
+container.bind<ITopicAlertRepository>(TYPES.TopicAlertRepository).toDynamicValue(() => {
+  const httpClient = container.get<HttpClient>(TYPES.HttpClient)
+  return new TopicAlertRepository(httpClient)
+}).inSingletonScope()
+
+container.bind<IListAlertsUseCase>(TYPES.ListAlertsUseCase).toDynamicValue(() => {
+  const topicAlertRepository = container.get<ITopicAlertRepository>(TYPES.TopicAlertRepository)
+  return new ListAlertsUseCase(topicAlertRepository)
+}).inSingletonScope()
+
+container.bind<IGetAlertsSummaryUseCase>(TYPES.GetAlertsSummaryUseCase).toDynamicValue(() => {
+  const topicAlertRepository = container.get<ITopicAlertRepository>(TYPES.TopicAlertRepository)
+  return new GetAlertsSummaryUseCase(topicAlertRepository)
+}).inSingletonScope()
+
+container.bind<IDismissAlertUseCase>(TYPES.DismissAlertUseCase).toDynamicValue(() => {
+  const topicAlertRepository = container.get<ITopicAlertRepository>(TYPES.TopicAlertRepository)
+  return new DismissAlertUseCase(topicAlertRepository)
 }).inSingletonScope()
 
 export { container }

--- a/src/modules/shared/infra/container/types.ts
+++ b/src/modules/shared/infra/container/types.ts
@@ -50,4 +50,8 @@ export const TYPES = {
   GetUnreadCountUseCase: Symbol.for('GetUnreadCountUseCase'),
   MarkNotificationReadUseCase: Symbol.for('MarkNotificationReadUseCase'),
   MarkAllReadUseCase: Symbol.for('MarkAllReadUseCase'),
+  TopicAlertRepository: Symbol.for('TopicAlertRepository'),
+  ListAlertsUseCase: Symbol.for('ListAlertsUseCase'),
+  GetAlertsSummaryUseCase: Symbol.for('GetAlertsSummaryUseCase'),
+  DismissAlertUseCase: Symbol.for('DismissAlertUseCase'),
 } as const

--- a/src/modules/topic-alerts/application/hooks/useTopicAlerts.ts
+++ b/src/modules/topic-alerts/application/hooks/useTopicAlerts.ts
@@ -1,0 +1,39 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { container, TYPES } from '@/modules/shared'
+import type { IListAlertsUseCase, IGetAlertsSummaryUseCase, IDismissAlertUseCase } from '../../domain/use-cases'
+import type { ListAlertsParams } from '../../domain/repositories'
+
+const listAlertsUseCase = container.get<IListAlertsUseCase>(TYPES.ListAlertsUseCase)
+const getAlertsSummaryUseCase = container.get<IGetAlertsSummaryUseCase>(TYPES.GetAlertsSummaryUseCase)
+const dismissAlertUseCase = container.get<IDismissAlertUseCase>(TYPES.DismissAlertUseCase)
+
+export const ALERTS_QUERY_KEY = (audienceId: string) => ['topic-alerts', audienceId] as const
+export const ALERTS_SUMMARY_QUERY_KEY = (audienceId: string) => ['topic-alerts', audienceId, 'summary'] as const
+
+export function useListAlerts(params: ListAlertsParams) {
+  return useQuery({
+    queryKey: [...ALERTS_QUERY_KEY(params.audienceId), params],
+    queryFn: () => listAlertsUseCase.execute(params),
+    enabled: !!params.audienceId,
+  })
+}
+
+export function useAlertsSummary(audienceId: string) {
+  return useQuery({
+    queryKey: [...ALERTS_SUMMARY_QUERY_KEY(audienceId)],
+    queryFn: () => getAlertsSummaryUseCase.execute(audienceId),
+    enabled: !!audienceId,
+  })
+}
+
+export function useDismissAlert(audienceId: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (alertId: string) => dismissAlertUseCase.execute(audienceId, alertId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ALERTS_QUERY_KEY(audienceId) })
+      queryClient.invalidateQueries({ queryKey: ALERTS_SUMMARY_QUERY_KEY(audienceId) })
+    },
+  })
+}

--- a/src/modules/topic-alerts/application/use-cases/dismiss-alert/index.ts
+++ b/src/modules/topic-alerts/application/use-cases/dismiss-alert/index.ts
@@ -1,0 +1,10 @@
+import type { ITopicAlertRepository, DismissAlertResult } from '../../../domain/repositories'
+import type { IDismissAlertUseCase } from '../../../domain/use-cases'
+
+export class DismissAlertUseCase implements IDismissAlertUseCase {
+  constructor(private readonly topicAlertRepository: ITopicAlertRepository) {}
+
+  async execute(audienceId: string, alertId: string): Promise<DismissAlertResult> {
+    return this.topicAlertRepository.dismissAlert(audienceId, alertId)
+  }
+}

--- a/src/modules/topic-alerts/application/use-cases/get-alerts-summary/index.ts
+++ b/src/modules/topic-alerts/application/use-cases/get-alerts-summary/index.ts
@@ -1,0 +1,10 @@
+import type { ITopicAlertRepository, AlertsSummary } from '../../../domain/repositories'
+import type { IGetAlertsSummaryUseCase } from '../../../domain/use-cases'
+
+export class GetAlertsSummaryUseCase implements IGetAlertsSummaryUseCase {
+  constructor(private readonly topicAlertRepository: ITopicAlertRepository) {}
+
+  async execute(audienceId: string): Promise<AlertsSummary> {
+    return this.topicAlertRepository.getAlertsSummary(audienceId)
+  }
+}

--- a/src/modules/topic-alerts/application/use-cases/index.ts
+++ b/src/modules/topic-alerts/application/use-cases/index.ts
@@ -1,0 +1,3 @@
+export { ListAlertsUseCase } from './list-alerts'
+export { GetAlertsSummaryUseCase } from './get-alerts-summary'
+export { DismissAlertUseCase } from './dismiss-alert'

--- a/src/modules/topic-alerts/application/use-cases/list-alerts/index.ts
+++ b/src/modules/topic-alerts/application/use-cases/list-alerts/index.ts
@@ -1,0 +1,10 @@
+import type { ITopicAlertRepository, ListAlertsParams, ListAlertsResult } from '../../../domain/repositories'
+import type { IListAlertsUseCase } from '../../../domain/use-cases'
+
+export class ListAlertsUseCase implements IListAlertsUseCase {
+  constructor(private readonly topicAlertRepository: ITopicAlertRepository) {}
+
+  async execute(params: ListAlertsParams): Promise<ListAlertsResult> {
+    return this.topicAlertRepository.listAlerts(params)
+  }
+}

--- a/src/modules/topic-alerts/domain/entities/index.ts
+++ b/src/modules/topic-alerts/domain/entities/index.ts
@@ -1,0 +1,2 @@
+export { TopicAlert } from './topic-alert.entity'
+export type { TopicAlertProps, TopicAlertMetadata, AlertType, AlertSeverity } from './topic-alert.entity'

--- a/src/modules/topic-alerts/domain/entities/topic-alert.entity.ts
+++ b/src/modules/topic-alerts/domain/entities/topic-alert.entity.ts
@@ -1,0 +1,81 @@
+export type AlertType = 'new_topic' | 'growth_spike' | 'new_theme'
+
+export type AlertSeverity = 'info' | 'warning' | 'critical'
+
+export interface TopicAlertMetadata {
+  topic_id?: string
+  topic_name?: string
+  audience_id?: string
+  audience_name?: string
+  analysis_id?: string
+  mention_frequency?: number
+  community_count?: number
+  growth_percentage?: number
+  trend?: string
+  [key: string]: unknown
+}
+
+export interface TopicAlertProps {
+  id: string
+  alertType: AlertType
+  severity: AlertSeverity
+  title: string
+  message: string
+  metadata: TopicAlertMetadata
+  isDismissed: boolean
+  createdAt: string
+}
+
+export class TopicAlert {
+  private readonly id: string
+  private readonly alertType: AlertType
+  private readonly severity: AlertSeverity
+  private readonly title: string
+  private readonly message: string
+  private readonly metadata: TopicAlertMetadata
+  private readonly isDismissed: boolean
+  private readonly createdAt: string
+
+  constructor(props: TopicAlertProps) {
+    this.id = props.id
+    this.alertType = props.alertType
+    this.severity = props.severity
+    this.title = props.title
+    this.message = props.message
+    this.metadata = props.metadata
+    this.isDismissed = props.isDismissed
+    this.createdAt = props.createdAt
+  }
+
+  getId(): string {
+    return this.id
+  }
+
+  getAlertType(): AlertType {
+    return this.alertType
+  }
+
+  getSeverity(): AlertSeverity {
+    return this.severity
+  }
+
+  getTitle(): string {
+    return this.title
+  }
+
+  getMessage(): string {
+    return this.message
+  }
+
+  getMetadata(): TopicAlertMetadata {
+    return this.metadata
+  }
+
+  getIsDismissed(): boolean {
+    return this.isDismissed
+  }
+
+  getCreatedAt(): string {
+    return this.createdAt
+  }
+}

--- a/src/modules/topic-alerts/domain/repositories/index.ts
+++ b/src/modules/topic-alerts/domain/repositories/index.ts
@@ -1,0 +1,7 @@
+export type {
+  ITopicAlertRepository,
+  ListAlertsParams,
+  ListAlertsResult,
+  AlertsSummary,
+  DismissAlertResult,
+} from './topic-alert.repository'

--- a/src/modules/topic-alerts/domain/repositories/topic-alert.repository.ts
+++ b/src/modules/topic-alerts/domain/repositories/topic-alert.repository.ts
@@ -1,0 +1,33 @@
+import type { TopicAlert, AlertType, AlertSeverity } from '../entities'
+
+export interface ListAlertsParams {
+  audienceId: string
+  alert_type?: AlertType
+  severity?: AlertSeverity
+  dismissed?: boolean
+  limit?: number
+  offset?: number
+}
+
+export interface ListAlertsResult {
+  alerts: TopicAlert[]
+  limit: number
+  offset: number
+}
+
+export interface AlertsSummary {
+  total: number
+  by_type: Record<string, number>
+  by_severity: Record<string, number>
+}
+
+export interface DismissAlertResult {
+  status: string
+  alert_id: string
+}
+
+export interface ITopicAlertRepository {
+  listAlerts(params: ListAlertsParams): Promise<ListAlertsResult>
+  getAlertsSummary(audienceId: string): Promise<AlertsSummary>
+  dismissAlert(audienceId: string, alertId: string): Promise<DismissAlertResult>
+}

--- a/src/modules/topic-alerts/domain/use-cases/dismiss-alert.use-case.ts
+++ b/src/modules/topic-alerts/domain/use-cases/dismiss-alert.use-case.ts
@@ -1,0 +1,5 @@
+import type { DismissAlertResult } from '../repositories'
+
+export interface IDismissAlertUseCase {
+  execute(audienceId: string, alertId: string): Promise<DismissAlertResult>
+}

--- a/src/modules/topic-alerts/domain/use-cases/get-alerts-summary.use-case.ts
+++ b/src/modules/topic-alerts/domain/use-cases/get-alerts-summary.use-case.ts
@@ -1,0 +1,5 @@
+import type { AlertsSummary } from '../repositories'
+
+export interface IGetAlertsSummaryUseCase {
+  execute(audienceId: string): Promise<AlertsSummary>
+}

--- a/src/modules/topic-alerts/domain/use-cases/index.ts
+++ b/src/modules/topic-alerts/domain/use-cases/index.ts
@@ -1,0 +1,3 @@
+export type { IListAlertsUseCase } from './list-alerts.use-case'
+export type { IGetAlertsSummaryUseCase } from './get-alerts-summary.use-case'
+export type { IDismissAlertUseCase } from './dismiss-alert.use-case'

--- a/src/modules/topic-alerts/domain/use-cases/list-alerts.use-case.ts
+++ b/src/modules/topic-alerts/domain/use-cases/list-alerts.use-case.ts
@@ -1,0 +1,5 @@
+import type { ListAlertsParams, ListAlertsResult } from '../repositories'
+
+export interface IListAlertsUseCase {
+  execute(params: ListAlertsParams): Promise<ListAlertsResult>
+}

--- a/src/modules/topic-alerts/index.ts
+++ b/src/modules/topic-alerts/index.ts
@@ -1,0 +1,9 @@
+export { TopicAlert } from './domain/entities'
+export type { TopicAlertProps, TopicAlertMetadata, AlertType, AlertSeverity } from './domain/entities'
+export type { ITopicAlertRepository, ListAlertsParams, ListAlertsResult, AlertsSummary, DismissAlertResult } from './domain/repositories'
+export type { IListAlertsUseCase, IGetAlertsSummaryUseCase, IDismissAlertUseCase } from './domain/use-cases'
+
+export { TopicAlertRepository } from './infra/repositories'
+
+export { ListAlertsUseCase, GetAlertsSummaryUseCase, DismissAlertUseCase } from './application/use-cases'
+export { useListAlerts, useAlertsSummary, useDismissAlert, ALERTS_QUERY_KEY, ALERTS_SUMMARY_QUERY_KEY } from './application/hooks/useTopicAlerts'

--- a/src/modules/topic-alerts/infra/repositories/index.ts
+++ b/src/modules/topic-alerts/infra/repositories/index.ts
@@ -1,0 +1,1 @@
+export { TopicAlertRepository } from './topic-alert.repository'

--- a/src/modules/topic-alerts/infra/repositories/topic-alert.repository.ts
+++ b/src/modules/topic-alerts/infra/repositories/topic-alert.repository.ts
@@ -1,0 +1,68 @@
+import type { HttpClient } from '@/modules/shared'
+import { TopicAlert, type TopicAlertProps } from '../../domain/entities'
+import type {
+  ITopicAlertRepository,
+  ListAlertsParams,
+  ListAlertsResult,
+  AlertsSummary,
+  DismissAlertResult,
+} from '../../domain/repositories'
+
+export class TopicAlertRepository implements ITopicAlertRepository {
+  constructor(private readonly httpClient: HttpClient) {}
+
+  async listAlerts(params: ListAlertsParams): Promise<ListAlertsResult> {
+    const searchParams = new URLSearchParams()
+    if (params.alert_type !== undefined) searchParams.set('alert_type', params.alert_type)
+    if (params.severity !== undefined) searchParams.set('severity', params.severity)
+    if (params.dismissed !== undefined) searchParams.set('dismissed', String(params.dismissed))
+    if (params.limit !== undefined) searchParams.set('limit', String(params.limit))
+    if (params.offset !== undefined) searchParams.set('offset', String(params.offset))
+
+    const query = searchParams.toString()
+    const url = query
+      ? `audiences/${params.audienceId}/alerts?${query}`
+      : `audiences/${params.audienceId}/alerts`
+
+    const response = await this.httpClient.get<{
+      alerts: Array<{
+        id: string
+        alert_type: TopicAlertProps['alertType']
+        severity: TopicAlertProps['severity']
+        title: string
+        message: string
+        metadata: Record<string, unknown>
+        is_dismissed: boolean
+        created_at: string
+      }>
+      limit: number
+      offset: number
+    }>(url)
+
+    const alerts = (response.alerts ?? []).map(
+      (a) =>
+        new TopicAlert({
+          id: a.id,
+          alertType: a.alert_type,
+          severity: a.severity,
+          title: a.title,
+          message: a.message,
+          metadata: a.metadata,
+          isDismissed: a.is_dismissed,
+          createdAt: a.created_at,
+        })
+    )
+
+    return { alerts, limit: response.limit, offset: response.offset }
+  }
+
+  async getAlertsSummary(audienceId: string): Promise<AlertsSummary> {
+    return this.httpClient.get<AlertsSummary>(`audiences/${audienceId}/alerts/summary`)
+  }
+
+  async dismissAlert(audienceId: string, alertId: string): Promise<DismissAlertResult> {
+    return this.httpClient.patch<DismissAlertResult>(
+      `audiences/${audienceId}/alerts/${alertId}/dismiss`
+    )
+  }
+}


### PR DESCRIPTION
## Resumo

- Implementa sistema completo de alertas inteligentes de tópicos (smart topic alerts) no frontend
- Integra com 3 endpoints da API: listagem, resumo e dismiss de alertas
- Adiciona nova aba "Alertas" no detalhe da audiência com filtros por tipo, severidade e status
- Atualiza sistema de notificações SSE para tratar eventos de alerta em tempo real

## Detalhes técnicos

### Novo módulo: `topic-alerts`
- **Entidade**: `TopicAlert` com tipos (`new_topic`, `growth_spike`, `new_theme`) e severidades (`info`, `warning`, `critical`)
- **Repositório**: implementação HTTP com `ky`, mapeamento snake_case → camelCase
- **Use Cases**: `ListAlerts`, `GetAlertsSummary`, `DismissAlert`
- **Hooks**: `useListAlerts`, `useAlertsSummary`, `useDismissAlert` (React Query)
- **DI Container**: 4 novos bindings no Inversify

### Componentes UI
- `AlertCard` — card com ícones por tipo/severidade, badge, time-ago, botão de dismiss
- `AlertsTabContent` — conteúdo da aba com filtros (tipo, severidade, dismissed), estados de loading/empty

### Notificações SSE
- 3 novos tipos: `topic_alert_new_topic`, `topic_alert_growth_spike`, `topic_alert_new_theme`
- Invalidação automática de queries ao receber evento SSE de alerta

### i18n
- Traduções completas em `en` e `pt-BR` para alertas e notificações

## Plano de teste

- [ ] Verificar aba "Alertas" aparece no detalhe da audiência com contador
- [ ] Testar filtros por tipo de alerta (new_topic, growth_spike, new_theme)
- [ ] Testar filtros por severidade (info, warning, critical)
- [ ] Testar toggle de mostrar/esconder alertas dismissados
- [ ] Verificar dismiss de alerta individual com feedback via toast
- [ ] Verificar estado vazio quando não há alertas
- [ ] Testar notificações SSE de alerta em tempo real
- [ ] Verificar ícones corretos no painel de notificações para cada tipo de alerta