### PR TITLE
feat: display thread insights on pain and solution pattern cards

### DIFF
--- a/src/components/audiences/detail/PainPatternsSection.tsx
+++ b/src/components/audiences/detail/PainPatternsSection.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronRight, ChevronDown, ArrowUp, MessageCircle, ExternalLink, Bookmark, FileText, RefreshCw, Loader2 } from 'lucide-react'
+import { ChevronRight, ChevronDown, ArrowUp, MessageCircle, ExternalLink, Bookmark, FileText, RefreshCw, Loader2, Lightbulb, Star } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import type { PainPattern } from '@/modules/audience/domain/entities/IntentCategory.entity'
+import { Badge } from '@/components/ui/badge'
+import type { PainPattern, SubmissionTopComment } from '@/modules/audience/domain/entities/IntentCategory.entity'
 
 export interface PainPatternsSectionProps {
   patterns: PainPattern[]
+  intentCategory?: string | null
   onRefresh?: () => void
   isRefreshing?: boolean
 }
@@ -15,6 +17,67 @@ function formatNumber(num: number): string {
     return `${(num / 1000).toFixed(num >= 10000 ? 0 : 1).replace(/\.0$/, '')}k`
   }
   return num.toLocaleString()
+}
+
+const validationBadgeVariant = {
+  high: 'success',
+  medium: 'warning',
+  low: 'neutral',
+} as const
+
+const consensusBadgeVariant = {
+  strong: 'success',
+  moderate: 'info',
+  weak: 'neutral',
+  divided: 'warning',
+} as const
+
+function SubmissionComments({ comments }: Readonly<{ comments: SubmissionTopComment[] }>) {
+  const { t } = useTranslation('audiences')
+  const [showComments, setShowComments] = useState(false)
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          setShowComments(!showComments)
+        }}
+        className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
+      >
+        <MessageCircle className="w-3 h-3" />
+        {showComments
+          ? t('themes.painPatterns.hideComments')
+          : t('themes.painPatterns.showComments', { count: comments.length })
+        }
+        {showComments
+          ? <ChevronDown className="w-3 h-3" />
+          : <ChevronRight className="w-3 h-3" />
+        }
+      </button>
+      {showComments && (
+        <div className="mt-2 space-y-2 pl-3 border-l-2 border-gray-200 dark:border-zinc-700">
+          {comments.map((comment, idx) => (
+            <div key={idx} className="text-xs">
+              <div className="flex items-center gap-2 mb-0.5">
+                <span className="font-medium text-gray-700 dark:text-zinc-300">
+                  u/{comment.author}
+                </span>
+                <span className="flex items-center gap-0.5 text-gray-400 dark:text-zinc-500">
+                  <ArrowUp className="w-2.5 h-2.5" />
+                  {comment.score}
+                </span>
+              </div>
+              <p className="text-gray-600 dark:text-zinc-400 leading-relaxed line-clamp-3">
+                {comment.body}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }
 
 function PainPatternCard({ pattern }: Readonly<{ pattern: PainPattern }>) {
@@ -40,10 +103,22 @@ function PainPatternCard({ pattern }: Readonly<{ pattern: PainPattern }>) {
           </div>
           <div className="flex-1 min-w-0">
             <div className="flex items-center justify-between gap-2">
-              <h5 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
-                <span className="mr-1.5">{pattern.emoji}</span>
-                {pattern.name}
-              </h5>
+              <div className="flex items-center gap-2 min-w-0">
+                <h5 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+                  <span className="mr-1.5">{pattern.emoji}</span>
+                  {pattern.name}
+                </h5>
+                {pattern.validationScore && (
+                  <Badge variant={validationBadgeVariant[pattern.validationScore]} size="sm">
+                    {t(`themes.painPatterns.validation${pattern.validationScore.charAt(0).toUpperCase()}${pattern.validationScore.slice(1)}`)}
+                  </Badge>
+                )}
+                {pattern.communityConsensus && (
+                  <Badge variant={consensusBadgeVariant[pattern.communityConsensus]} size="sm">
+                    {t(`themes.painPatterns.consensus${pattern.communityConsensus.charAt(0).toUpperCase()}${pattern.communityConsensus.slice(1)}`)}
+                  </Badge>
+                )}
+              </div>
               <div className="flex items-center gap-3 shrink-0 text-xs text-gray-500 dark:text-zinc-400">
                 <span className="flex items-center gap-1">
                   <ArrowUp className="w-3 h-3" />
@@ -70,6 +145,39 @@ function PainPatternCard({ pattern }: Readonly<{ pattern: PainPattern }>) {
 
       {expanded && (
         <div className="px-4 pb-4">
+          {pattern.suggestedCoping && pattern.suggestedCoping.length > 0 && (
+            <div className="mb-4 pb-3 border-b border-gray-200 dark:border-zinc-700">
+              <h6 className="flex items-center gap-1.5 text-xs font-semibold text-gray-700 dark:text-zinc-300 mb-2">
+                <Lightbulb className="w-3.5 h-3.5" />
+                {t('themes.painPatterns.communitySuggests')}
+              </h6>
+              <ul className="space-y-1">
+                {pattern.suggestedCoping.map((suggestion, idx) => (
+                  <li key={idx} className="text-xs text-gray-600 dark:text-zinc-400 flex items-start gap-1.5">
+                    <span className="text-gray-400 mt-0.5">-</span>
+                    {suggestion}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {pattern.recommendedSolutions && pattern.recommendedSolutions.length > 0 && (
+            <div className="mb-4 pb-3 border-b border-gray-200 dark:border-zinc-700">
+              <h6 className="flex items-center gap-1.5 text-xs font-semibold text-gray-700 dark:text-zinc-300 mb-2">
+                <Star className="w-3.5 h-3.5" />
+                {t('themes.painPatterns.recommendedByCommunity')}
+              </h6>
+              <div className="flex flex-wrap gap-1.5">
+                {pattern.recommendedSolutions.map((solution, idx) => (
+                  <Badge key={idx} variant="lime" size="sm">
+                    {solution}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+
           <div className="border-t border-gray-200 dark:border-zinc-700 pt-4 space-y-4">
             {pattern.submissions.map((sub, i) => (
               <div key={i}>
@@ -105,6 +213,9 @@ function PainPatternCard({ pattern }: Readonly<{ pattern: PainPattern }>) {
                     )}
                   </div>
                 </div>
+                {sub.topComments && sub.topComments.length > 0 && (
+                  <SubmissionComments comments={sub.topComments} />
+                )}
               </div>
             ))}
           </div>

--- a/src/components/audiences/detail/ThemeDetailPanel.tsx
+++ b/src/components/audiences/detail/ThemeDetailPanel.tsx
@@ -412,6 +412,7 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory, embedded =
             {showPatterns && isIntentTheme && (
               <PainPatternsSection
                 patterns={theme.painPatterns ?? []}
+                intentCategory={intentCategory}
                 onRefresh={handleRefreshPatterns}
                 isRefreshing={refreshIntentsMutation.isPending}
               />

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -137,7 +137,18 @@
       "generate": "Generate Patterns",
       "generating": "Analyzing...",
       "bookmark": "Bookmark {{count}} submissions",
-      "browse": "Browse {{count}} submissions"
+      "browse": "Browse {{count}} submissions",
+      "validationHigh": "High validation",
+      "validationMedium": "Medium validation",
+      "validationLow": "Low validation",
+      "consensusStrong": "Strong consensus",
+      "consensusModerate": "Moderate consensus",
+      "consensusWeak": "Weak consensus",
+      "consensusDivided": "Divided opinions",
+      "communitySuggests": "Community suggests",
+      "recommendedByCommunity": "Recommended by community",
+      "showComments": "Show comments ({{count}})",
+      "hideComments": "Hide comments"
     },
     "intents": {
       "advice_request": "Advice Requests",

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -137,7 +137,18 @@
       "generate": "Gerar Padrões",
       "generating": "Analisando...",
       "bookmark": "Salvar {{count}} submissions",
-      "browse": "Explorar {{count}} submissions"
+      "browse": "Explorar {{count}} submissions",
+      "validationHigh": "Alta validação",
+      "validationMedium": "Validação média",
+      "validationLow": "Baixa validação",
+      "consensusStrong": "Consenso forte",
+      "consensusModerate": "Consenso moderado",
+      "consensusWeak": "Consenso fraco",
+      "consensusDivided": "Opiniões divididas",
+      "communitySuggests": "Comunidade sugere",
+      "recommendedByCommunity": "Recomendado pela comunidade",
+      "showComments": "Ver comentários ({{count}})",
+      "hideComments": "Ocultar comentários"
     },
     "intents": {
       "advice_request": "Pedidos de Conselho",

--- a/src/modules/audience/domain/entities/IntentCategory.entity.ts
+++ b/src/modules/audience/domain/entities/IntentCategory.entity.ts
@@ -9,6 +9,12 @@ export interface IntentSubreddit {
   count: number
 }
 
+export interface SubmissionTopComment {
+  body: string
+  score: number
+  author: string
+}
+
 export interface PainPatternSubmission {
   title: string
   body: string
@@ -16,6 +22,7 @@ export interface PainPatternSubmission {
   score: number
   numComments: number
   permalink: string
+  topComments?: SubmissionTopComment[]
 }
 
 export interface PainPattern {
@@ -25,6 +32,10 @@ export interface PainPattern {
   totalUpvotes: number
   totalComments: number
   submissions: PainPatternSubmission[]
+  validationScore?: 'high' | 'medium' | 'low'
+  suggestedCoping?: string[]
+  recommendedSolutions?: string[]
+  communityConsensus?: 'strong' | 'moderate' | 'weak' | 'divided'
 }
 
 interface IntentCategoryProps {

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -507,6 +507,10 @@ interface IntentAnalysisApiResponse {
       post_count: number
       total_upvotes: number
       total_comments: number
+      validation_score?: 'high' | 'medium' | 'low'
+      suggested_coping?: string[]
+      recommended_solutions?: string[]
+      community_consensus?: 'strong' | 'moderate' | 'weak' | 'divided'
       submissions: Array<{
         title: string
         body: string
@@ -514,6 +518,7 @@ interface IntentAnalysisApiResponse {
         score: number
         num_comments: number
         permalink: string
+        top_comments?: Array<{ body: string; score: number; author: string }>
       }>
     }>
     rank: number
@@ -1329,6 +1334,10 @@ export class AudienceRepository implements IAudienceRepository {
           postCount: pp.post_count,
           totalUpvotes: pp.total_upvotes,
           totalComments: pp.total_comments,
+          validationScore: pp.validation_score,
+          suggestedCoping: pp.suggested_coping,
+          recommendedSolutions: pp.recommended_solutions,
+          communityConsensus: pp.community_consensus,
           submissions: pp.submissions.map((s) => ({
             title: s.title,
             body: s.body,
@@ -1336,6 +1345,11 @@ export class AudienceRepository implements IAudienceRepository {
             score: s.score,
             numComments: s.num_comments,
             permalink: s.permalink,
+            topComments: s.top_comments?.map((c) => ({
+              body: c.body,
+              score: c.score,
+              author: c.author,
+            })),
           })),
         })),
         rank: i.rank,


### PR DESCRIPTION
## Summary
- Display `validation_score` and `community_consensus` as badges in pattern card headers
- Show "Community suggests" (coping strategies) and "Recommended by community" (solutions as chips) when cards are expanded
- Add collapsible top Reddit comments within each submission
- Map new optional API fields (`validation_score`, `suggested_coping`, `recommended_solutions`, `community_consensus`, `top_comments`) with snake_case → camelCase conversion
- Add i18n keys for both EN and PT-BR locales
- All new fields are optional — backward-compatible with older analyses

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] Pattern cards render normally for old analyses (without new fields)
- [ ] Validation badge appears for `pain_and_anger` patterns with `validation_score`
- [ ] Consensus badge appears for `solution_request` patterns with `community_consensus`
- [ ] "Community suggests" section shows when `suggested_coping` has items
- [ ] "Recommended by community" chips show when `recommended_solutions` has items
- [ ] "Show comments (N)" toggle works within each submission
- [ ] Verify i18n in both EN and PT-BR

Closes #105