### PR TITLE
feat: add i18n subcategory translations for advice_request and solution_request

### DIFF
--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -113,7 +113,7 @@ function translateWithFallback(t: (key: string) => string, prefix: string, value
 
 function mapIntentToDetail(intent: IntentCategory, t: (key: string) => string): ThemeDetail {
   const subcategories = Object.entries(intent.getSubcategories()).map(([name, count]) => ({
-    name: translateWithFallback(t, 'themes.intents.sentiments', name),
+    name: translateWithFallback(t, 'themes.intents.subcategories', name),
     count,
   }))
   const topics = Object.entries(intent.getTopicKeywords()).map(([name, count]) => ({

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -163,7 +163,7 @@
       "ideas_desc": "People suggesting ideas",
       "news": "News",
       "news_desc": "Conversations about current news & events",
-      "sentiments": {
+      "subcategories": {
         "frustration": "Frustration",
         "concern": "Concern",
         "anxiety": "Anxiety",
@@ -173,7 +173,23 @@
         "sadness": "Sadness",
         "confusion": "Confusion",
         "fear": "Fear",
-        "irritation": "Irritation"
+        "irritation": "Irritation",
+        "tools": "Tools",
+        "automation": "Automation",
+        "templates": "Templates",
+        "frameworks": "Frameworks",
+        "integrations": "Integrations",
+        "platforms": "Platforms",
+        "workflows": "Workflows",
+        "optimization": "Optimization",
+        "career": "Career",
+        "strategy": "Strategy",
+        "beginner": "Beginner",
+        "comparison": "Comparison",
+        "best_practices": "Best Practices",
+        "recommendation": "Recommendation",
+        "troubleshooting": "Troubleshooting",
+        "scaling": "Scaling"
       },
       "keywords": {
         "agency": "Agency",

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -163,7 +163,7 @@
       "ideas_desc": "Pessoas sugerindo ideias",
       "news": "Notícias",
       "news_desc": "Conversas sobre notícias e eventos atuais",
-      "sentiments": {
+      "subcategories": {
         "frustration": "Frustração",
         "concern": "Preocupação",
         "anxiety": "Ansiedade",
@@ -173,7 +173,23 @@
         "sadness": "Tristeza",
         "confusion": "Confusão",
         "fear": "Medo",
-        "irritation": "Irritação"
+        "irritation": "Irritação",
+        "tools": "Ferramentas",
+        "automation": "Automação",
+        "templates": "Modelos",
+        "frameworks": "Frameworks",
+        "integrations": "Integrações",
+        "platforms": "Plataformas",
+        "workflows": "Fluxos de Trabalho",
+        "optimization": "Otimização",
+        "career": "Carreira",
+        "strategy": "Estratégia",
+        "beginner": "Iniciante",
+        "comparison": "Comparação",
+        "best_practices": "Boas Práticas",
+        "recommendation": "Recomendação",
+        "troubleshooting": "Resolução de Problemas",
+        "scaling": "Escalabilidade"
       },
       "keywords": {
         "agency": "Agência",


### PR DESCRIPTION
## Summary
- Rename `sentiments` → `subcategories` in i18n locale keys since the translation prefix applies to all intent categories, not just pain_and_anger emotions
- Add subcategory translations for `solution_request` (tools, automation, templates, frameworks, integrations, platforms, workflows, optimization) in EN and PT-BR
- Add subcategory translations for `advice_request` (career, strategy, beginner, comparison, best_practices, recommendation, troubleshooting, scaling) in EN and PT-BR
- Update `translateWithFallback` reference in `AudienceDetailTabs.tsx`

## Test plan
- [ ] Verify `pain_and_anger` subcategories still display correctly in both languages
- [ ] Verify `solution_request` subcategories display translated names instead of raw keys
- [ ] Verify `advice_request` subcategories display translated names instead of raw keys
- [ ] Switch language to PT-BR and confirm all subcategories are properly translated
- [ ] Run `npm run build` — passes without errors