### PR TITLE
feat: cross-platform validated alerts and decision matrix

### DIFF
--- a/src/components/audiences/detail/AlertCard.tsx
+++ b/src/components/audiences/detail/AlertCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { Clock, X, Zap, Flame, Sparkles, AlertTriangle, Info, AlertOctagon } from 'lucide-react'
+import { Clock, X, Zap, Flame, Sparkles, Youtube, AlertTriangle, Info, AlertOctagon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { TopicAlert } from '@/modules/topic-alerts'
 
@@ -13,6 +13,7 @@ const typeIcons: Record<string, React.ElementType> = {
   new_topic: Zap,
   growth_spike: Flame,
   new_theme: Sparkles,
+  cross_platform_validated: Youtube,
 }
 
 const severityConfig: Record<string, { icon: React.ElementType; bgClass: string; textClass: string; badgeBg: string; badgeText: string }> = {

--- a/src/components/audiences/detail/AlertsTabContent.tsx
+++ b/src/components/audiences/detail/AlertsTabContent.tsx
@@ -10,7 +10,7 @@ export interface AlertsTabContentProps {
   audienceId: string
 }
 
-const ALERT_TYPES: AlertType[] = ['new_topic', 'growth_spike', 'new_theme']
+const ALERT_TYPES: AlertType[] = ['new_topic', 'growth_spike', 'new_theme', 'cross_platform_validated']
 const SEVERITIES: AlertSeverity[] = ['info', 'warning', 'critical']
 
 export function AlertsTabContent({ audienceId }: Readonly<AlertsTabContentProps>) {

--- a/src/components/audiences/detail/youtube-validation/DecisionMatrixSection.tsx
+++ b/src/components/audiences/detail/youtube-validation/DecisionMatrixSection.tsx
@@ -1,0 +1,112 @@
+import { useTranslation } from 'react-i18next'
+import { Grid3x3 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import type { TopicAnalysis } from '@/modules/audience/domain/entities/YouTubeValidation.entity'
+
+export interface DecisionMatrixSectionProps {
+  topics: TopicAnalysis[]
+}
+
+type ActionLevel = 'ideal' | 'differentiate' | 'avoid' | 'niche' | 'no_traction'
+
+function getActionLevel(topic: TopicAnalysis): ActionLevel {
+  const highTraction = topic.tractionScore >= 7
+  const lowTraction = topic.tractionScore < 4
+
+  if (highTraction && topic.contentGap && !topic.contentSaturated) return 'ideal'
+  if (highTraction && !topic.contentGap && !topic.contentSaturated) return 'differentiate'
+  if (highTraction && topic.contentSaturated) return 'avoid'
+  if (lowTraction && topic.contentGap) return 'niche'
+  return 'no_traction'
+}
+
+const actionVariants: Record<ActionLevel, 'success' | 'warning' | 'error' | 'neutral'> = {
+  ideal: 'success',
+  differentiate: 'warning',
+  avoid: 'error',
+  niche: 'neutral',
+  no_traction: 'neutral',
+}
+
+function tractionVariant(score: number): 'success' | 'warning' | 'error' {
+  if (score >= 7) return 'success'
+  if (score >= 4) return 'warning'
+  return 'error'
+}
+
+export function DecisionMatrixSection({ topics }: Readonly<DecisionMatrixSectionProps>) {
+  const { t } = useTranslation('audiences')
+
+  return (
+    <div className="border border-gray-200 dark:border-zinc-700 rounded-xl overflow-hidden">
+      <div className="p-4">
+        <h4 className="text-sm font-medium text-gray-900 dark:text-white flex items-center gap-2 mb-4">
+          <Grid3x3 className="w-4 h-4 text-lime" />
+          {t('youtubeValidation.decisionMatrix.title')}
+        </h4>
+
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-gray-200 dark:border-zinc-700">
+                <th className="text-left py-2 pr-3 font-medium text-gray-500 dark:text-zinc-400">
+                  {t('youtubeValidation.decisionMatrix.topic')}
+                </th>
+                <th className="text-center py-2 px-3 font-medium text-gray-500 dark:text-zinc-400">
+                  {t('youtubeValidation.decisionMatrix.traction')}
+                </th>
+                <th className="text-center py-2 px-3 font-medium text-gray-500 dark:text-zinc-400">
+                  {t('youtubeValidation.decisionMatrix.gap')}
+                </th>
+                <th className="text-center py-2 px-3 font-medium text-gray-500 dark:text-zinc-400">
+                  {t('youtubeValidation.decisionMatrix.saturated')}
+                </th>
+                <th className="text-left py-2 pl-3 font-medium text-gray-500 dark:text-zinc-400">
+                  {t('youtubeValidation.decisionMatrix.action')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {topics.map((topic) => {
+                const action = getActionLevel(topic)
+                return (
+                  <tr key={topic.topicName} className="border-b border-gray-100 dark:border-zinc-800 last:border-b-0">
+                    <td className="py-2.5 pr-3 font-medium text-gray-900 dark:text-white max-w-[200px] truncate">
+                      {topic.topicName}
+                    </td>
+                    <td className="py-2.5 px-3 text-center">
+                      <Badge variant={tractionVariant(topic.tractionScore)} size="sm">
+                        {topic.tractionScore.toFixed(1)}
+                      </Badge>
+                    </td>
+                    <td className="py-2.5 px-3 text-center">
+                      <Badge variant={topic.contentGap ? 'warning' : 'neutral'} size="sm">
+                        {topic.contentGap
+                          ? t('youtubeValidation.decisionMatrix.yes')
+                          : t('youtubeValidation.decisionMatrix.no')
+                        }
+                      </Badge>
+                    </td>
+                    <td className="py-2.5 px-3 text-center">
+                      <Badge variant={topic.contentSaturated ? 'error' : 'neutral'} size="sm">
+                        {topic.contentSaturated
+                          ? t('youtubeValidation.decisionMatrix.yes')
+                          : t('youtubeValidation.decisionMatrix.no')
+                        }
+                      </Badge>
+                    </td>
+                    <td className="py-2.5 pl-3">
+                      <Badge variant={actionVariants[action]} size="sm">
+                        {t(`youtubeValidation.decisionMatrix.actions.${action}`)}
+                      </Badge>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/audiences/detail/youtube-validation/YouTubeValidationTabContent.tsx
+++ b/src/components/audiences/detail/youtube-validation/YouTubeValidationTabContent.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/modules/audience/application/hooks'
 import { toast } from '@/hooks/useToast'
 import { CrossPlatformSummarySection } from './CrossPlatformSummarySection'
+import { DecisionMatrixSection } from './DecisionMatrixSection'
 import { TopicAnalysisAccordion } from './TopicAnalysisAccordion'
 
 export interface YouTubeValidationTabContentProps {
@@ -113,6 +114,8 @@ export function YouTubeValidationTabContent({ audienceId, hasTopicsReady }: Read
             summary={validation.getSummary()}
             crossPlatform={validation.getAnalysisData().crossPlatformSummary}
           />
+
+          <DecisionMatrixSection topics={validation.getAnalysisData().topics} />
 
           <div className="space-y-3">
             {validation.getAnalysisData().topics.map((topic) => (

--- a/src/locales/en/audiences.json
+++ b/src/locales/en/audiences.json
@@ -454,7 +454,8 @@
     "type": {
       "new_topic": "New Topic",
       "growth_spike": "Growth Spike",
-      "new_theme": "New Theme"
+      "new_theme": "New Theme",
+      "cross_platform_validated": "Cross-Platform Validated"
     },
     "severity": {
       "info": "Info",
@@ -764,6 +765,23 @@
       "publishedAt": "Published",
       "tags": "Tags",
       "noVideos": "No videos collected for this topic"
+    },
+    "decisionMatrix": {
+      "title": "Decision Matrix",
+      "topic": "Topic",
+      "traction": "Traction",
+      "gap": "Gap",
+      "saturated": "Saturated",
+      "action": "Suggested Action",
+      "yes": "Yes",
+      "no": "No",
+      "actions": {
+        "ideal": "Ideal opportunity — invest now",
+        "differentiate": "Good topic, needs differentiation",
+        "avoid": "Avoid — saturated market",
+        "niche": "Niche potential",
+        "no_traction": "No traction — skip"
+      }
     }
   },
   "productIntelligence": {

--- a/src/locales/pt-BR/audiences.json
+++ b/src/locales/pt-BR/audiences.json
@@ -454,7 +454,8 @@
     "type": {
       "new_topic": "Novo Tópico",
       "growth_spike": "Pico de Crescimento",
-      "new_theme": "Novo Tema"
+      "new_theme": "Novo Tema",
+      "cross_platform_validated": "Validação Cross-Platform"
     },
     "severity": {
       "info": "Info",
@@ -764,6 +765,23 @@
       "publishedAt": "Publicado",
       "tags": "Tags",
       "noVideos": "Nenhum vídeo coletado para este tópico"
+    },
+    "decisionMatrix": {
+      "title": "Matriz de Decisão",
+      "topic": "Tópico",
+      "traction": "Tração",
+      "gap": "Gap",
+      "saturated": "Saturado",
+      "action": "Ação Sugerida",
+      "yes": "Sim",
+      "no": "Não",
+      "actions": {
+        "ideal": "Oportunidade ideal — investir agora",
+        "differentiate": "Bom tema, precisa de diferenciação",
+        "avoid": "Evitar — mercado saturado",
+        "niche": "Potencial de nicho",
+        "no_traction": "Sem tração — evitar"
+      }
     }
   },
   "productIntelligence": {

--- a/src/modules/notifications/application/hooks/useNotificationSSE.ts
+++ b/src/modules/notifications/application/hooks/useNotificationSSE.ts
@@ -30,7 +30,7 @@ function invalidateAnalysisQueries(
 
   if (!audienceId) return
 
-  if (type === 'topic_alert_new_topic' || type === 'topic_alert_growth_spike' || type === 'topic_alert_new_theme') {
+  if (type === 'topic_alert_new_topic' || type === 'topic_alert_growth_spike' || type === 'topic_alert_new_theme' || type === 'topic_alert_cross_platform_validated') {
     queryClient.invalidateQueries({ queryKey: ALERTS_QUERY_KEY(audienceId) })
     queryClient.invalidateQueries({ queryKey: ALERTS_SUMMARY_QUERY_KEY(audienceId) })
     return

--- a/src/modules/topic-alerts/domain/entities/topic-alert.entity.ts
+++ b/src/modules/topic-alerts/domain/entities/topic-alert.entity.ts
@@ -1,4 +1,4 @@
-export type AlertType = 'new_topic' | 'growth_spike' | 'new_theme'
+export type AlertType = 'new_topic' | 'growth_spike' | 'new_theme' | 'cross_platform_validated'
 
 export type AlertSeverity = 'info' | 'warning' | 'critical'
 


### PR DESCRIPTION
## Summary
- Add `cross_platform_validated` alert type to the alerts system (entity, icon, SSE handler, filter dropdown)
- Add Decision Matrix component to the YouTube Validation tab — a table showing each topic with traction score, content gap, saturation status, and a suggested action based on the combination

## Test plan
- [ ] Verify `cross_platform_validated` alerts render with YouTube icon in the Alerts tab
- [ ] Verify alert type filter dropdown includes "Cross-Platform Validated" option
- [ ] Verify SSE notifications for `topic_alert_cross_platform_validated` invalidate alerts queries
- [ ] Verify Decision Matrix table appears between the cross-platform summary and topic accordions
- [ ] Verify traction score badges use correct colors (green >= 7, yellow 4-7, red < 4)
- [ ] Verify suggested actions match the matrix: ideal/differentiate/avoid/niche/no_traction
- [ ] Verify translations work in both EN and PT-BR

Closes #120