### PR TITLE
fix: resolve dark mode issues across multiple components

### DIFF
--- a/src/components/audiences/detail/ThemeDetailPanel.tsx
+++ b/src/components/audiences/detail/ThemeDetailPanel.tsx
@@ -202,48 +202,50 @@ export function ThemeDetailPanel({ theme, audienceId, intentCategory, embedded =
               </>
             )}
 
-            <div className="flex flex-wrap justify-end gap-2 mb-6">
-              <Button
-                variant={showPosts ? 'primary' : 'outline'}
-                size="sm"
-                className="gap-1.5"
-                onClick={isIntentTheme ? () => { setShowPosts(!showPosts); setShowPatterns(false); setShowAsk(false); setShowChat(false) } : undefined}
-              >
-                <Search className="w-3.5 h-3.5" />
-                {t('themes.browseAll')}
-              </Button>
-              <Button
-                variant={showPatterns ? 'primary' : 'outline'}
-                size="sm"
-                className="gap-1.5"
-                onClick={isIntentTheme ? () => { setShowPatterns(!showPatterns); setShowPosts(false); setShowAsk(false); setShowChat(false) } : undefined}
-              >
-                <Sparkles className="w-3.5 h-3.5" />
-                {t('themes.patterns')}
-              </Button>
-              <Button
-                variant={showAsk ? 'primary' : 'outline'}
-                size="sm"
-                className="gap-1.5"
-                onClick={isIntentTheme ? () => { setShowAsk(!showAsk); setShowPosts(false); setShowPatterns(false); setShowChat(false) } : undefined}
-              >
-                <Sparkles className="w-3.5 h-3.5" />
-                {t('themes.ask')}
-              </Button>
-              <Button
-                variant={showChat ? 'primary' : 'outline'}
-                size="sm"
-                className="gap-1.5"
-                onClick={isIntentTheme ? () => { setShowChat(!showChat); setShowPosts(false); setShowPatterns(false); setShowAsk(false) } : undefined}
-              >
-                <MessageSquareText className="w-3.5 h-3.5" />
-                {t('themes.intentChat.title')}
-              </Button>
-              <Button variant="outline" size="sm" className="gap-1.5">
-                <Copy className="w-3.5 h-3.5" />
-                {t('themes.copy')}
-              </Button>
-            </div>
+            {isIntentTheme && (
+              <div className="flex flex-wrap justify-end gap-2 mb-6">
+                <Button
+                  variant={showPosts ? 'primary' : 'outline'}
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => { setShowPosts(!showPosts); setShowPatterns(false); setShowAsk(false); setShowChat(false) }}
+                >
+                  <Search className="w-3.5 h-3.5" />
+                  {t('themes.browseAll')}
+                </Button>
+                <Button
+                  variant={showPatterns ? 'primary' : 'outline'}
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => { setShowPatterns(!showPatterns); setShowPosts(false); setShowAsk(false); setShowChat(false) }}
+                >
+                  <Sparkles className="w-3.5 h-3.5" />
+                  {t('themes.patterns')}
+                </Button>
+                <Button
+                  variant={showAsk ? 'primary' : 'outline'}
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => { setShowAsk(!showAsk); setShowPosts(false); setShowPatterns(false); setShowChat(false) }}
+                >
+                  <Sparkles className="w-3.5 h-3.5" />
+                  {t('themes.ask')}
+                </Button>
+                <Button
+                  variant={showChat ? 'primary' : 'outline'}
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => { setShowChat(!showChat); setShowPosts(false); setShowPatterns(false); setShowAsk(false) }}
+                >
+                  <MessageSquareText className="w-3.5 h-3.5" />
+                  {t('themes.intentChat.title')}
+                </Button>
+                <Button variant="outline" size="sm" className="gap-1.5">
+                  <Copy className="w-3.5 h-3.5" />
+                  {t('themes.copy')}
+                </Button>
+              </div>
+            )}
 
             {/* Narrative Summaries */}
             {theme.summaryThemes && theme.summaryThemes.length > 0 && audienceId && (

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -168,7 +168,7 @@ export function Topbar() {
           >
             <Bell className="w-5 h-5" />
             {unreadCount > 0 && (
-              <span className="notification-badge absolute top-1.5 right-1.5 w-4 h-4 bg-red-500 text-white text-xs font-bold rounded-full flex items-center justify-center">
+              <span className="notification-badge absolute top-1 right-0 min-w-5 h-5 px-1 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center">
                 {unreadCount > 9 ? '9+' : unreadCount}
               </span>
             )}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,9 +9,9 @@ const buttonVariants = cva(
       variant: {
         primary: 'bg-lime text-black hover:bg-lime-hover',
         dark: 'bg-black text-white hover:bg-gray-800',
-        outline: 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-100',
-        ghost: 'bg-transparent text-gray-400 hover:text-gray-900',
-        danger: 'bg-error-bg text-error hover:bg-red-200',
+        outline: 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-100 dark:bg-zinc-900 dark:text-zinc-300 dark:border-zinc-700 dark:hover:bg-zinc-800',
+        ghost: 'bg-transparent text-gray-400 hover:text-gray-900 dark:text-zinc-400 dark:hover:text-white',
+        danger: 'bg-error-bg text-error hover:bg-red-200 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30',
       },
       size: {
         sm: 'h-8 px-3 text-sm rounded-lg',

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -36,7 +36,7 @@ const toastVariants = cva(
         destructive:
           "destructive group border-red-300 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-200",
         success:
-          "border-success bg-success-bg text-foreground",
+          "border-success bg-success-bg text-foreground dark:border-green-800 dark:bg-green-950 dark:text-green-200",
       },
     },
     defaultVariants: {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -114,6 +114,45 @@ body {
 }
 
 /* ============================================
+   SHADCN/UI LIGHT MODE DEFAULTS
+   ============================================ */
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+/* ============================================
    DARK MODE SUPPORT
    ============================================ */
 
@@ -283,41 +322,6 @@ body {
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
-}
-
-:root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
 }
 
 @layer base {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import path from 'node:path'
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  server: {
+    host: true,
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- **CSS cascade fix**: moved `:root` block before `.dark` in `globals.css` so dark mode variables (`--background`, `--card`, etc.) correctly override light defaults — this was causing Sheet/drawer backgrounds to render white in dark mode
- **Button dark variants**: added `dark:` classes to `outline`, `ghost`, and `danger` variants which had no dark mode support
- **Toast success variant**: added dark mode colors (`dark:bg-green-950 dark:text-green-200`)
- **Notification badge**: increased size from `w-4 h-4` to `min-w-5 h-5` so "9+" text is readable
- **ThemeDetailPanel**: hidden action buttons (Ver todos, Padrões, Perguntar, etc.) for scoring themes where they had no functionality
- **Vite config**: enabled `server.host` for network access (mobile testing)

## Test plan
- [ ] Toggle dark mode and verify Sheet/drawer backgrounds are dark
- [ ] Verify `outline`, `ghost`, and `danger` buttons render correctly in both themes
- [ ] Trigger a success toast and confirm it shows dark-themed in dark mode
- [ ] Check notification badge "9+" is visible and properly sized
- [ ] Open a scoring theme ("Discussões em Alta") and confirm action buttons are hidden
- [ ] Open an intent theme and confirm action buttons work normally
- [ ] Run `npm run dev` and verify `Network:` URL appears in terminal output