### PR TITLE
fix: correct product detail API mapping and improve UI

### DIFF
--- a/src/components/audiences/detail/products/ProductDetailPanel.tsx
+++ b/src/components/audiences/detail/products/ProductDetailPanel.tsx
@@ -1,9 +1,6 @@
-import { useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { TrendingUp, TrendingDown, Minus, ThumbsUp, ThumbsDown, AlertTriangle, ArrowRightLeft, Quote, Briefcase, Users } from 'lucide-react'
-import { gsap } from '@/lib/gsap'
-import { useReducedMotion } from '@/hooks'
-import { useGetProductOpportunities } from '@/modules/audience/application/hooks'
+import { TrendingUp, TrendingDown, Minus, ThumbsUp, ThumbsDown, AlertTriangle, ArrowRightLeft, Quote, Briefcase, Users, Info } from 'lucide-react'
+import { useGetProductOpportunities, useGetProductDetail } from '@/modules/audience/application/hooks'
 import { OpportunitiesSection } from './OpportunitiesSection'
 import type { ProductProfile } from '@/modules/audience/domain/entities/ProductProfile.entity'
 
@@ -27,31 +24,29 @@ const TREND_CONFIG: Record<string, { icon: typeof TrendingUp; color: string }> =
 
 export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDetailPanelProps>) {
   const { t } = useTranslation('audiences')
-  const panelRef = useRef<HTMLDivElement>(null)
-  const prefersReducedMotion = useReducedMotion()
+
+  const { data: detailResult, isLoading: isLoadingDetail } = useGetProductDetail(
+    audienceId,
+    product?.getId() ?? '',
+    !!product
+  )
+
+  const detailedProduct = detailResult?.product ?? null
 
   const { data: opportunitiesResult } = useGetProductOpportunities(audienceId, !!product)
 
-  const productName = product?.getNormalizedName() || product?.getProductName() || ''
+  const productNames = [product?.getProductName(), product?.getNormalizedName()]
+    .filter(Boolean)
+    .map((n) => n!.toLowerCase())
+
   const relatedOpportunities = (opportunitiesResult?.opportunities ?? []).filter((opp) =>
-    opp.getRelatedProducts().some(
-      (name) => productName && name.toLowerCase() === productName.toLowerCase()
-    )
-  )
-
-  useEffect(() => {
-    if (!panelRef.current || !product) return
-
-    if (prefersReducedMotion) {
-      gsap.set(panelRef.current, { opacity: 1, x: 0 })
-    } else {
-      gsap.fromTo(
-        panelRef.current,
-        { opacity: 0, x: 30 },
-        { opacity: 1, x: 0, duration: 0.35, ease: 'power3.out' }
+    opp.getRelatedProducts().some((relatedName) => {
+      const relatedLower = relatedName.toLowerCase()
+      return productNames.some(
+        (n) => n === relatedLower || relatedLower.includes(n) || n.includes(relatedLower)
       )
-    }
-  }, [prefersReducedMotion, product])
+    })
+  )
 
   if (!product) {
     return (
@@ -63,48 +58,69 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
     )
   }
 
-  const trendConfig = TREND_CONFIG[product.getTrendDirection()] ?? TREND_CONFIG.stable
+  const displayProduct = detailedProduct ?? product
+
+  const trendConfig = TREND_CONFIG[displayProduct.getTrendDirection()] ?? TREND_CONFIG.stable
   const TrendIcon = trendConfig.icon
-  const sentimentColor = SENTIMENT_COLORS[product.getSentimentLabel()] ?? SENTIMENT_COLORS.neutral
+  const sentimentColor = SENTIMENT_COLORS[displayProduct.getSentimentLabel()] ?? SENTIMENT_COLORS.neutral
 
   return (
-    <div
-      ref={panelRef}
-      className="flex-1 bg-white dark:bg-zinc-900 rounded-2xl p-5 md:p-6 max-h-[900px] overflow-y-auto border border-gray-200 dark:border-zinc-700"
-    >
+    <div className="flex-1 bg-white dark:bg-zinc-900 rounded-2xl p-5 md:p-6 max-h-[900px] overflow-y-auto border border-gray-200 dark:border-zinc-700">
       <div className="mb-5">
         <div className="flex items-start justify-between gap-3 mb-2">
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-            {product.getProductName()}
+            {displayProduct.getProductName()}
           </h3>
           <div className={`flex items-center gap-1 ${trendConfig.color}`}>
             <TrendIcon className="w-4 h-4" />
             <span className="text-xs font-medium">
-              {t(`productIntelligence.trend.${product.getTrendDirection()}`)}
+              {t(`productIntelligence.trend.${displayProduct.getTrendDirection()}`)}
             </span>
           </div>
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-zinc-700 text-gray-600 dark:text-zinc-400">
-            {t(`productIntelligence.category.${product.getCategory()}`)}
+            {t(`productIntelligence.category.${displayProduct.getCategory()}`)}
           </span>
           <span className={`text-xs px-2 py-0.5 rounded-full ${sentimentColor}`}>
-            {t(`productIntelligence.sentimentLabel.${product.getSentimentLabel()}`)} ({(product.getSentimentScore() ?? 0).toFixed(1)})
+            {t(`productIntelligence.sentimentLabel.${displayProduct.getSentimentLabel()}`)} ({(displayProduct.getSentimentScore() ?? 0).toFixed(1)})
           </span>
           <span className="text-xs text-gray-500 dark:text-zinc-400">
-            {t('productIntelligence.mentions', { count: product.getTotalMentions() })}
+            {t('productIntelligence.mentions', { count: displayProduct.getTotalMentions() })}
           </span>
         </div>
       </div>
 
-      {product.getCommunities().length > 0 && (
+      {isLoadingDetail && (
+        <div className="flex items-center justify-center py-8">
+          <div className="w-6 h-6 border-3 border-lime border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+
+      {!isLoadingDetail && displayProduct.getCommunities().length === 0 &&
+        displayProduct.getPositiveAspects().length === 0 &&
+        displayProduct.getNegativeAspects().length === 0 &&
+        displayProduct.getGaps().length === 0 &&
+        displayProduct.getAlternatives().length === 0 &&
+        displayProduct.getUseCases().length === 0 &&
+        displayProduct.getEvidenceQuotes().length === 0 &&
+        relatedOpportunities.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <Info className="w-6 h-6 text-gray-300 dark:text-zinc-600 mb-2" />
+          <p className="text-sm text-gray-400 dark:text-zinc-500">
+            {t('productIntelligence.detail.noData')}
+          </p>
+        </div>
+      )}
+
+      {displayProduct.getCommunities().length > 0 && (
         <DetailSection
           icon={<Users className="w-4 h-4 text-blue-500" />}
           title={t('productIntelligence.detail.communities')}
         >
           <div className="flex flex-wrap gap-1.5">
-            {product.getCommunities().map((community) => (
+            {displayProduct.getCommunities().map((community) => (
               <span
                 key={community}
                 className="text-xs px-2 py-0.5 rounded-full bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400"
@@ -116,13 +132,13 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
         </DetailSection>
       )}
 
-      {product.getPositiveAspects().length > 0 && (
+      {displayProduct.getPositiveAspects().length > 0 && (
         <DetailSection
           icon={<ThumbsUp className="w-4 h-4 text-green-500" />}
           title={t('productIntelligence.detail.positiveAspects')}
         >
           <ul className="space-y-1">
-            {product.getPositiveAspects().map((aspect, i) => (
+            {displayProduct.getPositiveAspects().map((aspect, i) => (
               <li key={i} className="text-xs text-gray-600 dark:text-zinc-400 flex items-start gap-2">
                 <span className="w-1 h-1 rounded-full bg-green-500 mt-1.5 shrink-0" />
                 {aspect}
@@ -132,13 +148,13 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
         </DetailSection>
       )}
 
-      {product.getNegativeAspects().length > 0 && (
+      {displayProduct.getNegativeAspects().length > 0 && (
         <DetailSection
           icon={<ThumbsDown className="w-4 h-4 text-red-500" />}
           title={t('productIntelligence.detail.negativeAspects')}
         >
           <ul className="space-y-1">
-            {product.getNegativeAspects().map((aspect, i) => (
+            {displayProduct.getNegativeAspects().map((aspect, i) => (
               <li key={i} className="text-xs text-gray-600 dark:text-zinc-400 flex items-start gap-2">
                 <span className="w-1 h-1 rounded-full bg-red-500 mt-1.5 shrink-0" />
                 {aspect}
@@ -148,13 +164,13 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
         </DetailSection>
       )}
 
-      {product.getGaps().length > 0 && (
+      {displayProduct.getGaps().length > 0 && (
         <DetailSection
           icon={<AlertTriangle className="w-4 h-4 text-yellow-500" />}
           title={t('productIntelligence.detail.gaps')}
         >
           <ul className="space-y-1">
-            {product.getGaps().map((gap, i) => (
+            {displayProduct.getGaps().map((gap, i) => (
               <li key={i} className="text-xs text-gray-600 dark:text-zinc-400 flex items-start gap-2">
                 <span className="w-1 h-1 rounded-full bg-yellow-500 mt-1.5 shrink-0" />
                 {gap}
@@ -164,13 +180,13 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
         </DetailSection>
       )}
 
-      {product.getAlternatives().length > 0 && (
+      {displayProduct.getAlternatives().length > 0 && (
         <DetailSection
           icon={<ArrowRightLeft className="w-4 h-4 text-purple-500" />}
           title={t('productIntelligence.detail.alternatives')}
         >
           <div className="flex flex-wrap gap-1.5">
-            {product.getAlternatives().map((alt) => {
+            {displayProduct.getAlternatives().map((alt) => {
               const altSentimentColor = SENTIMENT_COLORS[alt.sentimentLabel] ?? SENTIMENT_COLORS.neutral
               return (
                 <span
@@ -185,13 +201,13 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
         </DetailSection>
       )}
 
-      {product.getUseCases().length > 0 && (
+      {displayProduct.getUseCases().length > 0 && (
         <DetailSection
           icon={<Briefcase className="w-4 h-4 text-indigo-500" />}
           title={t('productIntelligence.detail.useCases')}
         >
           <ul className="space-y-1">
-            {product.getUseCases().map((useCase, i) => (
+            {displayProduct.getUseCases().map((useCase, i) => (
               <li key={i} className="text-xs text-gray-600 dark:text-zinc-400 flex items-start gap-2">
                 <span className="w-1 h-1 rounded-full bg-indigo-500 mt-1.5 shrink-0" />
                 {useCase}
@@ -201,13 +217,13 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
         </DetailSection>
       )}
 
-      {product.getEvidenceQuotes().length > 0 && (
+      {displayProduct.getEvidenceQuotes().length > 0 && (
         <DetailSection
           icon={<Quote className="w-4 h-4 text-gray-500 dark:text-zinc-400" />}
           title={t('productIntelligence.detail.evidenceQuotes')}
         >
           <div className="space-y-2">
-            {product.getEvidenceQuotes().slice(0, 5).map((ev, i) => (
+            {displayProduct.getEvidenceQuotes().slice(0, 5).map((ev, i) => (
               <div key={i} className="bg-gray-50 dark:bg-zinc-800 rounded-lg p-3">
                 <p className="text-xs italic text-gray-600 dark:text-zinc-400 line-clamp-3">
                   &ldquo;{ev.quote}&rdquo;
@@ -223,7 +239,7 @@ export function ProductDetailPanel({ product, audienceId }: Readonly<ProductDeta
       )}
 
       {relatedOpportunities.length > 0 && (
-        <div className="mt-5 pt-5 border-t border-gray-200 dark:border-zinc-700">
+        <div className="pt-5 border-t border-gray-200 dark:border-zinc-700">
           <OpportunitiesSection opportunities={relatedOpportunities} />
         </div>
       )}

--- a/src/components/audiences/detail/products/ProductsTabContent.tsx
+++ b/src/components/audiences/detail/products/ProductsTabContent.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Package, AlertCircle, RefreshCw, ChevronDown } from 'lucide-react'
+import { Package, AlertCircle, RefreshCw, ChevronDown, Lightbulb } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   useGetProductIntelligence,
@@ -8,6 +8,7 @@ import {
   useTriggerProductIntelligence,
 } from '@/modules/audience/application/hooks'
 import { toast } from '@/hooks/useToast'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { ProductsTable } from './ProductsTable'
 import { ProductDetailPanel } from './ProductDetailPanel'
 import { OpportunitiesSection } from './OpportunitiesSection'
@@ -24,6 +25,9 @@ export function ProductsTabContent({ audienceId }: Readonly<ProductsTabContentPr
   const triggerMutation = useTriggerProductIntelligence()
   const [selectedProduct, setSelectedProduct] = useState<ProductProfile | null>(null)
   const [windowDropdownOpen, setWindowDropdownOpen] = useState(false)
+  const [opportunitiesOpen, setOpportunitiesOpen] = useState(false)
+
+  const opportunities = opportunitiesResult?.opportunities ?? []
 
   const status = data?.status ?? 'no_analysis'
   const products = data?.products ?? []
@@ -129,7 +133,20 @@ export function ProductsTabContent({ audienceId }: Readonly<ProductsTabContentPr
           </p>
         </div>
       ) : (
-        <div className="space-y-6">
+        <div className="space-y-4">
+          {opportunities.length > 0 && (
+            <button
+              onClick={() => setOpportunitiesOpen(true)}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-gray-700 dark:text-zinc-300 hover:bg-gray-50 dark:hover:bg-zinc-700 transition-colors cursor-pointer"
+            >
+              <Lightbulb className="w-4 h-4 text-lime" />
+              {t('productIntelligence.opportunities.title')}
+              <span className="text-xs font-semibold px-1.5 py-0.5 rounded-full bg-lime text-black">
+                {opportunities.length}
+              </span>
+            </button>
+          )}
+
           <div className="flex flex-col md:flex-row gap-4 md:gap-6">
             <div className="w-full md:w-1/2">
               <ProductsTable
@@ -147,11 +164,19 @@ export function ProductsTabContent({ audienceId }: Readonly<ProductsTabContentPr
             </div>
           </div>
 
-          {(opportunitiesResult?.opportunities?.length ?? 0) > 0 && (
-            <div className="border-t border-gray-200 dark:border-zinc-700 pt-6">
-              <OpportunitiesSection opportunities={opportunitiesResult!.opportunities} />
-            </div>
-          )}
+          <Sheet open={opportunitiesOpen} onOpenChange={setOpportunitiesOpen}>
+            <SheetContent side="right" className="w-full sm:max-w-2xl overflow-y-auto">
+              <SheetHeader>
+                <SheetTitle>{t('productIntelligence.opportunities.title')}</SheetTitle>
+                <SheetDescription className="sr-only">
+                  {t('productIntelligence.opportunities.title')}
+                </SheetDescription>
+              </SheetHeader>
+              <div className="px-6 pb-6">
+                <OpportunitiesSection opportunities={opportunities} />
+              </div>
+            </SheetContent>
+          </Sheet>
         </div>
       )}
     </div>

--- a/src/components/audiences/detail/products/ProductsTable.tsx
+++ b/src/components/audiences/detail/products/ProductsTable.tsx
@@ -178,7 +178,7 @@ export function ProductsTable({
         ))}
       </div>
 
-      <div className="max-h-[900px] overflow-y-auto">
+      <div className="max-h-[600px] overflow-y-auto">
         <div ref={listRef} className="space-y-2">
           {sortedProducts.map((product) => {
             const TrendIcon = trendIconMap[product.getTrendDirection()] ?? Minus

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -817,7 +817,8 @@
       "evidenceQuotes": "Evidence Quotes",
       "useCases": "Use Cases",
       "communities": "Communities",
-      "noData": "No data available"
+      "noData": "No data available",
+      "productDetails": "Product details"
     },
     "opportunities": {
       "title": "Market Opportunities",

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -817,7 +817,8 @@
       "evidenceQuotes": "Citações de Evidência",
       "useCases": "Casos de Uso",
       "communities": "Comunidades",
-      "noData": "Sem dados disponíveis"
+      "noData": "Sem dados disponíveis",
+      "productDetails": "Detalhes do produto"
     },
     "opportunities": {
       "title": "Oportunidades de Mercado",

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -832,22 +832,25 @@ interface TriggerProductIntelligenceApiResponse {
 }
 
 interface ProductDetailApiResponse {
-  id: string
-  product_name: string
-  normalized_name?: string
-  category: string
-  total_mentions: number
-  sentiment_score: number
-  sentiment_label: string
-  trend_direction: string
-  communities?: string[]
-  positive_aspects?: string[]
-  negative_aspects?: string[]
-  gaps?: string[]
-  alternatives?: Array<{ name: string; sentiment_label: string }>
-  evidence_quotes?: Array<{ quote: string; source_subreddit: string; score: number }>
-  use_cases?: string[]
-  created_at?: string
+  status: string
+  product: {
+    id: string
+    product_name: string
+    normalized_name?: string
+    category: string
+    total_mentions: number
+    sentiment_score: number
+    sentiment_label: string
+    trend_direction: string
+    communities?: string[]
+    positive_aspects?: string[]
+    negative_aspects?: string[]
+    gaps?: string[]
+    alternatives?: Array<{ name: string; sentiment_label: string }>
+    evidence_quotes?: Array<{ quote: string; source_subreddit: string; score: number }>
+    use_cases?: string[]
+    created_at?: string
+  } | null
 }
 
 interface ProductOpportunitiesApiResponse {
@@ -2252,35 +2255,36 @@ export class AudienceRepository implements IAudienceRepository {
       `audiences/${params.audienceId}/products/${params.productId}`
     )
 
-    if (!response.id) {
+    const p = response.product
+    if (!p) {
       return { product: null }
     }
 
     return {
       product: new ProductProfile({
-        id: response.id,
-        productName: response.product_name,
-        normalizedName: response.normalized_name ?? '',
-        category: response.category,
-        totalMentions: response.total_mentions,
-        sentimentScore: response.sentiment_score,
-        sentimentLabel: response.sentiment_label,
-        trendDirection: response.trend_direction,
-        communities: response.communities ?? [],
-        positiveAspects: response.positive_aspects ?? [],
-        negativeAspects: response.negative_aspects ?? [],
-        gaps: response.gaps ?? [],
-        alternatives: (response.alternatives ?? []).map((a) => ({
+        id: p.id,
+        productName: p.product_name,
+        normalizedName: p.normalized_name ?? '',
+        category: p.category,
+        totalMentions: p.total_mentions,
+        sentimentScore: p.sentiment_score,
+        sentimentLabel: p.sentiment_label,
+        trendDirection: p.trend_direction,
+        communities: p.communities ?? [],
+        positiveAspects: p.positive_aspects ?? [],
+        negativeAspects: p.negative_aspects ?? [],
+        gaps: p.gaps ?? [],
+        alternatives: (p.alternatives ?? []).map((a) => ({
           name: a.name,
           sentimentLabel: a.sentiment_label,
         })),
-        evidenceQuotes: (response.evidence_quotes ?? []).map((e) => ({
+        evidenceQuotes: (p.evidence_quotes ?? []).map((e) => ({
           quote: e.quote,
           sourceSubreddit: e.source_subreddit,
           score: e.score,
         })),
-        useCases: response.use_cases ?? [],
-        createdAt: response.created_at ?? null,
+        useCases: p.use_cases ?? [],
+        createdAt: p.created_at ?? null,
       }),
     }
   }


### PR DESCRIPTION
## Summary
- Fix `ProductDetailApiResponse` to match actual API response format (`{ status, product: {...} }` wrapper instead of flat root fields)
- Use `useGetProductDetail` hook in `ProductDetailPanel` to fetch complete product data (positive_aspects, negative_aspects, gaps, alternatives, evidence_quotes, use_cases) from `GET /products/{product_id}`
- Move market opportunities to a Sheet drawer with trigger button for better visibility
- Add loading spinner and empty state fallback to detail panel
- Improve opportunity-to-product matching with flexible name comparison (includes-based)

## Test plan
- [ ] Select a product in the list — detail panel should show loading spinner, then full data (positive aspects, gaps, alternatives, use cases, evidence quotes)
- [ ] Verify Network tab shows `GET /audiences/{id}/products/{product_id}` returning complete data
- [ ] Click "Market Opportunities" button — drawer opens with all opportunities
- [ ] Verify products with no detail data show "No data available" fallback
- [ ] Test dark mode and mobile responsive layout