### PR TITLE
chore: remove unused placeholder pages and navigation entries

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -2,14 +2,7 @@ import { useEffect, useRef } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'
 import {
   Home,
-  FileText,
   Package,
-  Briefcase,
-  ShoppingBag,
-  Clock,
-  User,
-  Link2,
-  Smartphone,
   Bell,
   Settings,
   HelpCircle,
@@ -22,14 +15,7 @@ import { useLogout } from '@/modules/auth'
 
 const navItems = [
   { icon: Home, path: '/dashboard', label: 'Dashboard' },
-  { icon: FileText, path: '/orders', label: 'Orders' },
   { icon: Package, path: '/audiences', label: 'Audiences' },
-  { icon: Briefcase, path: '/campaigns', label: 'Campaigns' },
-  { icon: ShoppingBag, path: '/cart', label: 'Cart' },
-  { icon: Clock, path: '/analytics', label: 'Analytics' },
-  { icon: User, path: '/customers', label: 'Customers' },
-  { icon: Link2, path: '/integrations', label: 'Integrations' },
-  { icon: Smartphone, path: '/mobile', label: 'Mobile' },
   { icon: Bell, path: '/notifications', label: 'Notifications' },
 ]
 

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate, NavLink } from 'react-router-dom'
 import {
   Bell, Sun, Moon, Plus, ChevronDown, User, LogOut, Settings, HelpCircle, Menu,
-  Home, FileText, Package, Briefcase, ShoppingBag, Clock, Link2, Smartphone,
+  Home, Package,
 } from 'lucide-react'
 import { gsap } from '@/lib/gsap'
 import { Button, Input, Avatar } from '@/components/ui'
@@ -25,27 +25,13 @@ import { useReducedMotion } from '@/hooks'
 
 const mobileNavItems = [
   { icon: Home, path: '/dashboard', label: 'Dashboard' },
-  { icon: FileText, path: '/orders', label: 'Orders' },
   { icon: Package, path: '/audiences', label: 'Audiences' },
-  { icon: Briefcase, path: '/campaigns', label: 'Campaigns' },
-  { icon: ShoppingBag, path: '/cart', label: 'Cart' },
-  { icon: Clock, path: '/analytics', label: 'Analytics' },
-  { icon: User, path: '/customers', label: 'Customers' },
-  { icon: Link2, path: '/integrations', label: 'Integrations' },
-  { icon: Smartphone, path: '/mobile', label: 'Mobile' },
   { icon: Bell, path: '/notifications', label: 'Notifications' },
 ]
 
 const pageNames: Record<string, string> = {
   '/dashboard': 'Dashboard',
-  '/orders': 'Orders',
   '/audiences': 'Audiences',
-  '/campaigns': 'Campaigns',
-  '/cart': 'Cart',
-  '/analytics': 'Analytics',
-  '/customers': 'Customers',
-  '/integrations': 'Integrations',
-  '/mobile': 'Mobile',
   '/settings': 'Settings',
   '/help': 'Help',
   '/profile': 'Profile',

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -98,14 +98,6 @@ const router = createBrowserRouter([
         ),
       },
       {
-        path: 'orders',
-        element: (
-          <Suspense fallback={<PageLoader />}>
-            <Placeholder />
-          </Suspense>
-        ),
-      },
-      {
         path: 'audiences',
         element: (
           <Suspense fallback={<PageLoader />}>
@@ -118,54 +110,6 @@ const router = createBrowserRouter([
         element: (
           <Suspense fallback={<PageLoader />}>
             <AudienceDetail />
-          </Suspense>
-        ),
-      },
-      {
-        path: 'campaigns',
-        element: (
-          <Suspense fallback={<PageLoader />}>
-            <Placeholder />
-          </Suspense>
-        ),
-      },
-      {
-        path: 'cart',
-        element: (
-          <Suspense fallback={<PageLoader />}>
-            <Placeholder />
-          </Suspense>
-        ),
-      },
-      {
-        path: 'analytics',
-        element: (
-          <Suspense fallback={<PageLoader />}>
-            <Placeholder />
-          </Suspense>
-        ),
-      },
-      {
-        path: 'customers',
-        element: (
-          <Suspense fallback={<PageLoader />}>
-            <Placeholder />
-          </Suspense>
-        ),
-      },
-      {
-        path: 'integrations',
-        element: (
-          <Suspense fallback={<PageLoader />}>
-            <Placeholder />
-          </Suspense>
-        ),
-      },
-      {
-        path: 'mobile',
-        element: (
-          <Suspense fallback={<PageLoader />}>
-            <Placeholder />
           </Suspense>
         ),
       },


### PR DESCRIPTION
## Summary

- Remove 7 placeholder routes: `/campaigns`, `/orders`, `/cart`, `/analytics`, `/customers`, `/integrations`, `/mobile`
- Remove corresponding sidebar and mobile menu navigation items
- Clean up unused Lucide icon imports (`FileText`, `Briefcase`, `ShoppingBag`, `Clock`, `User`, `Link2`, `Smartphone`)
- Navigation now shows only: Dashboard, Audiences, Notifications (+ Settings/Help in bottom)

## Test plan

- [ ] Verify sidebar shows only Dashboard, Audiences, Notifications, Settings, Help, Logout
- [ ] Verify mobile menu (hamburger) shows the same reduced set
- [ ] Verify page title in topbar renders correctly for remaining pages
- [ ] Verify navigating to a removed path (e.g. `/campaigns`) shows the Not Found page
- [ ] `npm run build` passes without errors