### PR TITLE
fix: resolve UI bugs, missing i18n keys, and null safety issues

### DIFF
--- a/src/components/audiences/detail/TopicsTable.tsx
+++ b/src/components/audiences/detail/TopicsTable.tsx
@@ -189,8 +189,8 @@ export function TopicsTable({
                   : 'border-gray-200 dark:border-zinc-700 hover:border-lime dark:hover:border-lime'
               }`}
             >
-              <div className="flex items-center gap-2 md:gap-4">
-                <p className="text-sm md:text-base font-semibold text-gray-900 dark:text-white truncate shrink-0">
+              <div className="flex items-center gap-2 md:gap-4 min-w-0">
+                <p className="text-sm md:text-base font-semibold text-gray-900 dark:text-white truncate min-w-0">
                   {topic.name}
                 </p>
 

--- a/src/components/audiences/detail/products/OpportunitiesSection.tsx
+++ b/src/components/audiences/detail/products/OpportunitiesSection.tsx
@@ -7,10 +7,10 @@ export interface OpportunitiesSectionProps {
 }
 
 const TYPE_COLORS: Record<string, string> = {
-  unmet_need: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-  improvement: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
-  new_market: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-  integration: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  unmet_demand: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  declining_product: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+  underserved_niche: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  emerging_trend: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
 }
 
 export function OpportunitiesSection({ opportunities }: Readonly<OpportunitiesSectionProps>) {
@@ -22,7 +22,7 @@ export function OpportunitiesSection({ opportunities }: Readonly<OpportunitiesSe
     <div className="space-y-3">
       <h4 className="text-sm font-semibold text-gray-900 dark:text-white flex items-center gap-2">
         <Lightbulb className="w-4 h-4 text-lime" />
-        {t('productIntelligence.detail.opportunities')}
+        {t('productIntelligence.opportunities.title')}
       </h4>
 
       {opportunities.map((opp) => {
@@ -37,7 +37,7 @@ export function OpportunitiesSection({ opportunities }: Readonly<OpportunitiesSe
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2 mb-1">
                   <span className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${typeColor}`}>
-                    {t(`productIntelligence.opportunityType.${opp.getOpportunityType()}`)}
+                    {t(`productIntelligence.opportunities.type.${opp.getOpportunityType()}`)}
                   </span>
                 </div>
                 <p className="text-sm font-semibold text-gray-900 dark:text-white">
@@ -63,10 +63,10 @@ export function OpportunitiesSection({ opportunities }: Readonly<OpportunitiesSe
 
             <div className="flex items-center gap-4 text-xs text-gray-500 dark:text-zinc-400">
               <span>
-                {t('productIntelligence.demandSignals')}: <strong className="text-gray-700 dark:text-zinc-300">{opp.getDemandSignals()}</strong>
+                {t('productIntelligence.opportunities.demandSignals')}: <strong className="text-gray-700 dark:text-zinc-300">{opp.getDemandSignals()}</strong>
               </span>
               <span>
-                {t('productIntelligence.existingSolutions')}: <strong className="text-gray-700 dark:text-zinc-300">{opp.getExistingSolutionsCount()}</strong>
+                {t('productIntelligence.opportunities.existingSolutions')}: <strong className="text-gray-700 dark:text-zinc-300">{opp.getExistingSolutionsCount()}</strong>
               </span>
             </div>
 

--- a/src/components/audiences/detail/products/ProductDetailPanel.tsx
+++ b/src/components/audiences/detail/products/ProductDetailPanel.tsx
@@ -32,9 +32,10 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
 
   const { data: opportunitiesResult } = useGetProductOpportunities(audienceId, !!product)
 
+  const productName = product?.getNormalizedName() || product?.getProductName() || ''
   const relatedOpportunities = (opportunitiesResult?.opportunities ?? []).filter((opp) =>
     opp.getRelatedProducts().some(
-      (name) => product && name.toLowerCase() === product.getNormalizedName().toLowerCase()
+      (name) => productName && name.toLowerCase() === productName.toLowerCase()
     )
   )
 
@@ -89,10 +90,10 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
             {t(`productIntelligence.category.${product.getCategory()}`)}
           </span>
           <span className={`text-xs px-2 py-0.5 rounded-full ${sentimentColor}`}>
-            {t(`productIntelligence.sentiment.${product.getSentimentLabel()}`)} ({product.getSentimentScore().toFixed(1)})
+            {t(`productIntelligence.sentimentLabel.${product.getSentimentLabel()}`)} ({(product.getSentimentScore() ?? 0).toFixed(1)})
           </span>
           <span className="text-xs text-gray-500 dark:text-zinc-400">
-            {product.getTotalMentions()} {t('productIntelligence.mentions')}
+            {t('productIntelligence.mentions', { count: product.getTotalMentions() })}
           </span>
         </div>
       </div>
@@ -108,7 +109,7 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
                 key={community}
                 className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400"
               >
-                r/{community}
+                {community.startsWith('r/') ? community : `r/${community}`}
               </span>
             ))}
           </div>
