### PR TITLE
fix: correct YouTube Validation mapping and display

### DIFF
--- a/src/components/audiences/detail/AudienceDetailTabs.tsx
+++ b/src/components/audiences/detail/AudienceDetailTabs.tsx
@@ -421,7 +421,7 @@ export function AudienceDetailTabs({
       </TabsContent>
 
       <TabsContent value="youtube" className="mt-6">
-        <YouTubeValidationTabContent audienceId={audienceId} />
+        <YouTubeValidationTabContent audienceId={audienceId} hasTopicsReady={totalTopics > 0} />
       </TabsContent>
 
       <TabsContent value="products" className="mt-6">

--- a/src/components/audiences/detail/youtube-validation/CrossPlatformSummarySection.tsx
+++ b/src/components/audiences/detail/youtube-validation/CrossPlatformSummarySection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { BarChart3, TrendingUp, Lightbulb } from 'lucide-react'
+import { BarChart3, TrendingUp, Lightbulb, AlertTriangle, Rocket } from 'lucide-react'
 import type { ValidationSummary, CrossPlatformSummary } from '@/modules/audience/domain/entities/YouTubeValidation.entity'
 
 export interface CrossPlatformSummarySectionProps {
@@ -14,7 +14,7 @@ export function CrossPlatformSummarySection({ summary, crossPlatform }: Readonly
     { label: t('youtubeValidation.summary.topicsAnalyzed'), value: summary.topicsAnalyzed },
     { label: t('youtubeValidation.summary.topicsWithTraction'), value: summary.topicsWithYoutubeTraction },
     { label: t('youtubeValidation.summary.contentGaps'), value: summary.contentGapsFound },
-    { label: t('youtubeValidation.summary.avgTraction'), value: `${(summary.avgTractionScore * 100).toFixed(0)}%` },
+    { label: t('youtubeValidation.summary.avgTraction'), value: `${summary.avgTractionScore.toFixed(1)}/10` },
     { label: t('youtubeValidation.summary.videosAnalyzed'), value: summary.totalVideosAnalyzed },
     { label: t('youtubeValidation.summary.commentsAnalyzed'), value: summary.totalCommentsAnalyzed },
   ]
@@ -26,6 +26,13 @@ export function CrossPlatformSummarySection({ summary, crossPlatform }: Readonly
           <BarChart3 className="w-4 h-4 text-lime" />
           {t('youtubeValidation.summary.title')}
         </h4>
+
+        {/* Headline */}
+        {summary.headline && (
+          <p className="text-sm text-gray-700 dark:text-zinc-300 mb-4 font-medium">
+            {summary.headline}
+          </p>
+        )}
 
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
           {metrics.map((metric) => (
@@ -73,6 +80,40 @@ export function CrossPlatformSummarySection({ summary, crossPlatform }: Readonly
             </div>
           )}
         </div>
+
+        {/* Key Opportunities */}
+        {summary.keyOpportunities.length > 0 && (
+          <div className="mt-4 space-y-2">
+            <h5 className="text-xs font-medium text-gray-700 dark:text-zinc-300 flex items-center gap-1.5">
+              <Rocket className="w-3.5 h-3.5 text-green-500" />
+              {t('youtubeValidation.summary.keyOpportunities')}
+            </h5>
+            <ul className="space-y-1">
+              {summary.keyOpportunities.map((opp) => (
+                <li key={opp} className="text-xs text-gray-600 dark:text-zinc-400 pl-5 relative before:content-['•'] before:absolute before:left-1.5 before:text-green-400">
+                  {opp}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Risk Factors */}
+        {summary.riskFactors.length > 0 && (
+          <div className="mt-4 space-y-2">
+            <h5 className="text-xs font-medium text-gray-700 dark:text-zinc-300 flex items-center gap-1.5">
+              <AlertTriangle className="w-3.5 h-3.5 text-red-400" />
+              {t('youtubeValidation.summary.riskFactors')}
+            </h5>
+            <ul className="space-y-1">
+              {summary.riskFactors.map((risk) => (
+                <li key={risk} className="text-xs text-gray-600 dark:text-zinc-400 pl-5 relative before:content-['•'] before:absolute before:left-1.5 before:text-red-400">
+                  {risk}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/audiences/detail/youtube-validation/TopicAnalysisAccordion.tsx
+++ b/src/components/audiences/detail/youtube-validation/TopicAnalysisAccordion.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, ChevronRight, TrendingUp, Eye } from 'lucide-react'
+import { ChevronDown, ChevronRight, TrendingUp, Eye, AlertTriangle, Info } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import type { TopicAnalysis } from '@/modules/audience/domain/entities/YouTubeValidation.entity'
 import { TopicVideosSection } from './TopicVideosSection'
@@ -15,7 +15,7 @@ export function TopicAnalysisAccordion({ topic, audienceId }: Readonly<TopicAnal
   const [isExpanded, setIsExpanded] = useState(false)
   const [showVideos, setShowVideos] = useState(false)
 
-  const tractionPercent = (topic.tractionScore * 100).toFixed(0)
+  const tractionDisplay = topic.tractionScore.toFixed(1)
 
   return (
     <div className="border border-gray-200 dark:border-zinc-700 rounded-xl overflow-hidden">
@@ -38,18 +38,26 @@ export function TopicAnalysisAccordion({ topic, audienceId }: Readonly<TopicAnal
               ? t('youtubeValidation.topic.contentGap')
               : topic.contentSaturated
                 ? t('youtubeValidation.topic.contentSaturated')
-                : `${tractionPercent}%`
+                : `${tractionDisplay}/10`
             }
           </Badge>
           <div className="flex items-center gap-1 text-xs text-gray-500 dark:text-zinc-400">
             <TrendingUp className="w-3 h-3" />
-            {tractionPercent}%
+            {tractionDisplay}/10
           </div>
         </div>
       </button>
 
       {isExpanded && (
         <div className="px-4 pb-4 space-y-4">
+          {/* Content Gap Detail */}
+          {topic.contentGap && topic.contentGapDetail && (
+            <div className="bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-900/30 rounded-lg p-3 flex gap-2">
+              <Info className="w-3.5 h-3.5 text-amber-500 mt-0.5 shrink-0" />
+              <p className="text-xs text-amber-700 dark:text-amber-300">{topic.contentGapDetail}</p>
+            </div>
+          )}
+
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             {/* Sentiment Comparison */}
             <div className="bg-gray-50 dark:bg-zinc-800 rounded-lg p-3">
@@ -72,6 +80,14 @@ export function TopicAnalysisAccordion({ topic, audienceId }: Readonly<TopicAnal
                   </Badge>
                 </div>
               </div>
+
+              {/* Sentiment Divergence Explanation */}
+              {topic.sentimentComparison.divergence && (
+                <div className="mt-2 pt-2 border-t border-gray-200 dark:border-zinc-700 flex gap-1.5">
+                  <AlertTriangle className="w-3 h-3 text-amber-500 mt-0.5 shrink-0" />
+                  <p className="text-xs text-gray-600 dark:text-zinc-400">{topic.sentimentComparison.divergence}</p>
+                </div>
+              )}
             </div>
 
             {/* Metrics */}
@@ -79,11 +95,11 @@ export function TopicAnalysisAccordion({ topic, audienceId }: Readonly<TopicAnal
               <div className="space-y-2">
                 <div className="flex items-center justify-between text-xs">
                   <span className="text-gray-500 dark:text-zinc-400">{t('youtubeValidation.topic.tractionScore')}</span>
-                  <span className="font-medium text-gray-900 dark:text-white">{tractionPercent}%</span>
+                  <span className="font-medium text-gray-900 dark:text-white">{tractionDisplay}/10</span>
                 </div>
                 <div className="flex items-center justify-between text-xs">
                   <span className="text-gray-500 dark:text-zinc-400">{t('youtubeValidation.topic.audienceOverlap')}</span>
-                  <span className="font-medium text-gray-900 dark:text-white">{(topic.audienceOverlapScore * 100).toFixed(0)}%</span>
+                  <span className="font-medium text-gray-900 dark:text-white">{topic.audienceOverlapScore.toFixed(1)}/10</span>
                 </div>
                 {topic.productMentions.length > 0 && (
                   <div className="text-xs">
@@ -100,12 +116,18 @@ export function TopicAnalysisAccordion({ topic, audienceId }: Readonly<TopicAnal
           </div>
 
           {/* Opportunity Insights */}
-          {topic.opportunityInsights && (
+          {topic.opportunityInsights.length > 0 && (
             <div className="bg-lime/5 border border-lime/20 rounded-lg p-3">
               <p className="text-xs font-medium text-lime-700 dark:text-lime-400 mb-1">
                 {t('youtubeValidation.topic.opportunityInsights')}
               </p>
-              <p className="text-xs text-gray-600 dark:text-zinc-400">{topic.opportunityInsights}</p>
+              <ul className="space-y-1">
+                {topic.opportunityInsights.map((insight) => (
+                  <li key={insight} className="text-xs text-gray-600 dark:text-zinc-400 pl-4 relative before:content-['•'] before:absolute before:left-0.5 before:text-lime-500">
+                    {insight}
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
 

--- a/src/components/audiences/detail/youtube-validation/YouTubeValidationTabContent.tsx
+++ b/src/components/audiences/detail/youtube-validation/YouTubeValidationTabContent.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Youtube, AlertCircle, RefreshCw } from 'lucide-react'
+import { Youtube, AlertCircle, RefreshCw, Info } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
   useGetYouTubeValidation,
@@ -12,15 +11,18 @@ import { TopicAnalysisAccordion } from './TopicAnalysisAccordion'
 
 export interface YouTubeValidationTabContentProps {
   audienceId: string
+  hasTopicsReady: boolean
 }
 
-export function YouTubeValidationTabContent({ audienceId }: Readonly<YouTubeValidationTabContentProps>) {
+export function YouTubeValidationTabContent({ audienceId, hasTopicsReady }: Readonly<YouTubeValidationTabContentProps>) {
   const { t } = useTranslation('audiences')
   const { data, isLoading } = useGetYouTubeValidation(audienceId, true)
   const triggerMutation = useTriggerYouTubeValidation()
 
   const status = data?.status ?? 'no_analysis'
   const validation = data?.data ?? null
+
+  const canTrigger = hasTopicsReady && !triggerMutation.isPending && status !== 'processing'
 
   const handleTrigger = (force = false) => {
     triggerMutation.mutate({ audienceId, force }, {
@@ -44,7 +46,7 @@ export function YouTubeValidationTabContent({ audienceId }: Readonly<YouTubeVali
 
         <button
           onClick={() => handleTrigger(status === 'ready' || status === 'failed')}
-          disabled={triggerMutation.isPending || status === 'processing'}
+          disabled={!canTrigger}
           className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-[#FF0000] text-white hover:bg-[#CC0000] transition-colors cursor-pointer disabled:opacity-50"
         >
           {(triggerMutation.isPending || status === 'processing') ? (
@@ -55,6 +57,16 @@ export function YouTubeValidationTabContent({ audienceId }: Readonly<YouTubeVali
           {t('youtubeValidation.startValidation')}
         </button>
       </div>
+
+      {/* Prerequisite warning */}
+      {!hasTopicsReady && status === 'no_analysis' && (
+        <div className="bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-900/30 rounded-lg p-3 flex items-start gap-2">
+          <Info className="w-4 h-4 text-amber-500 mt-0.5 shrink-0" />
+          <p className="text-xs text-amber-700 dark:text-amber-300">
+            {t('youtubeValidation.prerequisite')}
+          </p>
+        </div>
+      )}
 
       {isLoading ? (
         <div className="flex items-center justify-center py-12">

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -725,6 +725,7 @@
     "failed": "YouTube validation failed. Please try again.",
     "noAnalysis": "No YouTube validation yet",
     "noAnalysisDescription": "Click the button above to validate your audience topics against YouTube content.",
+    "prerequisite": "You need to have analyzed topics first. Go to the Topics tab and run the analysis before validating on YouTube.",
     "summary": {
       "title": "Cross-Platform Summary",
       "topicsAnalyzed": "Topics analyzed",
@@ -735,7 +736,9 @@
       "commentsAnalyzed": "Comments analyzed",
       "keyFindings": "Key Findings",
       "bestOpportunity": "Best Opportunity",
-      "biggestDivergence": "Biggest Divergence"
+      "biggestDivergence": "Biggest Divergence",
+      "keyOpportunities": "Key Opportunities",
+      "riskFactors": "Risk Factors"
     },
     "topic": {
       "tractionScore": "Traction Score",
@@ -775,6 +778,7 @@
     "processing": "Analyzing products mentioned by your audience...",
     "processingHelp": "This may take 2-3 minutes. We're extracting products from posts and detecting market opportunities.",
     "failed": "Product analysis failed. Please try again.",
+    "failedTitle": "Product analysis failed",
     "noAnalysis": "No product analysis yet",
     "noAnalysisDescription": "Click the button above to discover products, brands and tools mentioned by your audience.",
     "totalProducts": "Products found",

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -725,6 +725,7 @@
     "failed": "Validação YouTube falhou. Tente novamente.",
     "noAnalysis": "Nenhuma validação YouTube ainda",
     "noAnalysisDescription": "Clique no botão acima para validar os tópicos da sua audiência com conteúdo do YouTube.",
+    "prerequisite": "Você precisa ter tópicos analisados primeiro. Vá até a aba Tópicos e execute a análise antes de validar no YouTube.",
     "summary": {
       "title": "Resumo Cross-Platform",
       "topicsAnalyzed": "Tópicos analisados",
@@ -735,7 +736,9 @@
       "commentsAnalyzed": "Comentários analisados",
       "keyFindings": "Principais Descobertas",
       "bestOpportunity": "Melhor Oportunidade",
-      "biggestDivergence": "Maior Divergência"
+      "biggestDivergence": "Maior Divergência",
+      "keyOpportunities": "Principais Oportunidades",
+      "riskFactors": "Fatores de Risco"
     },
     "topic": {
       "tractionScore": "Score de Tração",
@@ -775,6 +778,7 @@
     "processing": "Analisando produtos mencionados pela sua audiência...",
     "processingHelp": "Isso pode levar 2-3 minutos. Estamos extraindo produtos dos posts e detectando oportunidades de mercado.",
     "failed": "A análise de produtos falhou. Tente novamente.",
+    "failedTitle": "A análise de produtos falhou",
     "noAnalysis": "Nenhuma análise de produtos ainda",
     "noAnalysisDescription": "Clique no botão acima para descobrir produtos, marcas e ferramentas mencionados pela sua audiência.",
     "totalProducts": "Produtos encontrados",

--- a/src/modules/audience/domain/entities/YouTubeValidation.entity.ts
+++ b/src/modules/audience/domain/entities/YouTubeValidation.entity.ts
@@ -2,6 +2,7 @@ export interface SentimentComparison {
   reddit: string
   youtube: string
   alignment: string
+  divergence: string | null
 }
 
 export interface TopicAnalysis {
@@ -9,10 +10,11 @@ export interface TopicAnalysis {
   tractionScore: number
   sentimentComparison: SentimentComparison
   contentGap: boolean
+  contentGapDetail: string | null
   contentSaturated: boolean
   productMentions: string[]
   audienceOverlapScore: number
-  opportunityInsights: string
+  opportunityInsights: string[]
 }
 
 export interface CrossPlatformSummary {
@@ -36,6 +38,9 @@ export interface ValidationSummary {
   avgTractionScore: number
   totalVideosAnalyzed: number
   totalCommentsAnalyzed: number
+  headline: string | null
+  keyOpportunities: string[]
+  riskFactors: string[]
 }
 
 interface YouTubeValidationProps {

--- a/src/modules/audience/infra/repositories/audience.repository.ts
+++ b/src/modules/audience/infra/repositories/audience.repository.ts
@@ -743,12 +743,14 @@ interface YouTubeValidationApiResponse {
         reddit: string
         youtube: string
         alignment: string
+        divergence?: string
       }
       content_gap: boolean
+      content_gap_detail?: string
       content_saturated: boolean
       product_mentions: string[]
       audience_overlap_score: number
-      opportunity_insights: string
+      opportunity_insights: string | string[]
     }>
     cross_platform_summary: {
       total_topics_with_traction: number
@@ -766,6 +768,9 @@ interface YouTubeValidationApiResponse {
     avg_traction_score: number
     total_videos_analyzed: number
     total_comments_analyzed: number
+    headline?: string
+    key_opportunities?: string[]
+    risk_factors?: string[]
   }
   message?: string
 }
@@ -2108,20 +2113,25 @@ export class AudienceRepository implements IAudienceRepository {
         totalVideos: response.total_videos ?? 0,
         totalComments: response.total_comments ?? 0,
         analysisData: {
-          topics: (response.analysis_data.topics ?? []).map((t) => ({
-            topicName: t.topic_name,
-            tractionScore: t.traction_score,
-            sentimentComparison: {
-              reddit: t.sentiment_comparison.reddit,
-              youtube: t.sentiment_comparison.youtube,
-              alignment: t.sentiment_comparison.alignment,
-            },
-            contentGap: t.content_gap,
-            contentSaturated: t.content_saturated,
-            productMentions: t.product_mentions ?? [],
-            audienceOverlapScore: t.audience_overlap_score,
-            opportunityInsights: t.opportunity_insights,
-          })),
+          topics: (response.analysis_data.topics ?? []).map((t) => {
+            const insights = t.opportunity_insights
+            return {
+              topicName: t.topic_name,
+              tractionScore: t.traction_score,
+              sentimentComparison: {
+                reddit: t.sentiment_comparison.reddit,
+                youtube: t.sentiment_comparison.youtube,
+                alignment: t.sentiment_comparison.alignment,
+                divergence: t.sentiment_comparison.divergence ?? null,
+              },
+              contentGap: t.content_gap,
+              contentGapDetail: t.content_gap_detail ?? null,
+              contentSaturated: t.content_saturated,
+              productMentions: t.product_mentions ?? [],
+              audienceOverlapScore: t.audience_overlap_score,
+              opportunityInsights: Array.isArray(insights) ? insights : insights ? [insights] : [],
+            }
+          }),
           crossPlatformSummary: {
             totalTopicsWithTraction: response.analysis_data.cross_platform_summary.total_topics_with_traction,
             avgTractionScore: response.analysis_data.cross_platform_summary.avg_traction_score,
@@ -2138,6 +2148,9 @@ export class AudienceRepository implements IAudienceRepository {
           avgTractionScore: response.summary.avg_traction_score,
           totalVideosAnalyzed: response.summary.total_videos_analyzed,
           totalCommentsAnalyzed: response.summary.total_comments_analyzed,
+          headline: response.summary.headline ?? null,
+          keyOpportunities: response.summary.key_opportunities ?? [],
+          riskFactors: response.summary.risk_factors ?? [],
         } : null,
       }),
     }


### PR DESCRIPTION
## Summary
- Fix score display from broken percentage (e.g. "850%") to correct 0-10 scale (e.g. "8.5/10") for traction_score and audience_overlap_score
- Map missing API fields: `sentiment_divergence`, `content_gap_detail`, `headline`, `key_opportunities`, `risk_factors`
- Render `opportunity_insights` as a bulleted list instead of a single paragraph
- Add topics prerequisite check — disable YouTube validation trigger when topics are not analyzed yet
- Add i18n keys (en + pt-BR) for new UI sections

## Test plan
- [ ] Verify traction scores display as "X.X/10" (not percentages)
- [ ] Verify sentiment divergence text appears when alignment is "divergent"
- [ ] Verify content gap detail text appears below the "Content Gap" badge
- [ ] Verify opportunity insights render as a bulleted list
- [ ] Verify headline, key opportunities, and risk factors appear in the cross-platform summary
- [ ] Verify YouTube validation button is disabled when no topics are analyzed
- [ ] Verify prerequisite warning message appears when topics are not ready
- [ ] Verify translations work in both EN and PT-BR

Closes #118