### PR TITLE
fix: improve responsive layout for tablet and mobile

### DIFF
--- a/src/components/audiences/detail/AudienceDetailHeader.tsx
+++ b/src/components/audiences/detail/AudienceDetailHeader.tsx
@@ -20,20 +20,20 @@ export function AudienceDetailHeader({
   const { t } = useTranslation('audiences')
 
   return (
-    <div className="flex items-center justify-between mb-4">
-      <div className="flex items-center gap-4">
+    <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+      <div className="flex items-center gap-4 min-w-0">
         <button
           onClick={onBack}
-          className="cursor-pointer w-8 h-8 rounded-lg flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800 transition-colors"
+          className="cursor-pointer w-8 h-8 shrink-0 rounded-lg flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800 transition-colors"
         >
           <ChevronLeft className="w-5 h-5" />
         </button>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white truncate">
           {audienceName}
         </h1>
       </div>
 
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Button variant="outline" size="sm">
           <Info className="w-4 h-4" />
           {t('detail.info')}

--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -2,6 +2,7 @@ import { useState, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Sparkles, Bell, Lightbulb } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import {
   TopicsTable,
   TopicDetailPanel,
@@ -12,6 +13,7 @@ import {
   AlertsTabContent,
 } from '@/components/audiences/detail'
 import { ContentSuggestionsTabContent } from './ContentSuggestionsTabContent'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import type { TopicDetail, ThemeDetail, ThemeGridItem } from '@/components/audiences/detail'
 import type { SimilarCommunity } from './SimilarCommunitiesGrid'
 import type { AudienceStats, RadarData } from './AboutAudiencePanel'
@@ -155,6 +157,7 @@ export function AudienceDetailTabs({
   audienceId,
 }: Readonly<AudienceDetailTabsProps>) {
   const { t } = useTranslation('audiences')
+  const isDesktop = useMediaQuery('(min-width: 1024px)')
   const [activeTab, setActiveTab] = useState('search')
   const [selectedTopic, setSelectedTopic] = useState<TopicDetail | null>(null)
   const [selectedTheme, setSelectedTheme] = useState<ThemeDetail | null>(null)
@@ -335,9 +338,23 @@ export function AudienceDetailTabs({
                 }
               }}
             />
-            <div className="w-1/2 shrink-0">
-              <TopicDetailPanel topic={selectedTopic} audienceId={audienceId} />
-            </div>
+            {isDesktop ? (
+              <div className="w-1/2 shrink-0">
+                <TopicDetailPanel topic={selectedTopic} audienceId={audienceId} />
+              </div>
+            ) : (
+              <Sheet open={!!selectedTopic} onOpenChange={(open) => { if (!open) setSelectedTopic(null) }}>
+                <SheetContent side="right" className="sm:max-w-lg overflow-y-auto">
+                  <SheetHeader>
+                    <SheetTitle>{selectedTopic?.name}</SheetTitle>
+                    <SheetDescription>{selectedTopic?.description}</SheetDescription>
+                  </SheetHeader>
+                  <div className="px-4">
+                    <TopicDetailPanel topic={selectedTopic} audienceId={audienceId} embedded />
+                  </div>
+                </SheetContent>
+              </Sheet>
+            )}
           </div>
         )}
       </TabsContent>
@@ -354,13 +371,32 @@ export function AudienceDetailTabs({
               isRefreshing={refreshIntentsMutation.isPending}
             />
           </div>
-          <div className="w-1/2 shrink-0">
-            <ThemeDetailPanel
-              theme={selectedTheme}
-              audienceId={audienceId}
-              intentCategory={selectedIntentCategory}
-            />
-          </div>
+          {isDesktop ? (
+            <div className="w-1/2 shrink-0">
+              <ThemeDetailPanel
+                theme={selectedTheme}
+                audienceId={audienceId}
+                intentCategory={selectedIntentCategory}
+              />
+            </div>
+          ) : (
+            <Sheet open={!!selectedTheme} onOpenChange={(open) => { if (!open) setSelectedTheme(null) }}>
+              <SheetContent side="right" className="sm:max-w-lg overflow-y-auto">
+                <SheetHeader>
+                  <SheetTitle>{selectedTheme?.name}</SheetTitle>
+                  <SheetDescription>{selectedTheme?.description}</SheetDescription>
+                </SheetHeader>
+                <div className="px-4">
+                  <ThemeDetailPanel
+                    theme={selectedTheme}
+                    audienceId={audienceId}
+                    intentCategory={selectedIntentCategory}
+                    embedded
+                  />
+                </div>
+              </SheetContent>
+            </Sheet>
+          )}
         </div>
       </TabsContent>
 

--- a/src/components/audiences/detail/SubredditsTabContent.tsx
+++ b/src/components/audiences/detail/SubredditsTabContent.tsx
@@ -30,12 +30,12 @@ export function SubredditsTabContent({
 }: Readonly<SubredditsTabContentProps>) {
   return (
     <div className="space-y-8">
-      <div className="flex gap-6">
+      <div className="flex flex-col lg:flex-row gap-6">
         <SubredditsGrid
           subreddits={subredditsData}
           totalCount={communitiesCount}
         />
-        <div className="w-[280px] shrink-0">
+        <div className="w-full lg:w-[280px] lg:shrink-0">
           <AboutAudiencePanel
             stats={audienceStats}
             radarData={radarData}

--- a/src/components/audiences/detail/ThemeDetailPanel.tsx
+++ b/src/components/audiences/detail/ThemeDetailPanel.tsx
@@ -46,9 +46,10 @@ export interface ThemeDetailPanelProps {
   theme: ThemeDetail | null
   audienceId?: string
   intentCategory?: string | null
+  embedded?: boolean
 }
 
-export function ThemeDetailPanel({ theme, audienceId, intentCategory }: Readonly<ThemeDetailPanelProps>) {
+export function ThemeDetailPanel({ theme, audienceId, intentCategory, embedded = false }: Readonly<ThemeDetailPanelProps>) {
   const { t } = useTranslation('audiences')
   const containerRef = useRef<HTMLDivElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
@@ -104,15 +105,15 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory }: Readonly
     : theme?.subreddits ?? []
 
   useLayoutEffect(() => {
-    if (!containerRef.current || !panelRef.current) return
+    if (embedded || !containerRef.current || !panelRef.current) return
 
     if (!theme) {
       gsap.set(panelRef.current, { opacity: 0, x: 50, display: 'none' })
     }
-  }, [])
+  }, [embedded])
 
   useEffect(() => {
-    if (!containerRef.current || !panelRef.current) return
+    if (embedded || !containerRef.current || !panelRef.current) return
 
     if (theme) {
       gsap.set(panelRef.current, { display: 'block' })
@@ -148,7 +149,7 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory }: Readonly
         })
       }
     }
-  }, [prefersReducedMotion, theme])
+  }, [embedded, prefersReducedMotion, theme])
 
   useEffect(() => {
     setShowPosts(false)
@@ -160,20 +161,27 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory }: Readonly
   const isPanelLoading = isScoringTheme && (panelQuery.isLoading || refreshPanelMutation.isPending)
 
   return (
-    <div ref={containerRef} className="h-full">
+    <div ref={containerRef} className={embedded ? '' : 'h-full'}>
       <div
         ref={panelRef}
-        className="bg-white dark:bg-zinc-900 rounded-2xl p-6 hidden"
+        className={embedded
+          ? ''
+          : 'bg-white dark:bg-zinc-900 rounded-2xl p-6 hidden'
+        }
       >
         {theme && (
           <>
-            <h3 className="font-semibold text-lg text-gray-900 dark:text-white mb-4">
-              {theme.name}
-            </h3>
+            {!embedded && (
+              <>
+                <h3 className="font-semibold text-lg text-gray-900 dark:text-white mb-4">
+                  {theme.name}
+                </h3>
 
-            <p className="text-sm text-gray-600 dark:text-zinc-300 mb-6 leading-relaxed">
-              {theme.description}
-            </p>
+                <p className="text-sm text-gray-600 dark:text-zinc-300 mb-6 leading-relaxed">
+                  {theme.description}
+                </p>
+              </>
+            )}
 
             <div className="flex flex-wrap justify-end gap-2 mb-6">
               <Button

--- a/src/components/audiences/detail/TopicDetailPanel.tsx
+++ b/src/components/audiences/detail/TopicDetailPanel.tsx
@@ -55,9 +55,10 @@ export interface TopicDetail {
 export interface TopicDetailPanelProps {
   topic: TopicDetail | null
   audienceId: string
+  embedded?: boolean
 }
 
-export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPanelProps>) {
+export function TopicDetailPanel({ topic, audienceId, embedded = false }: Readonly<TopicDetailPanelProps>) {
   const { t } = useTranslation('audiences')
   const containerRef = useRef<HTMLDivElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
@@ -201,15 +202,15 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
   }
 
   useLayoutEffect(() => {
-    if (!containerRef.current || !panelRef.current) return
+    if (embedded || !containerRef.current || !panelRef.current) return
 
     if (!topic) {
       gsap.set(panelRef.current, { opacity: 0, x: 50, display: 'none' })
     }
-  }, [])
+  }, [embedded])
 
   useEffect(() => {
-    if (!containerRef.current || !panelRef.current) return
+    if (embedded || !containerRef.current || !panelRef.current) return
 
     if (topic) {
       gsap.set(panelRef.current, { display: 'block' })
@@ -245,7 +246,7 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
         })
       }
     }
-  }, [prefersReducedMotion, topic])
+  }, [embedded, prefersReducedMotion, topic])
 
   const browseAllLabel = isProcessing ? t('topicDetail.analyzing') : t('topicDetail.browseAll')
   const browseAllDisabled = isProcessing || triggerDeepDive.isPending