@@ -212,7 +213,7 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
                   &ldquo;{ev.quote}&rdquo;
                 </p>
                 <div className="flex items-center gap-2 mt-1.5 text-[10px] text-gray-400 dark:text-zinc-500">
-                  <span>r/{ev.sourceSubreddit}</span>
+                  <span>{ev.sourceSubreddit.startsWith('r/') ? ev.sourceSubreddit : `r/${ev.sourceSubreddit}`}</span>
                   {ev.score > 0 && <span>{ev.score} pts</span>}
                 </div>
               </div>

--- a/src/components/audiences/detail/products/ProductsTabContent.tsx
+++ b/src/components/audiences/detail/products/ProductsTabContent.tsx
@@ -4,11 +4,13 @@ import { Package, AlertCircle, RefreshCw, ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   useGetProductIntelligence,
+  useGetProductOpportunities,
   useTriggerProductIntelligence,
 } from '@/modules/audience/application/hooks'
 import { toast } from '@/hooks/useToast'
 import { ProductsTable } from './ProductsTable'
 import { ProductDetailPanel } from './ProductDetailPanel'
+import { OpportunitiesSection } from './OpportunitiesSection'
 import type { ProductProfile } from '@/modules/audience/domain/entities/ProductProfile.entity'
 
 export interface ProductsTabContentProps {
@@ -18,6 +20,7 @@ export interface ProductsTabContentProps {
 export function ProductsTabContent({ audienceId }: Readonly<ProductsTabContentProps>) {
   const { t } = useTranslation('audiences')
   const { data, isLoading } = useGetProductIntelligence(audienceId, true)
+  const { data: opportunitiesResult } = useGetProductOpportunities(audienceId, data?.status === 'ready')
   const triggerMutation = useTriggerProductIntelligence()
   const [selectedProduct, setSelectedProduct] = useState<ProductProfile | null>(null)
   const [windowDropdownOpen, setWindowDropdownOpen] = useState(false)
@@ -126,21 +129,29 @@ export function ProductsTabContent({ audienceId }: Readonly<ProductsTabContentPr
           </p>
         </div>
       ) : (
-        <div className="flex flex-col md:flex-row gap-4 md:gap-6">
-          <div className="w-full md:w-1/2">
-            <ProductsTable
-              products={products}
-              totalCount={totalProducts}
-              selectedProductId={selectedProduct?.getId() ?? null}
-              onProductSelect={handleProductSelect}
-            />
+        <div className="space-y-6">
+          <div className="flex flex-col md:flex-row gap-4 md:gap-6">
+            <div className="w-full md:w-1/2">
+              <ProductsTable
+                products={products}
+                totalCount={totalProducts}
+                selectedProductId={selectedProduct?.getId() ?? null}
+                onProductSelect={handleProductSelect}
+              />
+            </div>
+            <div className="w-full md:w-1/2">
+              <ProductDetailPanel
+                product={selectedProduct}
+                audienceId={audienceId}
+              />
+            </div>
           </div>
-          <div className="w-full md:w-1/2">
-            <ProductDetailPanel
-              product={selectedProduct}
-              audienceId={audienceId}
-            />
-          </div>
+
+          {(opportunitiesResult?.opportunities?.length ?? 0) > 0 && (
+            <div className="border-t border-gray-200 dark:border-zinc-700 pt-6">
+              <OpportunitiesSection opportunities={opportunitiesResult!.opportunities} />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/audiences/detail/products/ProductsTable.tsx
+++ b/src/components/audiences/detail/products/ProductsTable.tsx
@@ -47,7 +47,7 @@ export function ProductsTable({
       case 'mentions':
         return b.getTotalMentions() - a.getTotalMentions()
       case 'sentiment':
-        return b.getSentimentScore() - a.getSentimentScore()
+        return (b.getSentimentScore() ?? 0) - (a.getSentimentScore() ?? 0)
       case 'name':
         return a.getProductName().localeCompare(b.getProductName())
       default:
@@ -185,7 +185,8 @@ export function ProductsTable({
             const trendColor = trendColorMap[product.getTrendDirection()] ?? 'text-yellow-500'
             const sentimentColor = sentimentColorMap[product.getSentimentLabel()] ?? 'bg-gray-400'
 
-            const sentimentPercent = ((product.getSentimentScore() + 1) / 2) * 100
+            const score = product.getSentimentScore() ?? 0
+            const sentimentPercent = ((score + 1) / 2) * 100
 
             return (
               <button
@@ -221,7 +222,7 @@ export function ProductsTable({
                         />
                       </div>
                       <span className="text-[10px] text-gray-500 dark:text-zinc-400 w-8 text-right">
-                        {product.getSentimentScore().toFixed(1)}
+                        {score.toFixed(1)}
                       </span>
                     </div>
 

--- a/src/components/notifications/NotificationCard.tsx
+++ b/src/components/notifications/NotificationCard.tsx
@@ -50,7 +50,7 @@ export function NotificationCard({ notification, onMarkAsRead, isMarkingRead }: 
               ? 'text-gray-900 dark:text-white'
               : 'text-gray-600 dark:text-zinc-400'
           )}>
-            {notification.getTitle()}
+            {t(`messages.${notification.getTitle()}`, notification.getTitle())}
           </h4>
           {isUnread && (
             <span className="w-2 h-2 rounded-full bg-red-500 flex-shrink-0" />
@@ -58,7 +58,7 @@ export function NotificationCard({ notification, onMarkAsRead, isMarkingRead }: 
         </div>
 
         <p className="text-sm text-gray-500 dark:text-zinc-400 mt-0.5 line-clamp-2">
-          {notification.getMessage()}
+          {t(`messages.${notification.getMessage()}`, notification.getMessage())}
         </p>
 
         {isUnread && onMarkAsRead && (

--- a/src/components/notifications/NotificationDropdown.tsx
+++ b/src/components/notifications/NotificationDropdown.tsx
@@ -46,7 +46,7 @@ function DropdownNotificationItem({ notification, onMarkAsRead, isMarkingRead }:
       </div>
       <div className="flex-1 min-w-0">
         <p className="text-sm truncate text-gray-900 dark:text-white font-medium">
-          {notification.title}
+          {t(`messages.${notification.title}`, notification.title)}
         </p>
         <p className="text-xs text-gray-400 dark:text-zinc-500 mt-0.5">
           {timeAgo}

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -213,7 +213,11 @@
         "platform_update": "Platform Update",
         "tool": "Tool",
         "industry_trend": "Industry Trend",
-        "launch": "Launch"
+        "launch": "Launch",
+        "tool_showcase": "Tool Showcase",
+        "portfolio_showcase": "Portfolio Showcase",
+        "case_study": "Case Study",
+        "open_source": "Open Source"
       },
       "keywords": {
         "agency": "Agency",
@@ -766,6 +770,8 @@
     "reanalyze": "Re-analyze",
     "weekly": "Weekly",
     "monthly": "Monthly",
+    "windowWeek": "Last 7 days",
+    "windowMonth": "Last 30 days",
     "processing": "Analyzing products mentioned by your audience...",
     "processingHelp": "This may take 2-3 minutes. We're extracting products from posts and detecting market opportunities.",
     "failed": "Product analysis failed. Please try again.",

--- a/src/locales/en/notifications.json
+++ b/src/locales/en/notifications.json
@@ -48,5 +48,15 @@
     "markedAsRead": "Notification marked as read",
     "allMarkedAsRead": "All notifications marked as read",
     "error": "Failed to update notification"
+  },
+  "messages": {
+    "theme_panel_complete_title": "Theme Panel Ready",
+    "theme_panel_complete_msg_audience": "Your theme panel analysis is complete.",
+    "theme_panel_failed_title": "Theme Panel Failed",
+    "theme_panel_failed_msg_audience": "Failed to generate the theme panel.",
+    "theme_summary_complete_title": "Theme Summary Ready",
+    "theme_summary_complete_msg_audience": "Your theme summary is ready.",
+    "theme_summary_failed_title": "Theme Summary Failed",
+    "theme_summary_failed_msg_audience": "Failed to generate the theme summary."
   }
 }

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -213,7 +213,11 @@
         "platform_update": "Atualização de Plataforma",
         "tool": "Ferramenta",
         "industry_trend": "Tendência do Setor",
-        "launch": "Lançamento"
+        "launch": "Lançamento",
+        "tool_showcase": "Vitrine de Ferramentas",
+        "portfolio_showcase": "Vitrine de Portfólio",
+        "case_study": "Estudo de Caso",
+        "open_source": "Código Aberto"
       },
       "keywords": {
         "agency": "Agência",
@@ -766,6 +770,8 @@
     "reanalyze": "Re-analisar",
     "weekly": "Semanal",
     "monthly": "Mensal",
+    "windowWeek": "Últimos 7 dias",
+    "windowMonth": "Últimos 30 dias",
     "processing": "Analisando produtos mencionados pela sua audiência...",
     "processingHelp": "Isso pode levar 2-3 minutos. Estamos extraindo produtos dos posts e detectando oportunidades de mercado.",
     "failed": "A análise de produtos falhou. Tente novamente.",

--- a/src/locales/pt-BR/notifications.json
+++ b/src/locales/pt-BR/notifications.json
@@ -48,5 +48,15 @@
     "markedAsRead": "Notificacao marcada como lida",
     "allMarkedAsRead": "Todas as notificacoes marcadas como lidas",
     "error": "Erro ao atualizar notificacao"
+  },
+  "messages": {
+    "theme_panel_complete_title": "Painel de Tema Pronto",
+    "theme_panel_complete_msg_audience": "A analise do painel de tema foi concluida.",
+    "theme_panel_failed_title": "Painel de Tema Falhou",
+    "theme_panel_failed_msg_audience": "Erro ao gerar o painel de tema.",
+    "theme_summary_complete_title": "Resumo de Tema Pronto",
+    "theme_summary_complete_msg_audience": "O resumo do tema esta pronto.",
+    "theme_summary_failed_title": "Resumo de Tema Falhou",
+    "theme_summary_failed_msg_audience": "Erro ao gerar o resumo do tema."
   }
 }

--- a/src/modules/notifications/application/hooks/useNotificationSSE.ts
+++ b/src/modules/notifications/application/hooks/useNotificationSSE.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '@/modules/auth'
 import { toast } from '@/hooks/useToast'
@@ -99,6 +100,7 @@ function invalidateAnalysisQueries(
 
 export function useNotificationSSE() {
   const sseRef = useRef<NotificationSSEService | null>(null)
+  const { t } = useTranslation('notifications')
   const { isAuthenticated } = useAuthStore()
   const queryClient = useQueryClient()
   const incrementUnreadCount = useNotificationStore((state) => state.incrementUnreadCount)
@@ -128,8 +130,8 @@ export function useNotificationSSE() {
 
         const isAlert = notification.getType().startsWith('topic_alert_')
         toast({
-          title: notification.getTitle(),
-          description: notification.getMessage(),
+          title: t(`messages.${notification.getTitle()}`, notification.getTitle()),
+          description: t(`messages.${notification.getMessage()}`, notification.getMessage()),
           variant: isAlert || notification.isSuccess() ? 'success' : 'destructive',
         })
       },


### PR DESCRIPTION
## Summary
- Fix TopicsTable layout overflow (content cut off on left side) by correcting flex shrink behavior
- Add missing i18n translation keys for notifications (theme_panel/theme_summary events), product intelligence (windowWeek/windowMonth), opportunity types, and subcategories
- Fix null safety crash in ProductsTable/ProductDetailPanel when `sentiment_score` is null
- Fix wrong i18n paths for sentiment labels, mentions interpolation, and opportunity section
- Fix duplicated `r/` prefix in communities and evidence quotes
- Fix OpportunitiesSection TYPE_COLORS keys to match actual API values
- Show all product opportunities globally in ProductsTabContent, not only filtered by selected product

## Files changed
- `src/components/audiences/detail/TopicsTable.tsx` — layout overflow fix
- `src/components/audiences/detail/products/ProductsTable.tsx` — null safety for sentiment_score
- `src/components/audiences/detail/products/ProductDetailPanel.tsx` — i18n fixes, null safety, duplicated prefix
- `src/components/audiences/detail/products/OpportunitiesSection.tsx` — TYPE_COLORS and i18n paths
- `src/components/audiences/detail/products/ProductsTabContent.tsx` — show all opportunities
- `src/components/notifications/NotificationCard.tsx` — i18n lookup for notification messages
- `src/components/notifications/NotificationDropdown.tsx` — i18n lookup for notification title
- `src/modules/notifications/application/hooks/useNotificationSSE.ts` — i18n toast messages
- `src/locales/en/audiences.json` — added missing translation keys
- `src/locales/pt-BR/audiences.json` — added missing translation keys
- `src/locales/en/notifications.json` — added messages section
- `src/locales/pt-BR/notifications.json` — added messages section

## Test plan
- [ ] Verify TopicsTable layout renders correctly without overflow
- [ ] Verify notification toasts display translated titles/messages
- [ ] Verify notification dropdown and list show translated content
- [ ] Verify Product Intelligence "Analyze Products" dropdown shows translated window options
- [ ] Verify Products tab loads without crash when products have null sentiment_score
- [ ] Verify ProductDetailPanel shows correct sentiment labels, mentions count, and community prefixes
- [ ] Verify OpportunitiesSection displays with correct type badges and translations
- [ ] Verify all product opportunities are shown globally below the products table
- [ ] Verify subcategory labels render translated text