### PR TITLE
feat: display pain patterns in theme detail panel

### DIFF
--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -130,6 +130,7 @@ function mapIntentToDetail(intent: IntentCategory, t: (key: string) => string): 
       name: s.name,
       count: s.count,
     })),
+    painPatterns: intent.getPainPatterns(),
   }
 }
 

--- a/src/components/audiences/detail/PainPatternsSection.tsx
+++ b/src/components/audiences/detail/PainPatternsSection.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ChevronRight, ChevronDown, ArrowUp, MessageCircle, ExternalLink, Bookmark, FileText, RefreshCw, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { PainPattern } from '@/modules/audience/domain/entities/IntentCategory.entity'
+
+export interface PainPatternsSectionProps {
+  patterns: PainPattern[]
+  onRefresh?: () => void
+  isRefreshing?: boolean
+}
+
+function formatNumber(num: number): string {
+  if (num >= 1000) {
+    return `${(num / 1000).toFixed(num >= 10000 ? 0 : 1).replace(/\.0$/, '')}k`
+  }
+  return num.toLocaleString()
+}
+
+function PainPatternCard({ pattern }: Readonly<{ pattern: PainPattern }>) {
+  const { t } = useTranslation('audiences')
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="rounded-lg bg-gray-50 dark:bg-zinc-800 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full text-left p-4 hover:bg-gray-100 dark:hover:bg-zinc-750 transition-colors"
+      >
+        <div className="flex items-start gap-3">
+          <div className="flex items-center gap-2 shrink-0">
+            <span className="text-lg font-bold text-gray-900 dark:text-white">
+              {pattern.postCount}
+            </span>
+            {expanded
+              ? <ChevronDown className="w-4 h-4 text-gray-400 dark:text-zinc-500" />
+              : <ChevronRight className="w-4 h-4 text-gray-400 dark:text-zinc-500" />
+            }
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center justify-between gap-2">
+              <h5 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+                <span className="mr-1.5">{pattern.emoji}</span>
+                {pattern.name}
+              </h5>
+              <div className="flex items-center gap-3 shrink-0 text-xs text-gray-500 dark:text-zinc-400">
+                <span className="flex items-center gap-1">
+                  <ArrowUp className="w-3 h-3" />
+                  {formatNumber(pattern.totalUpvotes)}
+                </span>
+                <span className="flex items-center gap-1">
+                  <MessageCircle className="w-3 h-3" />
+                  {formatNumber(pattern.totalComments)}
+                </span>
+              </div>
+            </div>
+            {!expanded && (
+              <ul className="mt-2 space-y-0.5">
+                {pattern.submissions.map((sub, i) => (
+                  <li key={i} className="text-xs text-gray-500 dark:text-zinc-400 truncate">
+                    - {sub.title}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-4">
+          <div className="border-t border-gray-200 dark:border-zinc-700 pt-4 space-y-4">
+            {pattern.submissions.map((sub, i) => (
+              <div key={i}>
+                <h6 className="text-sm font-semibold text-gray-900 dark:text-white mb-1">
+                  {sub.title}
+                </h6>
+                {sub.body && (
+                  <p className="text-xs text-gray-600 dark:text-zinc-300 leading-relaxed mb-2 line-clamp-3">
+                    {sub.body}
+                  </p>
+                )}
+                <div className="flex items-center justify-between text-xs text-gray-500 dark:text-zinc-400">
+                  <div className="flex items-center gap-3">
+                    <span className="flex items-center gap-1">
+                      <ArrowUp className="w-3 h-3" />
+                      {sub.score}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <MessageCircle className="w-3 h-3" />
+                      {sub.numComments}
+                    </span>
+                    <span>{sub.subreddit}</span>
+                    {sub.permalink && (
+                      <a
+                        href={`https://reddit.com${sub.permalink}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="text-gray-400 dark:text-zinc-500 hover:text-gray-600 dark:hover:text-zinc-300 transition-colors"
+                      >
+                        <ExternalLink className="w-3 h-3" />
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex gap-2 mt-4 pt-3 border-t border-gray-200 dark:border-zinc-700">
+            <Button variant="outline" size="sm" className="gap-1.5 text-xs">
+              <Bookmark className="w-3.5 h-3.5" />
+              {t('themes.painPatterns.bookmark', { count: pattern.submissions.length })}
+            </Button>
+            <Button variant="outline" size="sm" className="gap-1.5 text-xs">
+              <FileText className="w-3.5 h-3.5" />
+              {t('themes.painPatterns.browse', { count: pattern.submissions.length })}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function PainPatternsSection({ patterns, onRefresh, isRefreshing }: Readonly<PainPatternsSectionProps>) {
+  const { t } = useTranslation('audiences')
+
+  if (patterns.length === 0) {
+    return (
+      <div className="mt-6 flex flex-col items-center gap-3 py-6">
+        <p className="text-sm text-gray-500 dark:text-zinc-400">
+          {t('themes.painPatterns.empty')}
+        </p>
+        {onRefresh && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={onRefresh}
+            disabled={isRefreshing}
+          >
+            {isRefreshing
+              ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              : <RefreshCw className="w-3.5 h-3.5" />
+            }
+            {isRefreshing ? t('themes.painPatterns.generating') : t('themes.painPatterns.generate')}
+          </Button>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-6">
+      <h4 className="font-medium text-gray-900 dark:text-white text-sm mb-3">
+        {t('themes.painPatterns.title')}
+        <span className="ml-2 text-xs text-gray-500 dark:text-zinc-400">{patterns.length}</span>
+      </h4>
+      <div className="space-y-2">
+        {patterns.map((pattern, i) => (
+          <PainPatternCard key={i} pattern={pattern} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/audiences/detail/ThemeDetailPanel.tsx
+++ b/src/components/audiences/detail/ThemeDetailPanel.tsx
@@ -4,11 +4,13 @@ import { Search, Sparkles, Copy, MessageSquare, Loader2 } from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { useReducedMotion } from '@/hooks'
 import { Button } from '@/components/ui/button'
-import { useGetIntentPosts } from '@/modules/audience/application/hooks'
+import { useGetIntentPosts, useRefreshAudienceIntents } from '@/modules/audience/application/hooks'
 import { useGetThemePanel } from '@/modules/audience/application/hooks/useGetThemePanel'
 import { useRefreshThemePanel } from '@/modules/audience/application/hooks/useRefreshThemePanel'
 import { ThemeSummaryCard } from './ThemeSummaryCard'
+import { PainPatternsSection } from './PainPatternsSection'
 import type { ThemeAnalysisWindow } from '@/modules/audience/domain/use-cases'
+import type { PainPattern } from '@/modules/audience/domain/entities/IntentCategory.entity'
 
 export interface ThemeSubcategory {
   name: string
@@ -39,6 +41,7 @@ export interface ThemeDetail {
   topics: ThemeTopic[]
   subreddits: ThemeSubreddit[]
   summaryThemes?: ThemeSummaryTheme[]
+  painPatterns?: PainPattern[]
   window?: ThemeAnalysisWindow
 }
 
@@ -55,6 +58,15 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory, embedded =
   const panelRef = useRef<HTMLDivElement>(null)
   const prefersReducedMotion = useReducedMotion()
   const [showPosts, setShowPosts] = useState(false)
+  const [showPatterns, setShowPatterns] = useState(false)
+
+  const refreshIntentsMutation = useRefreshAudienceIntents()
+
+  const handleRefreshPatterns = () => {
+    if (audienceId) {
+      refreshIntentsMutation.mutate({ audienceId, window: 'week' })
+    }
+  }
 
   const postsQuery = useGetIntentPosts(
     audienceId ?? '',
@@ -153,6 +165,7 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory, embedded =
 
   useEffect(() => {
     setShowPosts(false)
+    setShowPatterns(false)
   }, [theme?.id, intentCategory])
 
   const isIntentTheme = !!intentCategory
@@ -185,15 +198,20 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory, embedded =
 
             <div className="flex flex-wrap justify-end gap-2 mb-6">
               <Button
-                variant="primary"
+                variant={showPosts ? 'primary' : 'outline'}
                 size="sm"
                 className="gap-1.5"
-                onClick={isIntentTheme ? () => setShowPosts(!showPosts) : undefined}
+                onClick={isIntentTheme ? () => { setShowPosts(!showPosts); setShowPatterns(false) } : undefined}
               >
                 <Search className="w-3.5 h-3.5" />
                 {t('themes.browseAll')}
               </Button>
-              <Button variant="outline" size="sm" className="gap-1.5">
+              <Button
+                variant={showPatterns ? 'primary' : 'outline'}
+                size="sm"
+                className="gap-1.5"
+                onClick={isIntentTheme ? () => { setShowPatterns(!showPatterns); setShowPosts(false) } : undefined}
+              >
                 <Sparkles className="w-3.5 h-3.5" />
                 {t('themes.patterns')}
               </Button>
@@ -237,7 +255,7 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory, embedded =
               </div>
             )}
 
-            <div className="grid grid-cols-3 gap-4">
+            {!showPatterns && <div className="grid grid-cols-3 gap-4">
               {/* Subcategories */}
               <div>
                 <div className="flex items-center gap-2 mb-3">
@@ -329,7 +347,7 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory, embedded =
                   ))}
                 </ul>
               </div>
-            </div>
+            </div>}
 
             {showPosts && isIntentTheme && (
               <div className="mt-6">
@@ -369,6 +387,14 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory, embedded =
                   </p>
                 )}
               </div>
+            )}
+
+            {showPatterns && isIntentTheme && (
+              <PainPatternsSection
+                patterns={theme.painPatterns ?? []}
+                onRefresh={handleRefreshPatterns}
+                isRefreshing={refreshIntentsMutation.isPending}
+              />
             )}
           </>
         )}

--- a/src/components/audiences/detail/index.ts
+++ b/src/components/audiences/detail/index.ts
@@ -66,3 +66,6 @@ export type { ContentSuggestionDrawerProps } from './ContentSuggestionDrawer'
 
 export { ContentSuggestionsTabContent } from './ContentSuggestionsTabContent'
 export type { ContentSuggestionsTabContentProps } from './ContentSuggestionsTabContent'
+
+export { PainPatternsSection } from './PainPatternsSection'
+export type { PainPatternsSectionProps } from './PainPatternsSection'

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -131,6 +131,14 @@
     "panel": {
       "generating": "Generating panel data..."
     },
+    "painPatterns": {
+      "title": "Patterns",
+      "empty": "No patterns identified for this category.",
+      "generate": "Generate Patterns",
+      "generating": "Analyzing...",
+      "bookmark": "Bookmark {{count}} submissions",
+      "browse": "Browse {{count}} submissions"
+    },
     "intents": {
       "advice_request": "Advice Requests",
       "advice_request_desc": "People asking for advice & resources",

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -131,6 +131,14 @@
     "panel": {
       "generating": "Gerando dados do painel..."
     },
+    "painPatterns": {
+      "title": "Padrões",
+      "empty": "Nenhum padrão identificado para esta categoria.",
+      "generate": "Gerar Padrões",
+      "generating": "Analisando...",
+      "bookmark": "Salvar {{count}} submissions",
+      "browse": "Explorar {{count}} submissions"
+    },
     "intents": {
       "advice_request": "Pedidos de Conselho",
       "advice_request_desc": "Pessoas pedindo conselhos e recursos",

--- a/src/modules/audience/domain/entities/IntentCategory.entity.ts
+++ b/src/modules/audience/domain/entities/IntentCategory.entity.ts
@@ -9,6 +9,24 @@ export interface IntentSubreddit {
   count: number
 }
 
+export interface PainPatternSubmission {
+  title: string
+  body: string
+  subreddit: string
+  score: number
+  numComments: number
+  permalink: string
+}
+
+export interface PainPattern {
+  name: string
+  emoji: string
+  postCount: number
+  totalUpvotes: number
+  totalComments: number
+  submissions: PainPatternSubmission[]
+}
+
 interface IntentCategoryProps {
   category: string
   label: string
@@ -20,6 +38,7 @@ interface IntentCategoryProps {
   topicKeywords: Record<string, number>
   topSubreddits: IntentSubreddit[]
   samplePosts: IntentSamplePost[]
+  painPatterns: PainPattern[]
   rank: number
 }
 
@@ -34,9 +53,10 @@ export class IntentCategory {
   private readonly topicKeywords: Record<string, number>
   private readonly topSubreddits: IntentSubreddit[]
   private readonly samplePosts: IntentSamplePost[]
+  private readonly painPatterns: PainPattern[]
   private readonly rank: number
 
-  constructor({ category, label, icon, postCount, percentage, description, subcategories, topicKeywords, topSubreddits, samplePosts, rank }: IntentCategoryProps) {
+  constructor({ category, label, icon, postCount, percentage, description, subcategories, topicKeywords, topSubreddits, samplePosts, painPatterns, rank }: IntentCategoryProps) {
     this.category = category
     this.label = label
     this.icon = icon
@@ -47,6 +67,7 @@ export class IntentCategory {
     this.topicKeywords = topicKeywords
     this.topSubreddits = topSubreddits
     this.samplePosts = samplePosts
+    this.painPatterns = painPatterns
     this.rank = rank
   }
 
@@ -88,6 +109,10 @@ export class IntentCategory {
 
   getSamplePosts(): IntentSamplePost[] {
     return this.samplePosts
+  }
+
+  getPainPatterns(): PainPattern[] {
+    return this.painPatterns
   }
 
   getRank(): number {

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -420,6 +420,21 @@ interface IntentAnalysisApiResponse {
     topic_keywords: Record<string, number>
     top_subreddits: Array<{ name: string; count: number }>
     sample_posts: Array<{ title: string; subreddit: string; score: number }>
+    pain_patterns?: Array<{
+      name: string
+      emoji: string
+      post_count: number
+      total_upvotes: number
+      total_comments: number
+      submissions: Array<{
+        title: string
+        body: string
+        subreddit: string
+        score: number
+        num_comments: number
+        permalink: string
+      }>
+    }>
     rank: number
   }>
   message?: string
@@ -1163,6 +1178,21 @@ export class AudienceRepository implements IAudienceRepository {
           title: p.title,
           subreddit: p.subreddit,
           score: p.score,
+        })),
+        painPatterns: (i.pain_patterns ?? []).map((pp) => ({
+          name: pp.name,
+          emoji: pp.emoji,
+          postCount: pp.post_count,
+          totalUpvotes: pp.total_upvotes,
+          totalComments: pp.total_comments,
+          submissions: pp.submissions.map((s) => ({
+            title: s.title,
+            body: s.body,
+            subreddit: s.subreddit,
+            score: s.score,
+            numComments: s.num_comments,
+            permalink: s.permalink,
+          })),
         })),
         rank: i.rank,
       })),


### PR DESCRIPTION
## Descrição

Implementa a exibição dos **padrões de dor (pain patterns)** retornados pelo backend (Issue #84 backend) na interface do frontend. O campo `pain_patterns` já é retornado pelo endpoint `GET /audiences/{id}/themes/intents?window=week` dentro da categoria `pain_and_anger`.

## O que foi implementado

### Camada de Domínio
- Tipos `PainPattern` e `PainPatternSubmission` na entidade `IntentCategory`
- Campo `painPatterns: PainPattern[]` com getter

### Camada de Infraestrutura
- Mapeamento `pain_patterns` da API (snake_case → camelCase) no repository

### Componente UI — PainPatternsSection
- Cards colapsáveis para cada padrão de dor
- **Fechado**: post_count, chevron, emoji, nome do padrão, upvotes e comments, lista de títulos
- **Aberto**: submissions completas com body, score, comments, subreddit, link externo para Reddit
- Botões de ação: "Bookmark N submissions" e "Browse N submissions"
- Estado vazio com botão "Gerar Padrões" que dispara refresh de intents

### Integração no ThemeDetailPanel
- Botão "Padrões" funcional com toggle para todas as categorias de intent
- Esconde subcategorias/tópicos/subreddits quando padrões está ativo
- Toggle mutuamente exclusivo com "Browse All"

### Traduções i18n
- Chaves em EN e PT-BR para labels de pain patterns

## Arquivos

### Criado (1)
- `src/components/audiences/detail/PainPatternsSection.tsx`

### Modificados (7)
- `src/modules/audience/domain/entities/IntentCategory.entity.ts`
- `src/modules/audience/infra/repositories/audience.repository.ts`
- `src/components/audiences/detail/ThemeDetailPanel.tsx`
- `src/components/audiences/detail/AudienceDetailTabs.tsx`
- `src/components/audiences/detail/index.ts`
- `src/locales/en/audiences.json`
- `src/locales/pt-BR/audiences.json`

## Plano de teste

- [ ] Clicar em "Padrões" em qualquer categoria de intent → seção de padrões aparece, grid de subcategorias/tópicos/subreddits some
- [ ] Clicar novamente em "Padrões" → volta ao estado padrão (grid visível)
- [ ] Toggle mutuamente exclusivo com "Browse All"
- [ ] Estado vazio exibe mensagem + botão "Gerar Padrões"
- [ ] Botão "Gerar Padrões" dispara refresh de intents com loading
- [ ] Cards colapsáveis expandem/recolhem ao clicar
- [ ] Links externos abrem Reddit em nova aba
- [ ] Traduções EN e PT-BR funcionando
- [ ] Build sem erros (`npm run build`)

Closes #92