@@ -257,37 +258,44 @@ export function TopicDetailPanel({ topic, audienceId }: Readonly<TopicDetailPane
   const sentimentDisabled = isSentimentProcessing || triggerSentiment.isPending
 
   return (
-    <div ref={containerRef} className="h-full">
+    <div ref={containerRef} className={embedded ? '' : 'h-full'}>
       <div
         ref={panelRef}
-        className="bg-white dark:bg-zinc-900 rounded-2xl p-6 hidden max-h-[80vh] overflow-y-auto"
+        className={embedded
+          ? ''
+          : 'bg-white dark:bg-zinc-900 rounded-2xl p-6 hidden max-h-[80vh] overflow-y-auto'
+        }
       >
         {topic && (
           <>
-            <div className="flex items-start justify-between mb-4">
-              <h3 className="font-semibold text-lg text-gray-900 dark:text-white">
-                {topic.name}
-              </h3>
-              <div className="flex items-center gap-2 text-sm">
-                <span className="text-gray-500 dark:text-zinc-400">
-                  {topic.frequency} / {topic.frequencyUnit}
-                </span>
-                <span className={`flex items-center gap-1 ${
-                  topic.growthTrend === 'down' ? 'text-red-500'
-                    : topic.growthTrend === 'stable' ? 'text-yellow-500'
-                    : 'text-green-500'
-                }`}>
-                  {topic.growthTrend === 'down' ? <TrendingDown className="w-3 h-3" />
-                    : topic.growthTrend === 'stable' ? <Minus className="w-3 h-3" />
-                    : <TrendingUp className="w-3 h-3" />}
-                  {topic.growth}%
-                </span>
-              </div>
-            </div>
+            {!embedded && (
+              <>
+                <div className="flex items-start justify-between mb-4">
+                  <h3 className="font-semibold text-lg text-gray-900 dark:text-white">
+                    {topic.name}
+                  </h3>
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className="text-gray-500 dark:text-zinc-400">
+                      {topic.frequency} / {topic.frequencyUnit}
+                    </span>
+                    <span className={`flex items-center gap-1 ${
+                      topic.growthTrend === 'down' ? 'text-red-500'
+                        : topic.growthTrend === 'stable' ? 'text-yellow-500'
+                        : 'text-green-500'
+                    }`}>
+                      {topic.growthTrend === 'down' ? <TrendingDown className="w-3 h-3" />
+                        : topic.growthTrend === 'stable' ? <Minus className="w-3 h-3" />
+                        : <TrendingUp className="w-3 h-3" />}
+                      {topic.growth}%
+                    </span>
+                  </div>
+                </div>
 
-            <p className="text-sm text-gray-600 dark:text-zinc-300 mb-6 leading-relaxed">
-              {topic.description}
-            </p>
+                <p className="text-sm text-gray-600 dark:text-zinc-300 mb-6 leading-relaxed">
+                  {topic.description}
+                </p>
+              </>
+            )}
 
             <div className="flex flex-wrap justify-end gap-2 mb-6">
               <Button

--- a/src/components/audiences/detail/TopicsTable.tsx
+++ b/src/components/audiences/detail/TopicsTable.tsx
@@ -107,10 +107,10 @@ export function TopicsTable({
   }, [prefersReducedMotion, sortBy, searchQuery])
 
   return (
-    <div className="flex-1">
+    <div className="flex-1 min-w-0 px-1 md:px-0">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <h3 className="font-semibold text-gray-900 dark:text-white">
+          <h3 className="text-sm md:text-base font-semibold text-gray-900 dark:text-white">
             {t('topics.popularTopics')}
           </h3>
           <span className="text-sm text-gray-500 dark:text-zinc-400">
@@ -162,7 +162,7 @@ export function TopicsTable({
             placeholder={t('topics.searchPlaceholder')}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-4 py-2.5 bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-lg text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-lime/50 focus:border-lime transition-colors"
+            className="w-full pl-10 pr-4 py-2 md:py-2.5 text-sm md:text-base bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-lg text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-lime/50 focus:border-lime transition-colors"
           />
         </div>
       </div>
@@ -183,23 +183,23 @@ export function TopicsTable({
               type="button"
               key={topic.id}
               onClick={() => onTopicSelect?.(topic)}
-              className={`w-full text-left bg-white dark:bg-zinc-800 border rounded-xl p-4 transition-colors cursor-pointer ${
+              className={`w-full text-left bg-white dark:bg-zinc-800 border rounded-xl p-3 md:p-4 transition-colors cursor-pointer ${
                 selectedTopicId === topic.id
                   ? 'border-lime'
                   : 'border-gray-200 dark:border-zinc-700 hover:border-lime dark:hover:border-lime'
               }`}
             >
-              <div className="flex items-center gap-4">
-                <p className="font-semibold text-gray-900 dark:text-white truncate  shrink-0">
+              <div className="flex items-center gap-2 md:gap-4">
+                <p className="text-sm md:text-base font-semibold text-gray-900 dark:text-white truncate shrink-0">
                   {topic.name}
                 </p>
 
-                <div className="flex items-center gap-4 flex-1 justify-end">
-                  <div className="w-[70px] shrink-0">
+                <div className="flex items-center gap-2 md:gap-4 flex-1 justify-end">
+                  <div className="w-[70px] shrink-0 hidden lg:block">
                     <SparkLine growth={topic.growth} strokeColor={sparkColor} />
                   </div>
 
-                  <div className={`flex items-center gap-1 text-sm font-medium w-20 shrink-0 ${trendColor}`}>
+                  <div className={`flex items-center gap-1 text-xs md:text-sm font-medium w-16 md:w-20 shrink-0 ${trendColor}`}>
                     <TrendIcon className="w-4 h-4" />
                     <span>{topic.growth}%</span>
                     {topic.growthSource && (
@@ -222,16 +222,16 @@ export function TopicsTable({
                     )}
                   </div>
 
-                  <div className="text-sm text-right shrink-0 truncate mr-2">
+                  <div className="text-xs md:text-sm text-right shrink-0 truncate mr-2">
                     <span className="text-lime font-semibold mr-2">
                       {topic.frequency} / {topic.frequencyUnit}
                     </span>
-                    <span className="text-gray-500 dark:text-zinc-400 mr-2">{t('topics.in')}</span>
-                    <span className="text-gray-700 dark:text-zinc-300">
+                    <span className="hidden lg:inline text-gray-500 dark:text-zinc-400 mr-2">{t('topics.in')}</span>
+                    <span className="hidden lg:inline text-gray-700 dark:text-zinc-300">
                       {topic.subreddits.slice(0, 2).join(', ')}
                     </span>
                     {topic.subreddits.length > 2 && (
-                      <span className="text-gray-400 dark:text-zinc-500">
+                      <span className="hidden lg:inline text-gray-400 dark:text-zinc-500">
                         {t('topics.andOthers', { count: topic.subreddits.length - 2 })}
                       </span>
                     )}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -30,7 +30,7 @@ export function MainLayout() {
     <div className="min-h-screen bg-gray-50 dark:bg-zinc-950">
       <Sidebar />
 
-      <div className="ml-20">
+      <div className="md:ml-20">
         <Topbar />
 
         <main

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -90,7 +90,7 @@ export function Sidebar() {
   return (
     <aside
       ref={sidebarRef}
-      className="fixed left-0 top-0 h-screen w-20 bg-dark rounded-r-3xl flex flex-col items-center py-6 z-50"
+      className="fixed left-0 top-0 h-screen w-20 bg-dark rounded-r-3xl hidden md:flex flex-col items-center py-6 z-50"
     >
       <div className="w-12 h-12 bg-lime rounded-xl flex items-center justify-center mb-8">
         <span className="text-black font-bold text-xl">S</span>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useRef } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
-import { Bell, Sun, Moon, Plus, ChevronDown, User, LogOut, Settings, HelpCircle } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { useLocation, useNavigate, NavLink } from 'react-router-dom'
+import {
+  Bell, Sun, Moon, Plus, ChevronDown, User, LogOut, Settings, HelpCircle, Menu,
+  Home, FileText, Package, Briefcase, ShoppingBag, Clock, Link2, Smartphone,
+} from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { Button, Input, Avatar } from '@/components/ui'
 import {
@@ -12,11 +15,26 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { Sheet, SheetContent } from '@/components/ui/sheet'
+import { cn } from '@/lib/utils'
 import { useThemeStore } from '@/modules/shared'
 import { useAuthStore, useLogout } from '@/modules/auth'
 import { useUnreadCount, useNotificationStore } from '@/modules/notifications'
 import { NotificationDropdown } from '@/components/notifications'
 import { useReducedMotion } from '@/hooks'
+
+const mobileNavItems = [
+  { icon: Home, path: '/dashboard', label: 'Dashboard' },
+  { icon: FileText, path: '/orders', label: 'Orders' },
+  { icon: Package, path: '/audiences', label: 'Audiences' },
+  { icon: Briefcase, path: '/campaigns', label: 'Campaigns' },
+  { icon: ShoppingBag, path: '/cart', label: 'Cart' },
+  { icon: Clock, path: '/analytics', label: 'Analytics' },
+  { icon: User, path: '/customers', label: 'Customers' },
+  { icon: Link2, path: '/integrations', label: 'Integrations' },
+  { icon: Smartphone, path: '/mobile', label: 'Mobile' },
+  { icon: Bell, path: '/notifications', label: 'Notifications' },
+]
 
 const pageNames: Record<string, string> = {
   '/dashboard': 'Dashboard',
@@ -43,6 +61,7 @@ export function Topbar() {
   const { theme, toggleTheme } = useThemeStore()
   const { user } = useAuthStore()
   const handleLogout = useLogout()
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const prefersReducedMotion = useReducedMotion()
   useUnreadCount()
   const unreadCount = useNotificationStore((state) => state.unreadCount)
@@ -111,16 +130,24 @@ export function Topbar() {
   return (
     <header
       ref={topbarRef}
-      className="sticky top-0 z-40 flex items-center justify-between h-16 px-8 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md border-b border-gray-100 dark:border-zinc-800"
+      className="sticky top-0 z-40 flex items-center justify-between h-16 px-4 md:px-8 bg-white/80 dark:bg-zinc-900/80 backdrop-blur-md border-b border-gray-100 dark:border-zinc-800"
     >
-      <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{pageName}</h1>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => setMobileMenuOpen(true)}
+          className="md:hidden cursor-pointer w-10 h-10 rounded-full flex items-center justify-center text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-zinc-800 transition-colors"
+        >
+          <Menu className="w-5 h-5" />
+        </button>
+        <h1 className="text-xl md:text-3xl font-bold text-gray-900 dark:text-white">{pageName}</h1>
+      </div>
 
-      <div className="flex-1 max-w-md mx-8">
+      <div className="hidden md:block flex-1 max-w-md mx-8">
         <Input icon placeholder="Search..." className="w-full" />
       </div>
 
-      <div className="flex items-center gap-4">
-        <Button variant="primary" size="md" className="gap-2">
+      <div className="flex items-center gap-2 md:gap-4">
+        <Button variant="primary" size="md" className="gap-2 hidden sm:flex">
           <Plus className="w-4 h-4" />
           Create Audience
         </Button>
@@ -215,6 +242,73 @@ export function Topbar() {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+
+      <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
+        <SheetContent side="left" className="w-72 p-0 bg-dark border-none" showCloseButton={false}>
+          <div className="flex flex-col h-full py-6">
+            <div className="flex items-center justify-center mb-8">
+              <div className="w-12 h-12 bg-lime rounded-xl flex items-center justify-center">
+                <span className="text-black font-bold text-xl">S</span>
+              </div>
+            </div>
+
+            <nav className="flex-1 flex flex-col gap-1 px-4">
+              {mobileNavItems.map(({ icon: Icon, path, label }) => (
+                <NavLink
+                  key={path}
+                  to={path}
+                  onClick={() => setMobileMenuOpen(false)}
+                  className={cn(
+                    'flex items-center gap-3 px-4 py-3 rounded-xl transition-colors duration-200',
+                    location.pathname === path
+                      ? 'bg-lime text-black font-medium'
+                      : 'text-gray-400 hover:text-white hover:bg-white/10'
+                  )}
+                >
+                  <Icon className="w-5 h-5" />
+                  <span className="text-sm">{label}</span>
+                </NavLink>
+              ))}
+            </nav>
+
+            <div className="flex flex-col gap-1 px-4 mt-auto">
+              <NavLink
+                to="/settings"
+                onClick={() => setMobileMenuOpen(false)}
+                className={cn(
+                  'flex items-center gap-3 px-4 py-3 rounded-xl transition-colors duration-200',
+                  location.pathname === '/settings'
+                    ? 'bg-lime text-black font-medium'
+                    : 'text-gray-400 hover:text-white hover:bg-white/10'
+                )}
+              >
+                <Settings className="w-5 h-5" />
+                <span className="text-sm">Settings</span>
+              </NavLink>
+              <NavLink
+                to="/help"
+                onClick={() => setMobileMenuOpen(false)}
+                className={cn(
+                  'flex items-center gap-3 px-4 py-3 rounded-xl transition-colors duration-200',
+                  location.pathname === '/help'
+                    ? 'bg-lime text-black font-medium'
+                    : 'text-gray-400 hover:text-white hover:bg-white/10'
+                )}
+              >
+                <HelpCircle className="w-5 h-5" />
+                <span className="text-sm">Help</span>
+              </NavLink>
+              <button
+                onClick={() => { handleLogout(); setMobileMenuOpen(false) }}
+                className="flex items-center gap-3 px-4 py-3 rounded-xl text-gray-400 hover:text-red-400 hover:bg-red-400/10 transition-colors duration-200 cursor-pointer"
+              >
+                <LogOut className="w-5 h-5" />
+                <span className="text-sm">Logout</span>
+              </button>
+            </div>
+          </div>
+        </SheetContent>
+      </Sheet>
     </header>
   )
 }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -36,7 +36,7 @@ export function Tabs({ defaultValue, value, onValueChange, children, className }
 
   return (
     <TabsContext.Provider value={{ activeTab, setActiveTab }}>
-      <div className={className}>{children}</div>
+      <div className={cn('min-w-0 overflow-hidden', className)}>{children}</div>
     </TabsContext.Provider>
   )
 }
@@ -50,7 +50,7 @@ export function TabsList({ children, className }: Readonly<TabsListProps>) {
   return (
     <div
       className={cn(
-        'flex items-center gap-6 border-b border-gray-200 dark:border-zinc-800',
+        'flex items-center gap-6 border-b border-gray-200 dark:border-zinc-800 overflow-x-auto max-w-full [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
         className
       )}
     >
@@ -79,7 +79,7 @@ export function TabsTrigger({
     <button
       onClick={() => setActiveTab(value)}
       className={cn(
-        'cursor-pointer relative pb-3 text-sm font-medium transition-colors duration-200',
+        'cursor-pointer relative pb-3 text-sm font-medium whitespace-nowrap shrink-0 transition-colors duration-200',
         isActive
           ? 'text-gray-900 dark:text-white'
           : 'text-gray-500 dark:text-zinc-400 hover:text-gray-700 dark:hover:text-zinc-300',

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches)
+
+  useEffect(() => {
+    const media = window.matchMedia(query)
+    const listener = (e: MediaQueryListEvent) => setMatches(e.matches)
+    media.addEventListener('change', listener)
+    return () => media.removeEventListener('change', listener)
+  }, [query])
+
+  return matches
+}


### PR DESCRIPTION
## Summary
- Topic/theme detail panels now open in a Sheet overlay on screens below `lg` (1024px), preserving the side-by-side layout on desktop
- Sidebar is hidden on mobile with a hamburger menu that slides in from the left with full navigation
- Tabs are horizontally scrollable when they overflow on narrow viewports
- Header buttons wrap gracefully and title truncates on small screens
- Subreddits tab stacks vertically on mobile instead of side-by-side
- Topics list uses smaller font sizes, tighter spacing, and hides sparklines/subreddit names on mobile
- New `useMediaQuery` hook for JS-level breakpoint detection

## Test plan
- [ ] Verify tablet viewport (768px–1024px): topic/theme detail opens in Sheet from right
- [ ] Verify desktop viewport (1280px+): side-by-side layout preserved
- [ ] Verify mobile viewport (~375px): hamburger menu works, sidebar hidden, layouts stack
- [ ] Verify tabs scroll horizontally on narrow screens
- [ ] Verify header buttons don't overflow on tablet
- [ ] Verify subreddits tab stacks on mobile, side-by-side on desktop